### PR TITLE
Bugfixes

### DIFF
--- a/julian/leap_seconds.py
+++ b/julian/leap_seconds.py
@@ -59,7 +59,7 @@ def _default_lsk_path():
 
 
 def _leaps_from_lsk(lsk_path):
-    """Return the list of leap seconds from the specified SPICE leap seconds kernel file,
+    """The list of leap seconds from the specified SPICE leap seconds kernel file,
     represented by a string or Path.
     """
 
@@ -316,6 +316,7 @@ _DELTA_T_FUNCTIONS[12] = _delta_t_2050_2150
 
 
 def _delta_t_neg1999_3000(y, m, d):
+    """Delta T model from Five Millennium Canon of Solar Eclipses: -1999 to +3000."""
 
     y_int = _int(y)
     day = day_from_ymd(y_int, m, d)
@@ -473,9 +474,20 @@ def load_lsk(lsk_path=''):
     inserted, they must be inserted again.
     """
 
+    global _DELTA_T_DICT
+
     _initialize_leap_seconds(lsk_path)
     _initialize_utc_1958_1972()
     _initialize_ut1_neg1999_3000()
+
+    _DELTA_T_DICT = {
+        'LEAPS'   : _LEAPS_DELTA_T,
+        'SPICE'   : _SPICE_DELTA_T,
+        'PRE-1972': MergedDeltaT(_LEAPS_DELTA_T, _DELTA_T_1958_1972),
+        'CANON'   : MergedDeltaT(_LEAPS_DELTA_T, _DELTA_T_1958_1972,
+                                 _DELTA_T_NEG1999_3000),
+    }
+
     set_ut_model(_SELECTED_UT_MODEL, future=_SELECTED_FUTURE_YEAR)
 
 

--- a/julian/time_of_day.py
+++ b/julian/time_of_day.py
@@ -29,10 +29,10 @@ def hms_from_sec(sec):
     if np.any(sec >= 86410):
         raise JulianValidateFailure('seconds >= 86410')
 
-    h = np.minimum(_int(sec//3600), 23)
+    h = _int(np.minimum(_int(sec//3600), 23))
     t = sec - 3600 * h
 
-    m = np.minimum(_int(t//60), 59)
+    m = _int(np.minimum(_int(t//60), 59))
     t -= 60 * m
 
     return (h, m, t)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -33,6 +33,10 @@ class Test_calendar(unittest.TestCase):
 
         # day_from_ymd()
         self.assertEqual(day_from_ymd(2000,1,1), 0)
+        self.assertIs(type(day_from_ymd(2000,1,1)), int)
+        self.assertEqual(day_from_ymd(2000,1,1.), 0.)
+        self.assertIs(type(day_from_ymd(2000,1,1.)), float)
+
         self.assertEqual(day_from_ymd(2000,2,[27,28,29]).tolist(),    [57,58,59])
         self.assertEqual(day_from_ymd(2000,[1,2,3],1).tolist(),       [ 0,31,60])
         self.assertEqual(day_from_ymd([2000,2001,2002],1,1).tolist(), [0,366,731])
@@ -70,7 +74,16 @@ class Test_calendar(unittest.TestCase):
         self.assertRaises(jvf, day_from_ymd, 1582, 10, np.arange(1,32), validate=True)
 
         # ymd_from_day()
-        self.assertEqual(ymd_from_day(  0), (2000, 1, 1))
+        self.assertEqual(ymd_from_day(0), (2000, 1, 1))
+        self.assertIs(type(ymd_from_day(0)[0]), int)
+        self.assertIs(type(ymd_from_day(0)[1]), int)
+        self.assertIs(type(ymd_from_day(0)[2]), int)
+
+        self.assertEqual(ymd_from_day(0.), (2000, 1, 1.))
+        self.assertIs(type(ymd_from_day(0.)[0]), int)
+        self.assertIs(type(ymd_from_day(0.)[1]), int)
+        self.assertIs(type(ymd_from_day(0.)[2]), float)
+
         self.assertEqual(ymd_from_day( 60), (2000, 3, 1))
         self.assertEqual(ymd_from_day(365), (2000,12,31))
         self.assertEqual(ymd_from_day(366), (2001, 1, 1))

--- a/tests/test_leap_seconds.py
+++ b/tests/test_leap_seconds.py
@@ -117,6 +117,7 @@ class Test_leap_seconds(unittest.TestCase):
         delta_t = delta_t_from_ymd(year,1,1)
         canon_dt = _delta_t_neg1999_3000(year,1,1)
         mask = (year < 1958) | (year >= 2030)
+
         self.assertTrue(np.all(delta_t[mask] == canon_dt[mask]))
 
         set_ut_model('PRE-1972')
@@ -205,36 +206,43 @@ class Test_leap_seconds(unittest.TestCase):
     # Negative leap seconds...
     def test_negative_leap_seconds(self):
 
-        insert_leap_second(2030, 1, -1)
-        insert_leap_second(2031, 1, -2)
-        insert_leap_second(2040, 1, 1)
-
-        self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)  ), 86400)
-        self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)-1), 86399)
-
-        self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)  ), 86400)
-        self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)-1), 86398)
-
-        self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)  ), 86400)
-        self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)-1), 86401)
-
-        self.assertTrue(np.all(seconds_on_day(day_from_ymd([2030,2031,2040],1,1)-1)
-                               == [86399, 86398, 86401]))
-
-        tai = tai_from_iso('2030-01-01T00:00:00')
-        self.assertEqual(tai_from_iso('2029-12-31T23:59:58', validate=True), tai-1)
-        self.assertEqual(tai_from_iso('2029-12-31T23:59:59', validate=False), tai)
-        self.assertRaises(JulianValidateFailure,
-                          tai_from_iso, '2029-12-31T23:59:59', validate=True)
-
-        tai = tai_from_iso('2031-01-01T00:00:00')
-        self.assertEqual(tai_from_iso('2030-12-31T23:59:57', validate=True), tai-1)
-        self.assertRaises(JulianValidateFailure,
-                          tai_from_iso, '2030-12-31T23:59:58', validate=True)
-        self.assertRaises(JulianValidateFailure,
-                          tai_from_iso, '2030-12-31T23:59:59', validate=True)
-
         load_lsk()
+        for name in ('LEAPS', 'SPICE', 'PRE-1972', 'CANON'):
+            set_ut_model(name)
+
+            insert_leap_second(2030, 1, -1)
+            insert_leap_second(2031, 1, -2)
+            insert_leap_second(2040, 1, 1)
+
+            self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)  ), 86400)
+            self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)-1), 86399)
+
+            self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)  ), 86400)
+            self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)-1), 86398)
+
+            self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)  ), 86400)
+            self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)-1), 86401)
+
+            self.assertTrue(np.all(seconds_on_day(day_from_ymd([2030,2031,2040],1,1)-1)
+                                   == [86399, 86398, 86401]))
+
+            tai = tai_from_iso('2030-01-01T00:00:00')
+            self.assertEqual(tai_from_iso('2029-12-31T23:59:58', validate=True), tai-1)
+            self.assertEqual(tai_from_iso('2029-12-31T23:59:59', validate=False), tai)
+            self.assertRaises(JulianValidateFailure,
+                              tai_from_iso, '2029-12-31T23:59:59', validate=True)
+
+            tai = tai_from_iso('2031-01-01T00:00:00')
+            self.assertEqual(tai_from_iso('2030-12-31T23:59:57', validate=True), tai-1)
+            self.assertRaises(JulianValidateFailure,
+                              tai_from_iso, '2030-12-31T23:59:58', validate=True)
+            self.assertRaises(JulianValidateFailure,
+                              tai_from_iso, '2030-12-31T23:59:59', validate=True)
+
+            load_lsk()
+
+        # Go back to the default
+        set_ut_model('LEAPS')
 
 ############################################
 # Execute from command line...

--- a/tests/test_time_of_day.py
+++ b/tests/test_time_of_day.py
@@ -19,6 +19,15 @@ class Test_time_of_day(unittest.TestCase):
 
         # Check hms_from_sec
         self.assertEqual(hms_from_sec(0), (0, 0, 0))
+        self.assertIs(type(hms_from_sec(0)[0]), int)
+        self.assertIs(type(hms_from_sec(0)[1]), int)
+        self.assertIs(type(hms_from_sec(0)[2]), int)
+
+        self.assertEqual(hms_from_sec(0.), (0, 0, 0))
+        self.assertIs(type(hms_from_sec(0.)[0]), int)
+        self.assertIs(type(hms_from_sec(0.)[1]), int)
+        self.assertIs(type(hms_from_sec(0.)[2]), float)
+
         self.assertEqual(hms_from_sec(86400), (23, 59, 60))
         small = 2.**-20
         self.assertEqual(hms_from_sec(86410 - small), (23, 59, 70 - small))
@@ -27,7 +36,16 @@ class Test_time_of_day(unittest.TestCase):
 
         # Check sec_from_hms
         self.assertEqual(sec_from_hms(0, 0, 0), 0)
+        self.assertIs(type(sec_from_hms(0, 0, 0)), int)
+        self.assertIs(type(sec_from_hms(0, 0, 0.)), float)
+        self.assertIs(type(sec_from_hms(0, 0., 0)), float)
+        self.assertIs(type(sec_from_hms(0., 0, 0)), float)
+
         self.assertEqual(sec_from_hms(23, 59, 60), 86400)
+        self.assertIs(type(sec_from_hms(23, 59, 60)), int)
+        self.assertIs(type(sec_from_hms(23, 59, 60.)), float)
+        self.assertIs(type(sec_from_hms(23, 59., 60)), float)
+        self.assertIs(type(sec_from_hms(23., 59, 60)), float)
 
         # Array tests
         # This makes about 333,000 non-uniformly spaced transcendental numbers


### PR DESCRIPTION
I tripped over a minor bug where `sec_from_hms(int, int, int)` would return `np.int64` instead of `int`. I was checking to see whether a time was floating or integral by using `isinstance(..., int)` and it failed, because an `np.int64` is not an` int`. This led to much confusion. This happened because all the julian functions are set up to support arrays in place of any argument, but I had gone to some effort elsewhere to make sure that non-numpy inputs yield non-numpy outputs. I missed this case. Yes, I know I could have used `numbers.Integral` in the test, but the user really shouldn't need to do that. Now it's fixed.

Meanwhile, however, I discovered it was failing unit tests related to leap seconds. This occurred because the method of leap second handling is set globally, and there were cases where the globals were not all being reset properly when the unit tests jumped back and forth between methods. It meant that unit tests could succeed or fail depending on the order in which they execute. This was actually a bug in the module, not the tests, but it's fixed now.