### PR TITLE
Test suite refactor and Issue 9 fix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Test with coverage
         run: |
-          coverage run -m pytest
+          python -m pytest --cov=src -n auto tests
 
       - name: Print coverage report
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Test with coverage
         run: |
-          python -m pytest --cov=src -n auto tests
+          python -m pytest --cov=julian -n auto tests
 
       - name: Print coverage report
         run: |

--- a/julian/time_pyparser.py
+++ b/julian/time_pyparser.py
@@ -280,20 +280,20 @@ opt_iso_timezone = Optional(z_timezone_strict | hhmm_timezone)
 ##########################################################################################
 
 timesys_et = CaselessLiteral('ET')
-timesys_et.setParseAction(lambda s,l,t: _action('TIMESYS', 'TDB', s,l,t))
+timesys_et.set_parse_action(lambda s,l,t: _action('TIMESYS', 'TDB', s,l,t))
 
 timesys_tt = CaselessLiteral('TDT')
-timesys_tt.setParseAction(lambda s,l,t: _action('TIMESYS', 'TT', s,l,t))
+timesys_tt.set_parse_action(lambda s,l,t: _action('TIMESYS', 'TT', s,l,t))
 
 timesys_utc = one_of(['UTC', 'UT1', 'UT'], caseless=True)
-timesys_utc.setParseAction(lambda s,l,t: _action('TIMESYS', 'UTC', s,l,t))
+timesys_utc.set_parse_action(lambda s,l,t: _action('TIMESYS', 'UTC', s,l,t))
 
 timesys_z = CaselessLiteral('Z')    # both a time system and a time zone!
-timesys_z.setParseAction(
+timesys_z.set_parse_action(
     lambda s,l,t: _actions(['TIMESYS', 'UTC', 'TZ', 'Z', 'TZMIN', 0], s,l,t))
 
 timesys_other = one_of(['TAI', 'TDB', 'TT'], caseless=True)
-timesys_other.setParseAction(lambda s,l,t: _action('TIMESYS', t[0].upper(), s,l,t))
+timesys_other.set_parse_action(lambda s,l,t: _action('TIMESYS', t[0].upper(), s,l,t))
 
 timesys = opt_white + (timesys_other | timesys_utc| timesys_z | timesys_et | timesys_tt)
 opt_timesys = Optional(timesys)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,9 @@ packages = ["julian"]
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
 write_to = "julian/_version.py"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "julian"
+]
+addopts = ["-n", "auto", "--cov=julian"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rms-julian"
 dynamic = ["version"]
 description = "Tools for astronomical time systems, supporting array operations, leap seconds, date/time parsing, and formatting"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "pyparsing",
@@ -27,7 +27,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -52,7 +51,6 @@ local_scheme = "no-local-version"
 write_to = "julian/_version.py"
 
 [tool.pytest.ini_options]
-pythonpath = [
-  "julian"
-]
+# Use project root so "import julian" works and stdlib "calendar" is not shadowed by julian/calendar.py
+pythonpath = ["."]
 addopts = ["-n", "auto", "--cov=julian"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ myst-parser
 numpy
 pyparsing
 pytest
+pytest-cov
+pytest-xdist
 rms-filecache
 rms-textkernel
 sphinx

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -27,6 +27,7 @@ def confirm_failure(parser, test, msg):
     else:
         parse_dict = {pair[0]: pair[1] for pair in pairs}
         msg += f'; {parse_dict}'
+        assert '~' in parse_dict, msg + '; missing "~" key in parse result'
         remainder = test[parse_dict['~']:].lstrip()
         assert remainder not in ('', 'xxx'), msg
 
@@ -41,7 +42,7 @@ def confirm_success(parser, test, msg, values=()):
     except Exception as e:  # pragma: no cover
         error = e
 
-    assert error is None, msg
+    assert error is None, f'{msg}; Unexpected exception {type(error).__name__}: {error}'
 
     parse_dict = {pair[0]: pair[1] for pair in pairs}
     msg += f'; {parse_dict}'
@@ -50,6 +51,7 @@ def confirm_success(parser, test, msg, values=()):
         assert name in parse_dict, msg
         assert parse_dict[name] == value, msg
 
+    assert '~' in parse_dict, msg + '; missing "~" key in parse result'
     remainder = test[parse_dict['~']:].lstrip()
     assert remainder in ('', 'xxx'), msg
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,58 @@
+##########################################################################################
+# tests/_helpers.py: Shared test helper functions for the julian test suite.
+##########################################################################################
+
+import warnings
+
+import pytest
+from pyparsing import ParseException
+
+
+def confirm_failure(parser, test, msg):
+    """Confirm that parsing the test string with the given parser fails or only
+    partially matches."""
+
+    try:
+        pairs = parser.parse_string(test).as_list()
+
+    except ParseException:
+        with pytest.raises(ParseException):
+            parser.parse_string(test)
+
+    except Exception as e:  # pragma: no cover
+        warnings.warn(msg + f'; Incorrect exception {type(e)}: {e}')
+        with pytest.raises(Exception):
+            parser.parse_string(test)
+
+    else:
+        parse_dict = {pair[0]: pair[1] for pair in pairs}
+        msg += f'; {parse_dict}'
+        remainder = test[parse_dict['~']:].lstrip()
+        assert remainder not in ('', 'xxx'), msg
+
+
+def confirm_success(parser, test, msg, values=()):
+    """Confirm that parsing succeeds and check expected values. Returns
+    parse_dict."""
+
+    error = None
+    try:
+        pairs = parser.parse_string(test).as_list()
+    except Exception as e:  # pragma: no cover
+        error = e
+
+    assert error is None, msg
+
+    parse_dict = {pair[0]: pair[1] for pair in pairs}
+    msg += f'; {parse_dict}'
+
+    for name, value in values:
+        assert name in parse_dict, msg
+        assert parse_dict[name] == value, msg
+
+    remainder = test[parse_dict['~']:].lstrip()
+    assert remainder in ('', 'xxx'), msg
+
+    return parse_dict
+
+##########################################################################################

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -40,10 +40,14 @@ def test_calendar():
     assert day_from_ymd(2000,[1,2,3],1).tolist() == [ 0,31,60]
     assert day_from_ymd([2000,2001,2002],1,1).tolist() == [0,366,731]
 
-    with pytest.raises(JVF): day_from_ymd(2000, 1,  0, validate=True)
-    with pytest.raises(JVF): day_from_ymd(2000, 2, 30, validate=True)
-    with pytest.raises(JVF): day_from_ymd(2000, 0,  1, validate=True)
-    with pytest.raises(JVF): day_from_ymd(2000, 13, 1, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(2000, 1,  0, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(2000, 2, 30, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(2000, 0,  1, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(2000, 13, 1, validate=True)
 
     with pytest.raises(JVF):
         day_from_ymd([2000,2000], [1, 1], [ 1, 0], validate=True)
@@ -68,10 +72,12 @@ def test_calendar():
                      proleptic=False).tolist() == [-152386,-152385]
 
     _ = day_from_ymd(1582, 10, 7, validate=False)
-    with pytest.raises(JVF): day_from_ymd(1582, 10, 7, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(1582, 10, 7, validate=True)
 
     _ = day_from_ymd(1582, 10, np.arange(1,32), validate=False)
-    with pytest.raises(JVF): day_from_ymd(1582, 10, np.arange(1,32), validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd(1582, 10, np.arange(1,32), validate=True)
 
     # ymd_from_day()
     assert ymd_from_day(0) == (2000, 1, 1)
@@ -125,10 +131,13 @@ def test_calendar():
     assert day_from_yd([2000,2001],1).tolist() == [ 0,366]
     assert day_from_yd([2000,2001,2002],[1,2,3]).tolist() == [0,367,733]
 
-    with pytest.raises(JVF): day_from_yd(2000,  0, validate=True)
+    with pytest.raises(JVF):
+        day_from_yd(2000,  0, validate=True)
     assert day_from_yd(2000, 366, validate=True) == 365
-    with pytest.raises(JVF): day_from_yd(2000, 367, validate=True)
-    with pytest.raises(JVF): day_from_yd(1582, 360, validate=True, proleptic=False)
+    with pytest.raises(JVF):
+        day_from_yd(2000, 367, validate=True)
+    with pytest.raises(JVF):
+        day_from_yd(1582, 360, validate=True, proleptic=False)
     with pytest.raises(JVF):
         day_from_yd(1582, [300,355,360], validate=True, proleptic=False)
 
@@ -145,10 +154,14 @@ def test_calendar():
     # month_from_ym()
     assert month_from_ym(2000, 1, validate=False) == 0
     assert month_from_ym(2000, 1, validate=True) == 0
-    with pytest.raises(JVF): month_from_ym(2000, 0, validate=True)
-    with pytest.raises(JVF): month_from_ym(2000, 13, validate=True)
-    with pytest.raises(JVF): month_from_ym(2000, [12,14], validate=True)
-    with pytest.raises(JVF): month_from_ym([2000, 2001], [12,14], validate=True)
+    with pytest.raises(JVF):
+        month_from_ym(2000, 0, validate=True)
+    with pytest.raises(JVF):
+        month_from_ym(2000, 13, validate=True)
+    with pytest.raises(JVF):
+        month_from_ym(2000, [12,14], validate=True)
+    with pytest.raises(JVF):
+        month_from_ym([2000, 2001], [12,14], validate=True)
 
     # days_in_ym()
     for proleptic in (False, True):

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -153,7 +153,7 @@ def test_calendar():
     # days_in_ym()
     for proleptic in (False, True):
         assert days_in_ym(2000, 2, proleptic=proleptic) == 29
-        assert type(days_in_ym(2000, 2, proleptic=proleptic)) == int
+        assert type(days_in_ym(2000, 2, proleptic=proleptic)) is int
         assert days_in_ym(1999, 2, proleptic=proleptic) == 28
 
         with pytest.raises(JVF):
@@ -181,7 +181,7 @@ def test_calendar():
     # days_in_year()
     for proleptic in (False, True):
         assert days_in_year(2000, proleptic=proleptic) == 366
-        assert type(days_in_year(2000, proleptic=proleptic)) == int
+        assert type(days_in_year(2000, proleptic=proleptic)) is int
         assert np.all(days_in_year(np.arange(2000,2012), proleptic=proleptic)
                                == 3*[366,365,365,365])
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,7 +3,7 @@
 ##########################################################################################
 
 import numpy as np
-import unittest
+import pytest
 
 from julian.calendar import (
     day_from_yd,
@@ -24,335 +24,331 @@ from julian._DEPRECATED import (
 from julian._exceptions import JulianValidateFailure as JVF
 
 
-class Test_calendar(unittest.TestCase):
+def test_calendar():
 
-    def runTest(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    # day_from_ymd()
+    assert day_from_ymd(2000,1,1) == 0
+    assert type(day_from_ymd(2000,1,1)) is int
+    assert day_from_ymd(2000,1,1.) == 0.
+    assert type(day_from_ymd(2000,1,1.)) is float
 
-        # day_from_ymd()
-        self.assertEqual(day_from_ymd(2000,1,1), 0)
-        self.assertIs(type(day_from_ymd(2000,1,1)), int)
-        self.assertEqual(day_from_ymd(2000,1,1.), 0.)
-        self.assertIs(type(day_from_ymd(2000,1,1.)), float)
+    assert day_from_ymd(2000,2,[27,28,29]).tolist() == [57,58,59]
+    assert day_from_ymd(2000,[1,2,3],1).tolist() == [ 0,31,60]
+    assert day_from_ymd([2000,2001,2002],1,1).tolist() == [0,366,731]
 
-        self.assertEqual(day_from_ymd(2000,2,[27,28,29]).tolist(),    [57,58,59])
-        self.assertEqual(day_from_ymd(2000,[1,2,3],1).tolist(),       [ 0,31,60])
-        self.assertEqual(day_from_ymd([2000,2001,2002],1,1).tolist(), [0,366,731])
+    with pytest.raises(JVF): day_from_ymd(2000, 1,  0, validate=True)
+    with pytest.raises(JVF): day_from_ymd(2000, 2, 30, validate=True)
+    with pytest.raises(JVF): day_from_ymd(2000, 0,  1, validate=True)
+    with pytest.raises(JVF): day_from_ymd(2000, 13, 1, validate=True)
 
-        self.assertRaises(JVF, day_from_ymd, 2000, 1,  0, validate=True)
-        self.assertRaises(JVF, day_from_ymd, 2000, 2, 30, validate=True)
-        self.assertRaises(JVF, day_from_ymd, 2000, 0,  1, validate=True)
-        self.assertRaises(JVF, day_from_ymd, 2000, 13, 1, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd([2000,2000], [1, 1], [ 1, 0], validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd([2000,2000], [2, 2], [28,30], validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd([2000,2000], [1, 0], [ 1, 1], validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd([2000,2000], [1,13], [ 1, 1], validate=True)
 
-        self.assertRaises(JVF, day_from_ymd, [2000,2000], [1, 1], [ 1, 0],
-                                             validate=True)
-        self.assertRaises(JVF, day_from_ymd, [2000,2000], [2, 2], [28,30],
-                                             validate=True)
-        self.assertRaises(JVF, day_from_ymd, [2000,2000], [1, 0], [ 1, 1],
-                                             validate=True)
-        self.assertRaises(JVF, day_from_ymd, [2000,2000], [1,13], [ 1, 1],
-                                             validate=True)
+    assert day_from_ymd(1582, 10, 15,) == -152384
+    assert day_from_ymd(1582, 10, 14, proleptic=True) == -152385
+    with pytest.raises(JVF):
+        day_from_ymd(1582, 10, 14, proleptic=False, validate=True)
+    with pytest.raises(JVF):
+        day_from_ymd([1582,1582], [10,10], [15,14], proleptic=False, validate=True)
+    assert day_from_ymd([1582,1582],[10,10],[15,4],
+                     proleptic=True).tolist() == [-152384,-152395]
+    assert day_from_ymd([1582,1582],[10,10],[15,4],
+                     proleptic=False).tolist() == [-152384,-152385]
+    assert day_from_ymd([1582,1582],[10,10],[3,4],
+                     proleptic=False).tolist() == [-152386,-152385]
 
-        self.assertEqual(day_from_ymd(1582, 10, 15,), -152384)
-        self.assertEqual(day_from_ymd(1582, 10, 14, proleptic=True), -152385)
-        self.assertRaises(JVF, day_from_ymd, 1582, 10, 14, proleptic=False, validate=True)
-        self.assertRaises(JVF, day_from_ymd, [1582,1582], [10,10], [15,14],
-                          proleptic=False, validate=True)
-        self.assertEqual(day_from_ymd([1582,1582],[10,10],[15,4],
-                         proleptic=True).tolist(), [-152384,-152395])
-        self.assertEqual(day_from_ymd([1582,1582],[10,10],[15,4],
-                         proleptic=False).tolist(),[-152384,-152385])
-        self.assertEqual(day_from_ymd([1582,1582],[10,10],[3,4],
-                         proleptic=False).tolist(),[-152386,-152385])
+    _ = day_from_ymd(1582, 10, 7, validate=False)
+    with pytest.raises(JVF): day_from_ymd(1582, 10, 7, validate=True)
 
-        _ = day_from_ymd(1582, 10, 7, validate=False)
-        self.assertRaises(JVF, day_from_ymd, 1582, 10, 7, validate=True)
+    _ = day_from_ymd(1582, 10, np.arange(1,32), validate=False)
+    with pytest.raises(JVF): day_from_ymd(1582, 10, np.arange(1,32), validate=True)
 
-        _ = day_from_ymd(1582, 10, np.arange(1,32), validate=False)
-        self.assertRaises(JVF, day_from_ymd, 1582, 10, np.arange(1,32), validate=True)
+    # ymd_from_day()
+    assert ymd_from_day(0) == (2000, 1, 1)
+    assert type(ymd_from_day(0)[0]) is int
+    assert type(ymd_from_day(0)[1]) is int
+    assert type(ymd_from_day(0)[2]) is int
 
-        # ymd_from_day()
-        self.assertEqual(ymd_from_day(0), (2000, 1, 1))
-        self.assertIs(type(ymd_from_day(0)[0]), int)
-        self.assertIs(type(ymd_from_day(0)[1]), int)
-        self.assertIs(type(ymd_from_day(0)[2]), int)
+    assert ymd_from_day(0.) == (2000, 1, 1.)
+    assert type(ymd_from_day(0.)[0]) is int
+    assert type(ymd_from_day(0.)[1]) is int
+    assert type(ymd_from_day(0.)[2]) is float
 
-        self.assertEqual(ymd_from_day(0.), (2000, 1, 1.))
-        self.assertIs(type(ymd_from_day(0.)[0]), int)
-        self.assertIs(type(ymd_from_day(0.)[1]), int)
-        self.assertIs(type(ymd_from_day(0.)[2]), float)
+    assert ymd_from_day( 60) == (2000, 3, 1)
+    assert ymd_from_day(365) == (2000,12,31)
+    assert ymd_from_day(366) == (2001, 1, 1)
 
-        self.assertEqual(ymd_from_day( 60), (2000, 3, 1))
-        self.assertEqual(ymd_from_day(365), (2000,12,31))
-        self.assertEqual(ymd_from_day(366), (2001, 1, 1))
+    assert np.all(np.array(ymd_from_day([  0,  31]))
+                           == ([2000,2000],[ 1, 2],[ 1, 1]))
+    assert np.all(np.array(ymd_from_day([ 60,  61]))
+                           == ([2000,2000],[ 3, 3],[ 1, 2]))
+    assert np.all(np.array(ymd_from_day([365, 364]))
+                           == ([2000,2000],[12,12],[31,30]))
+    assert np.all(np.array(ymd_from_day([366, 365]))
+                           == ([2001,2000],[ 1,12],[ 1,31]))
 
-        self.assertTrue(np.all(np.array(ymd_from_day([  0,  31]))
-                               == ([2000,2000],[ 1, 2],[ 1, 1])))
-        self.assertTrue(np.all(np.array(ymd_from_day([ 60,  61]))
-                               == ([2000,2000],[ 3, 3],[ 1, 2])))
-        self.assertTrue(np.all(np.array(ymd_from_day([365, 364]))
-                               == ([2000,2000],[12,12],[31,30])))
-        self.assertTrue(np.all(np.array(ymd_from_day([366, 365]))
-                               == ([2001,2000],[ 1,12],[ 1,31])))
+    assert ymd_from_day(-152384) == (1582, 10, 15)
+    assert ymd_from_day(-152385, proleptic=True) == (1582, 10, 14)
+    assert ymd_from_day(-152385, proleptic=False) == (1582, 10,  4)
 
-        self.assertEqual(ymd_from_day(-152384), (1582, 10, 15))
-        self.assertEqual(ymd_from_day(-152385, proleptic=True),  (1582, 10, 14))
-        self.assertEqual(ymd_from_day(-152385, proleptic=False), (1582, 10,  4))
+    assert np.all(np.array(ymd_from_day([-152384,-152385], proleptic=True))
+                           == ([1582,1582],[10,10],[15,14]))
+    assert np.all(np.array(ymd_from_day([-152384,-152385], proleptic=False))
+                           == ([1582,1582],[10,10],[15, 4]))
 
-        self.assertTrue(np.all(np.array(ymd_from_day([-152384,-152385], proleptic=True))
-                               == ([1582,1582],[10,10],[15,14])))
-        self.assertTrue(np.all(np.array(ymd_from_day([-152384,-152385], proleptic=False))
-                               == ([1582,1582],[10,10],[15, 4])))
+    # There's some weirdness surrounding March 1, 1 BCE (= astronomical year 0)
+    for proleptic in (True, False):
+        day = np.arange(day_from_ymd(-101, 1, 1, proleptic=proleptic),
+                        day_from_ymd(-102, 1, 2, proleptic=proleptic))
+        (y, m, d) = ymd_from_day(day, proleptic=proleptic)
+        day2 = day_from_ymd(y, m, d, proleptic=proleptic)
+        assert np.all(day == day2)
 
-        # There's some weirdness surrounding March 1, 1 BCE (= astronomical year 0)
-        for proleptic in (True, False):
-            day = np.arange(day_from_ymd(-101, 1, 1, proleptic=proleptic),
-                            day_from_ymd(-102, 1, 2, proleptic=proleptic))
+        for dd in day:
+            (y, m, d) = ymd_from_day(dd, proleptic=proleptic)
+            day2 = day_from_ymd(y, m, d, proleptic=proleptic)
+            assert dd == day2
+
+    # day_from_yd()
+    assert day_from_yd(2000,1) == 0
+    assert day_from_yd(2001,[2,3,4]).tolist() == [367,368,369]
+    assert day_from_yd([2000,2001],1).tolist() == [ 0,366]
+    assert day_from_yd([2000,2001,2002],[1,2,3]).tolist() == [0,367,733]
+
+    with pytest.raises(JVF): day_from_yd(2000,  0, validate=True)
+    assert day_from_yd(2000, 366, validate=True) == 365
+    with pytest.raises(JVF): day_from_yd(2000, 367, validate=True)
+    with pytest.raises(JVF): day_from_yd(1582, 360, validate=True, proleptic=False)
+    with pytest.raises(JVF):
+        day_from_yd(1582, [300,355,360], validate=True, proleptic=False)
+
+    # In 1582, not a leap year, October 4 was day of year 277
+    assert day_from_yd(1582, 277, proleptic=False) == -152385
+    assert day_from_yd(1582, [277,278], proleptic=False).tolist() == [-152385,-152384]
+    assert day_from_yd(1582, 277, proleptic=True) == -152395
+    assert day_from_yd(1582, [277,278], proleptic=True).tolist() == [-152395,-152394]
+
+    # yd_from_day()
+    assert yd_from_day(0) == (2000,1)
+    assert yd_from_day(365) == (2000,366)
+
+    # month_from_ym()
+    assert month_from_ym(2000, 1, validate=False) == 0
+    assert month_from_ym(2000, 1, validate=True) == 0
+    with pytest.raises(JVF): month_from_ym(2000, 0, validate=True)
+    with pytest.raises(JVF): month_from_ym(2000, 13, validate=True)
+    with pytest.raises(JVF): month_from_ym(2000, [12,14], validate=True)
+    with pytest.raises(JVF): month_from_ym([2000, 2001], [12,14], validate=True)
+
+    # days_in_ym()
+    for proleptic in (False, True):
+        assert days_in_ym(2000, 2, proleptic=proleptic) == 29
+        assert type(days_in_ym(2000, 2, proleptic=proleptic)) == int
+        assert days_in_ym(1999, 2, proleptic=proleptic) == 28
+
+        with pytest.raises(JVF):
+            days_in_ym(2000, 0, proleptic=proleptic, validate=True)
+
+        assert np.all(days_in_ym(np.arange(2000,2012), 2,
+                                          proleptic=proleptic)
+                               == 3*[29,28,28,28])
+        assert np.all(days_in_ym(np.arange(2000,2012), 3,
+                                          proleptic=proleptic)
+                               == 31)
+
+    assert days_in_ym(1582, 10, proleptic=True) == 31
+    assert days_in_ym(1582, 10, proleptic=False) == 21
+    assert days_in_ym(1582, [10,11], proleptic=False).tolist() == [21,30]
+
+    # days_in_month()
+    assert days_in_month(1) == 29
+    assert days_in_month(-11) == 28
+    month = month_from_ym(1582, 10)
+    assert days_in_month(month, proleptic=True) == 31
+    assert days_in_month(month, proleptic=False) == 21
+    assert days_in_month([month,month+1], proleptic=False).tolist() == [21,30]
+
+    # days_in_year()
+    for proleptic in (False, True):
+        assert days_in_year(2000, proleptic=proleptic) == 366
+        assert type(days_in_year(2000, proleptic=proleptic)) == int
+        assert np.all(days_in_year(np.arange(2000,2012), proleptic=proleptic)
+                               == 3*[366,365,365,365])
+
+    assert days_in_year(1582, proleptic=False) == 355
+    assert days_in_year(1582, proleptic=True) == 365
+
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
+
+    # Convert to ymd and back
+    (ylist, mlist, dlist) = ymd_from_day(daylist)
+    test_daylist = day_from_ymd(ylist, mlist, dlist)
+
+    assert np.all(test_daylist == daylist), \
+        'Large-scale conversion from day to YMD and back failed'
+
+    # Make sure every month is in range
+    assert np.all(mlist >= 1), 'Month-of-year < 1 found'
+    assert np.all(mlist <= 12), 'Month-of-year > 12 found'
+
+    # Make sure every day is in range
+    assert np.all(dlist >= 1), 'Day < 1 found'
+    assert np.all(dlist <= 31), 'Day > 31 found'
+
+    # Another large number of dates, spanning > 200 years
+    daylist = np.arange(-40001,40000,79)
+
+    # Convert to yd and back
+    (ylist, dlist) = yd_from_day(daylist)
+    test_daylist = day_from_yd(ylist, dlist)
+
+    assert np.all(test_daylist == daylist)
+
+    # Make sure every day is in range
+    assert np.all(dlist >= 1), 'Day < 1 found'
+    assert np.all(dlist <= 366), 'Day > 366 found'
+
+    # A large number of months, spanning > 200 years
+    monthlist = np.arange(-15002,15000,19)
+
+    # Convert to ym and back
+    (ylist, mlist) = ym_from_month(monthlist)
+    test_monthlist = month_from_ym(ylist, mlist)
+
+    assert np.all(test_monthlist == monthlist)
+
+    # Make sure every month is in range
+    assert np.all(mlist >= 1), 'Month-of-year < 1 found'
+    assert np.all(mlist <= 12), 'Month-of-year > 12 found'
+
+    # Check the days in each January
+    mlist = np.arange(month_from_ym(1980,1),month_from_ym(2220,1),12)
+    assert np.all(days_in_month(mlist) == 31), \
+        'Not every January has 31 days'
+
+    # Check the days in each April
+    mlist = np.arange(month_from_ym(1980,4),month_from_ym(2220,4),12)
+    assert np.all(days_in_month(mlist) == 30), \
+        'Not every April has 30 days'
+
+    # Check the days in each year
+    ylist = np.arange(1890, 2210)
+    dlist = days_in_year(ylist)
+    assert np.all((dlist == 365) | (dlist == 366)), \
+        'Not every year has 365 or 366 days'
+
+    # Every leap year is a multiple of four
+    select = np.where(dlist == 366)
+    assert np.all(ylist[select]%4 == 0), \
+        'Not every leapyear is a multiple of four'
+
+    # February always has 29 days in a leapyear
+    assert np.all(days_in_month(month_from_ym(ylist[select],2)) == 29), \
+        'Not every leap year February has 29 days'
+
+    # February always has 28 days otherwise
+    select = np.where(dlist == 365)
+    assert np.all(days_in_month(month_from_ym(ylist[select],2)) == 28), \
+        'Not every non-leap year February has 28 days'
+
+    # Julian vs. Gregorian calendars around 1 CE
+    for proleptic in (False, True):
+        start_day = day_from_ymd(-10, 1, 1, proleptic=proleptic)
+        stop_day  = day_from_ymd( 11, 1, 1, proleptic=proleptic)
+        days = []
+        for day in range(start_day, stop_day+1):
+            days.append(day)
+
             (y, m, d) = ymd_from_day(day, proleptic=proleptic)
             day2 = day_from_ymd(y, m, d, proleptic=proleptic)
-            self.assertTrue(np.all(day == day2))
+            assert day == day2
 
-            for dd in day:
-                (y, m, d) = ymd_from_day(dd, proleptic=proleptic)
-                day2 = day_from_ymd(y, m, d, proleptic=proleptic)
-                self.assertEqual(dd, day2)
+            (y, d) = yd_from_day(day, proleptic=proleptic)
+            day2 = day_from_yd(y, d, proleptic=proleptic)
+            assert day == day2
 
-        # day_from_yd()
-        self.assertEqual(day_from_yd(2000,1), 0)
-        self.assertEqual(day_from_yd(2001,[2,3,4]).tolist(),  [367,368,369])
-        self.assertEqual(day_from_yd([2000,2001],1).tolist(), [ 0,366])
-        self.assertEqual(day_from_yd([2000,2001,2002],[1,2,3]).tolist(), [0,367,733])
+        (y, m, d) = ymd_from_day(days, proleptic=proleptic)
+        days2 = day_from_ymd(y, m, d, proleptic=proleptic)
+        assert np.all(days2 == days)
 
-        self.assertRaises(JVF, day_from_yd, 2000,  0, validate=True)
-        self.assertEqual(day_from_yd(2000, 366, validate=True), 365)
-        self.assertRaises(JVF, day_from_yd, 2000, 367, validate=True)
-        self.assertRaises(JVF, day_from_yd, 1582, 360, validate=True, proleptic=False)
-        self.assertRaises(JVF, day_from_yd, 1582, [300,355,360], validate=True,
-                                            proleptic=False)
+        (y, d) = yd_from_day(days, proleptic=proleptic)
+        days2 = day_from_yd(y, d, proleptic=proleptic)
+        assert np.all(days2 == days)
 
-        # In 1582, not a leap year, October 4 was day of year 277
-        self.assertEqual(day_from_yd(1582, 277, proleptic=False), -152385)
-        self.assertEqual(day_from_yd(1582, [277,278], proleptic=False).tolist(),
-                         [-152385,-152384])
-        self.assertEqual(day_from_yd(1582, 277, proleptic=True), -152395)
-        self.assertEqual(day_from_yd(1582, [277,278], proleptic=True).tolist(),
-                         [-152395,-152394])
+    # Julian vs. Gregorian calendars around 1582
+    for proleptic in (False, True):
+        start_day = day_from_ymd(1572, 1, 1, proleptic=proleptic)
+        stop_day  = day_from_ymd(1593, 1, 1, proleptic=proleptic)
+        days = []
+        for day in range(start_day, stop_day+1):
+            days.append(day)
 
-        # yd_from_day()
-        self.assertEqual(yd_from_day(0), (2000,1))
-        self.assertEqual(yd_from_day(365), (2000,366))
+            (y, m, d) = ymd_from_day(day, proleptic=proleptic)
+            day2 = day_from_ymd(y, m, d, proleptic=proleptic)
+            assert day == day2
 
-        # month_from_ym()
-        self.assertEqual(month_from_ym(2000, 1, validate=False), 0)
-        self.assertEqual(month_from_ym(2000, 1, validate=True),  0)
-        self.assertRaises(JVF, month_from_ym, 2000, 0, validate=True)
-        self.assertRaises(JVF, month_from_ym, 2000, 13, validate=True)
-        self.assertRaises(JVF, month_from_ym, 2000, [12,14], validate=True)
-        self.assertRaises(JVF, month_from_ym, [2000, 2001], [12,14], validate=True)
+            (y, d) = yd_from_day(day, proleptic=proleptic)
+            day2 = day_from_yd(y, d, proleptic=proleptic)
+            assert day == day2
 
-        # days_in_ym()
-        for proleptic in (False, True):
-            self.assertEqual(days_in_ym(2000, 2, proleptic=proleptic), 29)
-            self.assertEqual(type(days_in_ym(2000, 2, proleptic=proleptic)), int)
-            self.assertEqual(days_in_ym(1999, 2, proleptic=proleptic), 28)
+        (y, m, d) = ymd_from_day(days, proleptic=proleptic)
+        days2 = day_from_ymd(y, m, d, proleptic=proleptic)
+        assert np.all(days2 == days)
 
-            self.assertRaises(JVF, days_in_ym, 2000, 0, proleptic=proleptic,
-                              validate=True)
+        (y, d) = yd_from_day(days, proleptic=proleptic)
+        days2 = day_from_yd(y, d, proleptic=proleptic)
+        assert np.all(days2 == days)
 
-            self.assertTrue(np.all(days_in_ym(np.arange(2000,2012), 2,
-                                              proleptic=proleptic)
-                                   == 3*[29,28,28,28]))
-            self.assertTrue(np.all(days_in_ym(np.arange(2000,2012), 3,
-                                              proleptic=proleptic)
-                                   == 31))
+    # Dates between calendars
+    _ = day_from_ymd(1582, 10, np.arange(1,32), validate=False, proleptic=False)
+    _ = day_from_ymd(1582, 10, np.arange(1,32), validate=True, proleptic=True)
+    with pytest.raises(JVF):
+        day_from_ymd(1582, 10, np.arange(1,32), validate=True, proleptic=False)
+    _ = day_from_ymd(1582,  9, np.arange(1,31), validate=True, proleptic=False)
+    _ = day_from_ymd(1582, 11, np.arange(1,31), validate=True, proleptic=False)
 
-        self.assertEqual(days_in_ym(1582, 10, proleptic=True), 31)
-        self.assertEqual(days_in_ym(1582, 10, proleptic=False), 21)
-        self.assertEqual(days_in_ym(1582, [10,11], proleptic=False).tolist(), [21,30])
+    # Math jump on March 1 in leap years before 200
+    days = day_from_ymd(np.arange(192,205), 3, 1)
+    for day in days:
+        (y,m,d) = ymd_from_day(day)
+        assert m == 3
+        assert d == 1
 
-        # days_in_month()
-        self.assertEqual(days_in_month(1), 29)
-        self.assertEqual(days_in_month(-11), 28)
-        month = month_from_ym(1582, 10)
-        self.assertEqual(days_in_month(month, proleptic=True), 31)
-        self.assertEqual(days_in_month(month, proleptic=False), 21)
-        self.assertEqual(days_in_month([month,month+1], proleptic=False).tolist(),
-                         [21,30])
+        (y,m,d) = ymd_from_day(day+1)
+        assert m == 3
+        assert d == 2
 
-        # days_in_year()
-        for proleptic in (False, True):
-            self.assertEqual(days_in_year(2000, proleptic=proleptic), 366)
-            self.assertEqual(type(days_in_year(2000, proleptic=proleptic)), int)
-            self.assertTrue(np.all(days_in_year(np.arange(2000,2012), proleptic=proleptic)
-                                   == 3*[366,365,365,365]))
+    (y,m,d) = ymd_from_day(days)
+    assert np.all(m == 3)
+    assert np.all(d == 1)
 
-        self.assertEqual(days_in_year(1582, proleptic=False), 355)
-        self.assertEqual(days_in_year(1582, proleptic=True),  365)
+    # Reality checks, set_gregorian_start
+    assert day_from_ymd(-4712, 1, 1, proleptic=False) == -2451545
+    assert day_from_ymd(-4713,11,24, proleptic=True) == -2451545
+    assert days_in_year(1582, proleptic=False) == 355
+    assert days_in_year(1582, proleptic=True) == 365
 
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
+    set_gregorian_start(None)
+    assert day_from_ymd(-4713,11,24, proleptic=True) == -2451545
+    assert day_from_ymd(-4713,11,24, proleptic=False) == -2451545
 
-        # Convert to ymd and back
-        (ylist, mlist, dlist) = ymd_from_day(daylist)
-        test_daylist = day_from_ymd(ylist, mlist, dlist)
+    set_gregorian_start(1752, 9, 14)
+    assert days_in_year(1582, proleptic=False) == 365
+    assert days_in_year(1582, proleptic=True) == 365
+    assert days_in_year(1752, proleptic=False) == 355
+    assert days_in_year(1752, proleptic=True) == 366
 
-        self.assertTrue(np.all(test_daylist == daylist),
-                        'Large-scale conversion from day to YMD and back failed')
-
-        # Make sure every month is in range
-        self.assertTrue(np.all(mlist >= 1), 'Month-of-year < 1 found')
-        self.assertTrue(np.all(mlist <= 12), 'Month-of-year > 12 found')
-
-        # Make sure every day is in range
-        self.assertTrue(np.all(dlist >= 1), 'Day < 1 found')
-        self.assertTrue(np.all(dlist <= 31), 'Day > 31 found')
-
-        # Another large number of dates, spanning > 200 years
-        daylist = np.arange(-40001,40000,79)
-
-        # Convert to yd and back
-        (ylist, dlist) = yd_from_day(daylist)
-        test_daylist = day_from_yd(ylist, dlist)
-
-        self.assertTrue(np.all(test_daylist == daylist))
-
-        # Make sure every day is in range
-        self.assertTrue(np.all(dlist >= 1), 'Day < 1 found')
-        self.assertTrue(np.all(dlist <= 366), 'Day > 366 found')
-
-        # A large number of months, spanning > 200 years
-        monthlist = np.arange(-15002,15000,19)
-
-        # Convert to ym and back
-        (ylist, mlist) = ym_from_month(monthlist)
-        test_monthlist = month_from_ym(ylist, mlist)
-
-        self.assertTrue(np.all(test_monthlist == monthlist))
-
-        # Make sure every month is in range
-        self.assertTrue(np.all(mlist >= 1), 'Month-of-year < 1 found')
-        self.assertTrue(np.all(mlist <= 12), 'Month-of-year > 12 found')
-
-        # Check the days in each January
-        mlist = np.arange(month_from_ym(1980,1),month_from_ym(2220,1),12)
-        self.assertTrue(np.all(days_in_month(mlist) == 31),
-            'Not every January has 31 days')
-
-        # Check the days in each April
-        mlist = np.arange(month_from_ym(1980,4),month_from_ym(2220,4),12)
-        self.assertTrue(np.all(days_in_month(mlist) == 30),
-            'Not every April has 30 days')
-
-        # Check the days in each year
-        ylist = np.arange(1890, 2210)
-        dlist = days_in_year(ylist)
-        self.assertTrue(np.all((dlist == 365) | (dlist == 366)),
-            'Not every year has 365 or 366 days')
-
-        # Every leap year is a multiple of four
-        select = np.where(dlist == 366)
-        self.assertTrue(np.all(ylist[select]%4 == 0),
-                        'Not every leapyear is a multiple of four')
-
-        # February always has 29 days in a leapyear
-        self.assertTrue(np.all(days_in_month(month_from_ym(ylist[select],2)) == 29),
-                        'Not every leap year February has 29 days')
-
-        # February always has 28 days otherwise
-        select = np.where(dlist == 365)
-        self.assertTrue(np.all(days_in_month(month_from_ym(ylist[select],2)) == 28),
-                        'Not every non-leap year February has 28 days')
-
-        # Julian vs. Gregorian calendars around 1 CE
-        for proleptic in (False, True):
-            start_day = day_from_ymd(-10, 1, 1, proleptic=proleptic)
-            stop_day  = day_from_ymd( 11, 1, 1, proleptic=proleptic)
-            days = []
-            for day in range(start_day, stop_day+1):
-                days.append(day)
-
-                (y, m, d) = ymd_from_day(day, proleptic=proleptic)
-                day2 = day_from_ymd(y, m, d, proleptic=proleptic)
-                self.assertEqual(day, day2)
-
-                (y, d) = yd_from_day(day, proleptic=proleptic)
-                day2 = day_from_yd(y, d, proleptic=proleptic)
-                self.assertEqual(day, day2)
-
-            (y, m, d) = ymd_from_day(days, proleptic=proleptic)
-            days2 = day_from_ymd(y, m, d, proleptic=proleptic)
-            self.assertTrue(np.all(days2 == days))
-
-            (y, d) = yd_from_day(days, proleptic=proleptic)
-            days2 = day_from_yd(y, d, proleptic=proleptic)
-            self.assertTrue(np.all(days2 == days))
-
-        # Julian vs. Gregorian calendars around 1582
-        for proleptic in (False, True):
-            start_day = day_from_ymd(1572, 1, 1, proleptic=proleptic)
-            stop_day  = day_from_ymd(1593, 1, 1, proleptic=proleptic)
-            days = []
-            for day in range(start_day, stop_day+1):
-                days.append(day)
-
-                (y, m, d) = ymd_from_day(day, proleptic=proleptic)
-                day2 = day_from_ymd(y, m, d, proleptic=proleptic)
-                self.assertEqual(day, day2)
-
-                (y, d) = yd_from_day(day, proleptic=proleptic)
-                day2 = day_from_yd(y, d, proleptic=proleptic)
-                self.assertEqual(day, day2)
-
-            (y, m, d) = ymd_from_day(days, proleptic=proleptic)
-            days2 = day_from_ymd(y, m, d, proleptic=proleptic)
-            self.assertTrue(np.all(days2 == days))
-
-            (y, d) = yd_from_day(days, proleptic=proleptic)
-            days2 = day_from_yd(y, d, proleptic=proleptic)
-            self.assertTrue(np.all(days2 == days))
-
-        # Dates between calendars
-        _ = day_from_ymd(1582, 10, np.arange(1,32), validate=False, proleptic=False)
-        _ = day_from_ymd(1582, 10, np.arange(1,32), validate=True, proleptic=True)
-        self.assertRaises(JVF, day_from_ymd, 1582, 10, np.arange(1,32), validate=True,
-                                             proleptic=False)
-        _ = day_from_ymd(1582,  9, np.arange(1,31), validate=True, proleptic=False)
-        _ = day_from_ymd(1582, 11, np.arange(1,31), validate=True, proleptic=False)
-
-        # Math jump on March 1 in leap years before 200
-        days = day_from_ymd(np.arange(192,205), 3, 1)
-        for day in days:
-            (y,m,d) = ymd_from_day(day)
-            self.assertEqual(m, 3)
-            self.assertEqual(d, 1)
-
-            (y,m,d) = ymd_from_day(day+1)
-            self.assertEqual(m, 3)
-            self.assertEqual(d, 2)
-
-        (y,m,d) = ymd_from_day(days)
-        self.assertTrue(np.all(m == 3))
-        self.assertTrue(np.all(d == 1))
-
-        # Reality checks, set_gregorian_start
-        self.assertEqual(day_from_ymd(-4712, 1, 1, proleptic=False), -2451545)
-        self.assertEqual(day_from_ymd(-4713,11,24, proleptic=True),  -2451545)
-        self.assertEqual(days_in_year(1582, proleptic=False), 355)
-        self.assertEqual(days_in_year(1582, proleptic=True),  365)
-
-        set_gregorian_start(None)
-        self.assertEqual(day_from_ymd(-4713,11,24, proleptic=True),  -2451545)
-        self.assertEqual(day_from_ymd(-4713,11,24, proleptic=False), -2451545)
-
-        set_gregorian_start(1752, 9, 14)
-        self.assertEqual(days_in_year(1582, proleptic=False), 365)
-        self.assertEqual(days_in_year(1582, proleptic=True),  365)
-        self.assertEqual(days_in_year(1752, proleptic=False), 355)
-        self.assertEqual(days_in_year(1752, proleptic=True),  366)
-
-        set_gregorian_start()
+    set_gregorian_start()
 
 ##########################################################################################

--- a/tests/test_date_parsers.py
+++ b/tests/test_date_parsers.py
@@ -38,11 +38,11 @@ def test_date_parsers():
     assert _date_pattern_filter('abcdefg1 2 3456hijkl')
     assert _date_pattern_filter('abcdefg1000hijkl')
 
-    assert  _date_pattern_filter('abcdefg3000 399hijkl', doy=True)
+    assert _date_pattern_filter('abcdefg3000 399hijkl', doy=True)
     assert not _date_pattern_filter('abcdefg3000 399hijkl', doy=False)
     assert not _date_pattern_filter('abcdefg3000 400hijkl', doy=False)
 
-    assert  _date_pattern_filter('abcdefg MJTd hijkl', mjd=True)
+    assert _date_pattern_filter('abcdefg MJTd hijkl', mjd=True)
     assert not _date_pattern_filter('abcdefg Jed hijkl', mjd=False)
     assert not _date_pattern_filter('abcdefgJd hijkl',  mjd=True)
     assert not _date_pattern_filter('abcdefg mJdhijkl', mjd=True)
@@ -62,16 +62,23 @@ def test_date_parsers():
     assert day_from_string('1582-10-01', proleptic=True) == -152398
     assert day_from_string('1582-10-01', proleptic=False) == -152388
 
-    with pytest.raises(JPE): day_from_string('whatever')
-    with pytest.raises(JPE): day_from_string('01-02-2000 cE', extended=False)
+    with pytest.raises(JPE):
+        day_from_string('whatever')
+    with pytest.raises(JPE):
+        day_from_string('01-02-2000 cE', extended=False)
 
     # Check date validator, weekdays
-    with pytest.raises(JVF): day_from_string('2001-11-31')
-    with pytest.raises(JVF): day_from_string('2001-02-29')
-    with pytest.raises(JPE): day_from_string('2001-02-ab')
+    with pytest.raises(JVF):
+        day_from_string('2001-11-31')
+    with pytest.raises(JVF):
+        day_from_string('2001-02-29')
+    with pytest.raises(JPE):
+        day_from_string('2001-02-ab')
 
-    with pytest.raises(JVF): day_from_string('Monday, 2000-01-01', weekdays=True)
-    with pytest.raises(JVF): day_from_string('Monday, 2000-001', weekdays=True)
+    with pytest.raises(JVF):
+        day_from_string('Monday, 2000-01-01', weekdays=True)
+    with pytest.raises(JVF):
+        day_from_string('Monday, 2000-001', weekdays=True)
     # because it was a Saturday
 
     # Check day_in_string
@@ -117,7 +124,7 @@ def test_date_parsers():
     assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
                            order='DMY', first=True) == day_from_ymd(2000,1,2)
     assert days_in_strings(['Is this today?02-01-xxx0-0', '2000-xx-03!'],
-                           order='DMY', first=True) == None
+                           order='DMY', first=True) is None
     assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
                            order='DMY', substrings=True) == \
         [(day_from_ymd(2000,1,2), '02-01-2000'),
@@ -144,10 +151,14 @@ def test_date_parsers():
         [(day_from_yd(1001,1), '1001-001')]
 
     # Check date validator
-    with pytest.raises(JVF): days_in_strings('Today=(2001-11-31)', first=True)
-    with pytest.raises(JVF): days_in_strings('Today=(2001-11-31)', first=False)
-    with pytest.raises(JVF): days_in_strings('Today 2001-02-29T12:34:56', first=True)
-    with pytest.raises(JVF): days_in_strings('Today 2001-02-29T12:34:56', first=False)
+    with pytest.raises(JVF):
+        days_in_strings('Today=(2001-11-31)', first=True)
+    with pytest.raises(JVF):
+        days_in_strings('Today=(2001-11-31)', first=False)
+    with pytest.raises(JVF):
+        days_in_strings('Today 2001-02-29T12:34:56', first=True)
+    with pytest.raises(JVF):
+        days_in_strings('Today 2001-02-29T12:34:56', first=False)
     assert day_in_string('Today 2001-01-01, not tomorrow', remainder=True) == \
         (366, ', not tomorrow')
 

--- a/tests/test_date_parsers.py
+++ b/tests/test_date_parsers.py
@@ -82,7 +82,7 @@ def test_date_parsers():
     assert day_in_string('Test--02-01-00-00', order='DMY') == day_from_ymd(2000,1,2)
     assert day_in_string('Test 2000-02-29=today', order='DMY') == day_from_ymd(2000,2,29)
     assert day_in_string('Using DOY is 2020-366') == day_from_ymd(2020,12,31)
-    assert day_in_string('Using DOY is 2020-367') == None
+    assert day_in_string('Using DOY is 2020-367') is None
 
     # Check days_in_string
     assert days_in_string('Today is 01-02-2000!', order='MDY') == \
@@ -155,7 +155,6 @@ def test_date_parsers():
     test_path = 'test_files/cpck15Dec2017.tpc'
     with open(test_path, 'r') as f:
         strings = f.readlines()
-    f.close()
 
     PCK_ANSWER = [(6571, '2017-12-28'),
                   (6558, '2017-DEC-15'),

--- a/tests/test_date_parsers.py
+++ b/tests/test_date_parsers.py
@@ -2,7 +2,7 @@
 # julian/test_date_parsers.py
 ##########################################################################################
 
-import unittest
+import pytest
 
 from julian.date_parsers import (
     day_from_string,
@@ -19,353 +19,336 @@ from julian.calendar    import day_from_yd, day_from_ymd
 from julian._exceptions import JulianParseException as JPE
 from julian._exceptions import JulianValidateFailure as JVF
 
-class Test_date_parsers(unittest.TestCase):
+def test_date_parsers():
 
-    def runTest(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    # Note: test_date_pyparser.py has more extensive unit tests
 
-        # Note: test_date_pyparser.py has more extensive unit tests
+    # _date_pattern_filter
+    assert not _date_pattern_filter('abcdefg1 2')
+    assert not _date_pattern_filter('abcdefg3000')
+    assert not _date_pattern_filter('abcdefgwedhijk')
 
-        # _date_pattern_filter
-        self.assertFalse(_date_pattern_filter('abcdefg1 2'))
-        self.assertFalse(_date_pattern_filter('abcdefg3000'))
-        self.assertFalse(_date_pattern_filter('abcdefgwedhijk'))
+    assert _date_pattern_filter('abcdefg wedhijkl')
+    assert _date_pattern_filter('abcdefg jANhijkl')
+    assert _date_pattern_filter('abcdefg1 2 3 4 56hijkl')
+    assert _date_pattern_filter('abcdefg1 2 3456hijkl')
+    assert _date_pattern_filter('abcdefg1000hijkl')
 
-        self.assertTrue(_date_pattern_filter('abcdefg wedhijkl'))
-        self.assertTrue(_date_pattern_filter('abcdefg jANhijkl'))
-        self.assertTrue(_date_pattern_filter('abcdefg1 2 3 4 56hijkl'))
-        self.assertTrue(_date_pattern_filter('abcdefg1 2 3456hijkl'))
-        self.assertTrue(_date_pattern_filter('abcdefg1000hijkl'))
+    assert  _date_pattern_filter('abcdefg3000 399hijkl', doy=True)
+    assert not _date_pattern_filter('abcdefg3000 399hijkl', doy=False)
+    assert not _date_pattern_filter('abcdefg3000 400hijkl', doy=False)
 
-        self.assertTrue(_date_pattern_filter( 'abcdefg3000 399hijkl', doy=True))
-        self.assertFalse(_date_pattern_filter('abcdefg3000 399hijkl', doy=False))
-        self.assertFalse(_date_pattern_filter('abcdefg3000 400hijkl', doy=False))
+    assert  _date_pattern_filter('abcdefg MJTd hijkl', mjd=True)
+    assert not _date_pattern_filter('abcdefg Jed hijkl', mjd=False)
+    assert not _date_pattern_filter('abcdefgJd hijkl',  mjd=True)
+    assert not _date_pattern_filter('abcdefg mJdhijkl', mjd=True)
 
-        self.assertTrue(_date_pattern_filter( 'abcdefg MJTd hijkl', mjd=True))
-        self.assertFalse(_date_pattern_filter('abcdefg Jed hijkl', mjd=False))
-        self.assertFalse(_date_pattern_filter('abcdefgJd hijkl',  mjd=True))
-        self.assertFalse(_date_pattern_filter('abcdefg mJdhijkl', mjd=True))
+    # Check if day_from_string works like day_from_ymd
+    assert day_from_string('2000-01-01') == day_from_ymd(2000,1,1)
 
-        # Check if day_from_string works like day_from_ymd
-        self.assertEqual(day_from_string('2000-01-01'), day_from_ymd(2000,1,1))
+    # Check day_from_string
+    assert day_from_string('01-02-2000', order='MDY') == day_from_ymd(2000,1,2)
+    assert day_from_string('01-02-00', order='MDY') == day_from_ymd(2000,1,2)
+    assert day_from_string('02-01-2000', order='DMY') == day_from_ymd(2000,1,2)
+    assert day_from_string('02-01-00', order='DMY') == day_from_ymd(2000,1,2)
+    assert day_from_string('2000-02-29', order='DMY') == day_from_ymd(2000,2,29)
+    assert day_from_string('01-02-2000 cE', order='MDY', extended=True) == \
+        day_from_ymd(2000,1,2)
 
-        # Check day_from_string
-        self.assertEqual(day_from_string('01-02-2000', order='MDY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_from_string('01-02-00', order='MDY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_from_string('02-01-2000', order='DMY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_from_string('02-01-00', order='DMY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_from_string('2000-02-29', order='DMY'),
-                         day_from_ymd(2000,2,29))
-        self.assertEqual(day_from_string('01-02-2000 cE', order='MDY', extended=True),
-                         day_from_ymd(2000,1,2))
+    assert day_from_string('1582-10-01', proleptic=True) == -152398
+    assert day_from_string('1582-10-01', proleptic=False) == -152388
 
-        self.assertEqual(day_from_string('1582-10-01', proleptic=True),  -152398)
-        self.assertEqual(day_from_string('1582-10-01', proleptic=False), -152388)
+    with pytest.raises(JPE): day_from_string('whatever')
+    with pytest.raises(JPE): day_from_string('01-02-2000 cE', extended=False)
 
-        self.assertRaises(JPE, day_from_string, 'whatever')
-        self.assertRaises(JPE, day_from_string, '01-02-2000 cE', extended=False)
+    # Check date validator, weekdays
+    with pytest.raises(JVF): day_from_string('2001-11-31')
+    with pytest.raises(JVF): day_from_string('2001-02-29')
+    with pytest.raises(JPE): day_from_string('2001-02-ab')
 
-        # Check date validator, weekdays
-        self.assertRaises(JVF, day_from_string, '2001-11-31')
-        self.assertRaises(JVF, day_from_string, '2001-02-29')
-        self.assertRaises(JPE, day_from_string, '2001-02-ab')
+    with pytest.raises(JVF): day_from_string('Monday, 2000-01-01', weekdays=True)
+    with pytest.raises(JVF): day_from_string('Monday, 2000-001', weekdays=True)
+    # because it was a Saturday
 
-        self.assertRaises(JVF, day_from_string, 'Monday, 2000-01-01', weekdays=True)
-        self.assertRaises(JVF, day_from_string, 'Monday, 2000-001', weekdays=True)
-        # because it was a Saturday
+    # Check day_in_string
+    assert day_in_string('Today is 01-02-2000!', order='MDY') == day_from_ymd(2000,1,2)
+    assert day_in_string('Today is:[01-02-00]', order='MDY') == day_from_ymd(2000,1,2)
+    assert day_in_string('Is this today?02-01-2000-0', order='DMY') == \
+        day_from_ymd(2000,1,2)
+    assert day_in_string('Test--02-01-00-00', order='DMY') == day_from_ymd(2000,1,2)
+    assert day_in_string('Test 2000-02-29=today', order='DMY') == day_from_ymd(2000,2,29)
+    assert day_in_string('Using DOY is 2020-366') == day_from_ymd(2020,12,31)
+    assert day_in_string('Using DOY is 2020-367') == None
 
-        # Check day_in_string
-        self.assertEqual(day_in_string('Today is 01-02-2000!', order='MDY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_in_string('Today is:[01-02-00]', order='MDY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_in_string('Is this today?02-01-2000-0', order='DMY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_in_string('Test--02-01-00-00', order='DMY'),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(day_in_string('Test 2000-02-29=today', order='DMY'),
-                         day_from_ymd(2000,2,29))
-        self.assertEqual(day_in_string('Using DOY is 2020-366'),
-                         day_from_ymd(2020,12,31))
-        self.assertEqual(day_in_string('Using DOY is 2020-367'), None)
+    # Check days_in_string
+    assert days_in_string('Today is 01-02-2000!', order='MDY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_string('Today is:[01-02-00]', order='MDY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_string('Is this today?02-01-2000-0', order='DMY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_string('Test--02-01-00-00', order='DMY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_string('Test 2000-02-29=today', order='DMY') == \
+        [day_from_ymd(2000,2,29)]
+    assert days_in_string('Test 2000=today', order='DMY') == []
+    assert days_in_string('2020-01-01|30-10-20, etc.') == \
+        [day_from_ymd(2020,1,1), day_from_ymd(2030,10,20)]
 
-        # Check days_in_string
-        self.assertEqual(days_in_string('Today is 01-02-2000!', order='MDY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_string('Today is:[01-02-00]', order='MDY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_string('Is this today?02-01-2000-0', order='DMY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_string('Test--02-01-00-00', order='DMY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_string('Test 2000-02-29=today', order='DMY'),
-                         [day_from_ymd(2000,2,29)])
-        self.assertEqual(days_in_string('Test 2000=today', order='DMY'),
-                         [])
-        self.assertEqual(days_in_string('2020-01-01|30-10-20, etc.'),
-                         [day_from_ymd(2020,1,1), day_from_ymd(2030,10,20)])
+    # Check days_in_strings
+    assert days_in_strings('Today is 2000-01-02!') == [day_from_ymd(2000,1,2)]
+    assert days_in_strings(['Today is 2000-01-02!', 'Not 2000-13-02']) == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_strings('Today is 01-02-2000!', order='MDY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_strings(['Today is 01-02-2000!', 'I think'], order='MDY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_strings(['Maybe', 'Today is:[01-02-00]'], order='MDY') == \
+        [day_from_ymd(2000,1,2)]
+    assert days_in_strings(['Is this today?02-01-2000-0', 'Or tomorrow?'],
+                           order='DMY') == [day_from_ymd(2000,1,2)]
+    assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
+                           order='DMY') == \
+        [day_from_ymd(2000,1,2), day_from_ymd(2000,1,3)]
+    assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
+                           order='DMY', first=True) == day_from_ymd(2000,1,2)
+    assert days_in_strings(['Is this today?02-01-xxx0-0', '2000-xx-03!'],
+                           order='DMY', first=True) == None
+    assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
+                           order='DMY', substrings=True) == \
+        [(day_from_ymd(2000,1,2), '02-01-2000'),
+         (day_from_ymd(2000,1,3), '2000-01-03')]
+    assert days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
+                           order='DMY', substrings=True, first=True) == \
+        (day_from_ymd(2000,1,2), '02-01-2000')
+    assert days_in_strings(['Is this today?02-01-2000-0', ' MJD 51544.5'],
+                           order='DMY', mjd=False, substrings=True) == \
+        [(day_from_ymd(2000,1,2), '02-01-2000')]
+    assert days_in_strings(['Is this today?02-01-2000-0', ' MJD 51544.5'],
+                           order='DMY', mjd=True, substrings=True) == \
+        [(day_from_ymd(2000,1,2), '02-01-2000'),
+         (day_from_ymd(2000,1,1), 'MJD 51544')]
+    assert days_in_strings(['Is this today?02-01-2000-0', ' 2001-001'],
+                           order='DMY', mjd=True, doy=True, substrings=True) == \
+        [(day_from_ymd(2000,1,2), '02-01-2000'),
+         (day_from_yd(2001,1), '2001-001')]
+    assert days_in_strings(['Is this today?02-01-2000-0', ' 2000-366'],
+                           order='DMY', mjd=True, doy=True, substrings=True) == \
+        [(day_from_ymd(2000,1,2), '02-01-2000'),
+         (day_from_yd(2000,366), '2000-366')]
+    assert days_in_strings(' 1001-001', doy=True, substrings=True) == \
+        [(day_from_yd(1001,1), '1001-001')]
 
-        # Check days_in_strings
-        self.assertEqual(days_in_strings('Today is 2000-01-02!'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings(['Today is 2000-01-02!', 'Not 2000-13-02']),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings('Today is 01-02-2000!', order='MDY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings(['Today is 01-02-2000!', 'I think'], order='MDY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings(['Maybe', 'Today is:[01-02-00]'], order='MDY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', 'Or tomorrow?'],
-                                         order='DMY'),
-                         [day_from_ymd(2000,1,2)])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
-                                         order='DMY'),
-                         [day_from_ymd(2000,1,2), day_from_ymd(2000,1,3)])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
-                                         order='DMY', first=True),
-                         day_from_ymd(2000,1,2))
-        self.assertEqual(days_in_strings(['Is this today?02-01-xxx0-0', '2000-xx-03!'],
-                                         order='DMY', first=True),
-                         None)
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
-                                         order='DMY', substrings=True),
-                         [(day_from_ymd(2000,1,2), '02-01-2000'),
-                          (day_from_ymd(2000,1,3), '2000-01-03')])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', '2000-01-03!'],
-                                         order='DMY', substrings=True, first=True),
-                         (day_from_ymd(2000,1,2), '02-01-2000'))
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', ' MJD 51544.5'],
-                                         order='DMY', mjd=False, substrings=True),
-                         [(day_from_ymd(2000,1,2), '02-01-2000')])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', ' MJD 51544.5'],
-                                         order='DMY', mjd=True, substrings=True),
-                         [(day_from_ymd(2000,1,2), '02-01-2000'),
-                          (day_from_ymd(2000,1,1), 'MJD 51544')])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', ' 2001-001'],
-                                         order='DMY', mjd=True, doy=True, substrings=True),
-                         [(day_from_ymd(2000,1,2), '02-01-2000'),
-                          (day_from_yd(2001,1), '2001-001')])
-        self.assertEqual(days_in_strings(['Is this today?02-01-2000-0', ' 2000-366'],
-                                         order='DMY', mjd=True, doy=True, substrings=True),
-                         [(day_from_ymd(2000,1,2), '02-01-2000'),
-                          (day_from_yd(2000,366), '2000-366')])
-        self.assertEqual(days_in_strings(' 1001-001', doy=True, substrings=True),
-                         [(day_from_yd(1001,1), '1001-001')])
+    # Check date validator
+    with pytest.raises(JVF): days_in_strings('Today=(2001-11-31)', first=True)
+    with pytest.raises(JVF): days_in_strings('Today=(2001-11-31)', first=False)
+    with pytest.raises(JVF): days_in_strings('Today 2001-02-29T12:34:56', first=True)
+    with pytest.raises(JVF): days_in_strings('Today 2001-02-29T12:34:56', first=False)
+    assert day_in_string('Today 2001-01-01, not tomorrow', remainder=True) == \
+        (366, ', not tomorrow')
 
-        # Check date validator
-        self.assertRaises(JVF, days_in_strings, 'Today=(2001-11-31)', first=True)
-        self.assertRaises(JVF, days_in_strings, 'Today=(2001-11-31)', first=False)
-        self.assertRaises(JVF, days_in_strings, 'Today 2001-02-29T12:34:56', first=True)
-        self.assertRaises(JVF, days_in_strings, 'Today 2001-02-29T12:34:56', first=False)
-        self.assertEqual(day_in_string('Today 2001-01-01, not tomorrow', remainder=True),
-                                       (366, ', not tomorrow'))
+    # Real-world test
+    test_path = 'test_files/cpck15Dec2017.tpc'
+    with open(test_path, 'r') as f:
+        strings = f.readlines()
+    f.close()
 
-        # Real-world test
-        test_path = 'test_files/cpck15Dec2017.tpc'
-        with open(test_path, 'r') as f:
-            strings = f.readlines()
-        f.close()
+    PCK_ANSWER = [(6571, '2017-12-28'),
+                  (6558, '2017-DEC-15'),
+                  (6558, '2017-Dec-15'),
+                  (6513, '2017-Oct-31'),
+                  (6512, '2017-Oct-30'),
+                  (6503, '2017-Oct-21'),
+                  (6435, '2017-Aug-14'),
+                  (6415, '2017-Jul-25'),
+                  (6338, '2017-May-09'),
+                  (6295, '2017-Mar-27'),
+                  (6288, '2017-Mar-20'),
+                  (6269, '2017-Mar-01'),
+                  (6268, '2017-Feb-28'),
+                  (6193, '2016-Dec-15'),
+                  (6190, '2016-Dec-12'),
+                  (6165, '2016-Nov-17'),
+                  (6082, '2016-Aug-26'),
+                  (6045, '2016-Jul-20'),
+                  (6003, '2016-Jun-08'),
+                  (5984, '2016-May-20'),
+                  (5947, '2016-Apr-13'),
+                  (5933, '2016-Mar-30'),
+                  (5927, '2016-Mar-24'),
+                  (5872, '2016-Jan-29'),
+                  (5798, '2015-Nov-16'),
+                  (5795, '2015-Nov-13'),
+                  (5784, '2015-Nov-02'),
+                  (5765, '2015-Oct-14'),
+                  (5764, '2015-Oct-13'),
+                  (5763, '2015-Oct-12'),
+                  (5718, '2015-Aug-28'),
+                  (5693, '2015-Aug-03'),
+                  (5639, '2015-Jun-10'),
+                  (5541, '2015-Mar-04'),
+                  (5500, '2015-Jan-22'),
+                  (5486, '2015-Jan-08'),
+                  (5429, '2014-Nov-12'),
+                  (5365, '2014-Sep-09'),
+                  (5364, '2014-Sep-08'),
+                  (5324, '2014-Jul-30'),
+                  (5219, '2014-Apr-16'),
+                  (5057, '2013-Nov-05'),
+                  (5045, '2013-Oct-24'),
+                  (4967, '2013-Aug-07'),
+                  (4966, '2013-Aug-06'),
+                  (4939, '2013-Jul-10'),
+                  (4855, '2013-Apr-17'),
+                  (4828, '2013-Mar-21'),
+                  (4826, '2013-Mar-19'),
+                  (4825, '2013-Mar-18'),
+                  (4758, '2013-Jan-10'),
+                  (4724, '2012-Dec-07'),
+                  (4718, '2012-Dec-01'),
+                  (4625, '2012-Aug-30'),
+                  (4563, '2012-Jun-29'),
+                  (4526, '2012-May-23'),
+                  (4499, '2012-Apr-26'),
+                  (4491, '2012-Apr-18'),
+                  (4441, '2012-Feb-28'),
+                  (4401, '2012-Jan-19'),
+                  (4399, '2012-Jan-17'),
+                  (4304, '2011-Oct-14'),
+                  (4300, '2011-Oct-10'),
+                  (4239, '2011-Aug-10'),
+                  (4157, '2011-May-20'),
+                  (4052, '2011-Feb-04'),
+                  (4036, '2011-Jan-19'),
+                  (4003, '2010-Dec-17'),
+                  (3939, '2010-Oct-14'),
+                  (3908, '2010-Sep-13'),
+                  (3860, '2010-Jul-27'),
+                  (3839, '2010-Jul-06'),
+                  (3828, '2010-Jun-25'),
+                  (3819, '2010-Jun-16'),
+                  (3762, '2010-Apr-20'),
+                  (3736, '2010-Mar-25'),
+                  (3693, '2010-Feb-10'),
+                  (3666, '2010-Jan-14'),
+                  (3665, '2010-Jan-13'),
+                  (3659, '2010-Jan-07'),
+                  (3630, '2009-Dec-09'),
+                  (3609, '2009-Nov-18'),
+                  (3567, '2009-Oct-07'),
+                  (3554, '2009-Sep-24'),
+                  (3552, '2009-Sep-22'),
+                  (3516, '2009-Aug-17'),
+                  (3505, '2009-Aug-06'),
+                  (3476, '2009-Jul-08'),
+                  (3469, '2009-Jul-01'),
+                  (3462, '2009-Jun-24'),
+                  (3449, '2009-Jun-11'),
+                  (3428, '2009-May-21'),
+                  (3414, '2009-May-07'),
+                  (3400, '2009-Apr-23'),
+                  (3344, '2009-Feb-26'),
+                  (3320, '2009-Feb-02'),
+                  (3307, '2009-Jan-20'),
+                  (3273, '2008-Dec-17'),
+                  (3259, '2008-Dec-03'),
+                  (3226, '2008-Oct-31'),
+                  (3181, '2008-Sep-16'),
+                  (3170, '2008-Sep-05'),
+                  (3091, '2008-Jun-18'),
+                  (3079, '2008-Jun-06'),
+                  (3057, '2008-May-15'),
+                  (3044, '2008-May-02'),
+                  (3009, '2008-Mar-28'),
+                  (2991, '2008-Mar-10'),
+                  (2946, '2008-Jan-25'),
+                  (2943, '2008-Jan-22'),
+                  (2887, '2007-Nov-27'),
+                  (2847, '2007-Oct-18'),
+                  (2791, '2007 August 23'),
+                  (2767, '2007 July 30'),
+                  (2746, '2007 July 9'),
+                  (2732, '2007 June 25'),
+                  (2732, '2007-JUN-25'),
+                  (2713, '2007 June 06'),
+                  (2693, '2007 May 17'),
+                  (2684, '2007 May 8'),
+                  (2677, '2007 May 1'),
+                  (2651, '2007 Apr. 5'),
+                  (2627, '2007 Mar. 12'),
+                  (2601, '2007 Feb. 14'),
+                  (2597, '2007 Feb. 10'),
+                  (2582, '2007 Jan. 26'),
+                  (2582, '2007 Jan. 26'),
+                  (2573, '2007 Jan. 17'),
+                  (2566, '2007 Jan. 10'),
+                  (2539, '2006 Dec. 14'),
+                  (2526, '2006 Dec. 01'),
+                  (2511, '2006 Nov. 16'),
+                  (2503, '2006 Nov. 08'),
+                  (2480, '2006 Oct. 16'),
+                  (2460, '2006 Sep. 26'),
+                  (2441, '2006 Sep. 07'),
+                  (2414, '2006 AUG 11'),
+                  (2392, '2006 July 20'),
+                  (2356, '2006 June 14'),
+                  (2326, '2006 MAY 15'),
+                  (2299, '2006 Apr 18'),
+                  (2271, '2006 Mar 21'),
+                  (2265, '2006 Mar 15'),
+                  (2236, '2006 Feb 14'),
+                  (1201, '16-Apr-2003'),
+                  (2203, '2006 Jan 12'),
+                  (2173, '2005 Dec 13'),
+                  (2145, '2005 Nov 15'),
+                  (2120, '2005 Oct 21'),
+                  (2110, '2005 Oct 11'),
+                  (2092, '2005 Sep 23'),
+                  (2077, '2005 Sep 08'),
+                  (2064, '2005 Aug 26'),
+                  (2040, '2005 Aug 02'),
+                  (2018, '2005 Jul 11'),
+                  (2012, '2005 Jul 05'),
+                  (1986, '2005 Jun 09'),
+                  (1965, '2005 May 19'),
+                  (1951, '2005 May 05'),
+                  (1945, '2005 Apr 29'),
+                  (1937, '2005 Apr 21'),
+                  (1928, '2005 Apr 12'),
+                  (1886, '2005 Mar 01'),
+                  (1885, '2005 Feb 28'),
+                  (1836, '2005 Jan 10'),
+                  (1804, '2004 Dec 9'),
+                  (1836, '2005 Jan 10'),
+                  (1804, '2004 Dec 9'),
+                  (1733, '2004 Sep 29'),
+                  (1633, '2004 Jun 21'),
+                  (1628, '16 June 2004'),
+                  (1586, '2004 May 05'),
+                  (3897, '2010-SEP-02'),
+                  (3897, '2010 Sep 02'),
+                  (3028, '2008 Apr 16'),
+                  (1804, '2004 Dec 09'),
+                  (1748, '2004 Oct 14'),
+                  (1633, '2004 Jun 21'),
+                  (1628, '16 June 2004'),
+                  (1525, '2004 Mar 05'),
+                  (1490, '1/30/2004'),
+                  (1496, '2/5/2004'),
+                  (1424, '25 Nov 2003'),
+                  (1004, '2002 Oct 01'),
+                  (0, '1/1/2000'),
+                  (-1437, '25 January 1996'),
+                  (-80, '13 Oct 1999'),
+                  (1490, '1/30/2004'),
+                  (1496, '2/5/2004'),
+                  (1628, '16 June 2004'),
+                  (1726, '2004 September 22')]
 
-        PCK_ANSWER = [(6571, '2017-12-28'),
-                      (6558, '2017-DEC-15'),
-                      (6558, '2017-Dec-15'),
-                      (6513, '2017-Oct-31'),
-                      (6512, '2017-Oct-30'),
-                      (6503, '2017-Oct-21'),
-                      (6435, '2017-Aug-14'),
-                      (6415, '2017-Jul-25'),
-                      (6338, '2017-May-09'),
-                      (6295, '2017-Mar-27'),
-                      (6288, '2017-Mar-20'),
-                      (6269, '2017-Mar-01'),
-                      (6268, '2017-Feb-28'),
-                      (6193, '2016-Dec-15'),
-                      (6190, '2016-Dec-12'),
-                      (6165, '2016-Nov-17'),
-                      (6082, '2016-Aug-26'),
-                      (6045, '2016-Jul-20'),
-                      (6003, '2016-Jun-08'),
-                      (5984, '2016-May-20'),
-                      (5947, '2016-Apr-13'),
-                      (5933, '2016-Mar-30'),
-                      (5927, '2016-Mar-24'),
-                      (5872, '2016-Jan-29'),
-                      (5798, '2015-Nov-16'),
-                      (5795, '2015-Nov-13'),
-                      (5784, '2015-Nov-02'),
-                      (5765, '2015-Oct-14'),
-                      (5764, '2015-Oct-13'),
-                      (5763, '2015-Oct-12'),
-                      (5718, '2015-Aug-28'),
-                      (5693, '2015-Aug-03'),
-                      (5639, '2015-Jun-10'),
-                      (5541, '2015-Mar-04'),
-                      (5500, '2015-Jan-22'),
-                      (5486, '2015-Jan-08'),
-                      (5429, '2014-Nov-12'),
-                      (5365, '2014-Sep-09'),
-                      (5364, '2014-Sep-08'),
-                      (5324, '2014-Jul-30'),
-                      (5219, '2014-Apr-16'),
-                      (5057, '2013-Nov-05'),
-                      (5045, '2013-Oct-24'),
-                      (4967, '2013-Aug-07'),
-                      (4966, '2013-Aug-06'),
-                      (4939, '2013-Jul-10'),
-                      (4855, '2013-Apr-17'),
-                      (4828, '2013-Mar-21'),
-                      (4826, '2013-Mar-19'),
-                      (4825, '2013-Mar-18'),
-                      (4758, '2013-Jan-10'),
-                      (4724, '2012-Dec-07'),
-                      (4718, '2012-Dec-01'),
-                      (4625, '2012-Aug-30'),
-                      (4563, '2012-Jun-29'),
-                      (4526, '2012-May-23'),
-                      (4499, '2012-Apr-26'),
-                      (4491, '2012-Apr-18'),
-                      (4441, '2012-Feb-28'),
-                      (4401, '2012-Jan-19'),
-                      (4399, '2012-Jan-17'),
-                      (4304, '2011-Oct-14'),
-                      (4300, '2011-Oct-10'),
-                      (4239, '2011-Aug-10'),
-                      (4157, '2011-May-20'),
-                      (4052, '2011-Feb-04'),
-                      (4036, '2011-Jan-19'),
-                      (4003, '2010-Dec-17'),
-                      (3939, '2010-Oct-14'),
-                      (3908, '2010-Sep-13'),
-                      (3860, '2010-Jul-27'),
-                      (3839, '2010-Jul-06'),
-                      (3828, '2010-Jun-25'),
-                      (3819, '2010-Jun-16'),
-                      (3762, '2010-Apr-20'),
-                      (3736, '2010-Mar-25'),
-                      (3693, '2010-Feb-10'),
-                      (3666, '2010-Jan-14'),
-                      (3665, '2010-Jan-13'),
-                      (3659, '2010-Jan-07'),
-                      (3630, '2009-Dec-09'),
-                      (3609, '2009-Nov-18'),
-                      (3567, '2009-Oct-07'),
-                      (3554, '2009-Sep-24'),
-                      (3552, '2009-Sep-22'),
-                      (3516, '2009-Aug-17'),
-                      (3505, '2009-Aug-06'),
-                      (3476, '2009-Jul-08'),
-                      (3469, '2009-Jul-01'),
-                      (3462, '2009-Jun-24'),
-                      (3449, '2009-Jun-11'),
-                      (3428, '2009-May-21'),
-                      (3414, '2009-May-07'),
-                      (3400, '2009-Apr-23'),
-                      (3344, '2009-Feb-26'),
-                      (3320, '2009-Feb-02'),
-                      (3307, '2009-Jan-20'),
-                      (3273, '2008-Dec-17'),
-                      (3259, '2008-Dec-03'),
-                      (3226, '2008-Oct-31'),
-                      (3181, '2008-Sep-16'),
-                      (3170, '2008-Sep-05'),
-                      (3091, '2008-Jun-18'),
-                      (3079, '2008-Jun-06'),
-                      (3057, '2008-May-15'),
-                      (3044, '2008-May-02'),
-                      (3009, '2008-Mar-28'),
-                      (2991, '2008-Mar-10'),
-                      (2946, '2008-Jan-25'),
-                      (2943, '2008-Jan-22'),
-                      (2887, '2007-Nov-27'),
-                      (2847, '2007-Oct-18'),
-                      (2791, '2007 August 23'),
-                      (2767, '2007 July 30'),
-                      (2746, '2007 July 9'),
-                      (2732, '2007 June 25'),
-                      (2732, '2007-JUN-25'),
-                      (2713, '2007 June 06'),
-                      (2693, '2007 May 17'),
-                      (2684, '2007 May 8'),
-                      (2677, '2007 May 1'),
-                      (2651, '2007 Apr. 5'),
-                      (2627, '2007 Mar. 12'),
-                      (2601, '2007 Feb. 14'),
-                      (2597, '2007 Feb. 10'),
-                      (2582, '2007 Jan. 26'),
-                      (2582, '2007 Jan. 26'),
-                      (2573, '2007 Jan. 17'),
-                      (2566, '2007 Jan. 10'),
-                      (2539, '2006 Dec. 14'),
-                      (2526, '2006 Dec. 01'),
-                      (2511, '2006 Nov. 16'),
-                      (2503, '2006 Nov. 08'),
-                      (2480, '2006 Oct. 16'),
-                      (2460, '2006 Sep. 26'),
-                      (2441, '2006 Sep. 07'),
-                      (2414, '2006 AUG 11'),
-                      (2392, '2006 July 20'),
-                      (2356, '2006 June 14'),
-                      (2326, '2006 MAY 15'),
-                      (2299, '2006 Apr 18'),
-                      (2271, '2006 Mar 21'),
-                      (2265, '2006 Mar 15'),
-                      (2236, '2006 Feb 14'),
-                      (1201, '16-Apr-2003'),
-                      (2203, '2006 Jan 12'),
-                      (2173, '2005 Dec 13'),
-                      (2145, '2005 Nov 15'),
-                      (2120, '2005 Oct 21'),
-                      (2110, '2005 Oct 11'),
-                      (2092, '2005 Sep 23'),
-                      (2077, '2005 Sep 08'),
-                      (2064, '2005 Aug 26'),
-                      (2040, '2005 Aug 02'),
-                      (2018, '2005 Jul 11'),
-                      (2012, '2005 Jul 05'),
-                      (1986, '2005 Jun 09'),
-                      (1965, '2005 May 19'),
-                      (1951, '2005 May 05'),
-                      (1945, '2005 Apr 29'),
-                      (1937, '2005 Apr 21'),
-                      (1928, '2005 Apr 12'),
-                      (1886, '2005 Mar 01'),
-                      (1885, '2005 Feb 28'),
-                      (1836, '2005 Jan 10'),
-                      (1804, '2004 Dec 9'),
-                      (1836, '2005 Jan 10'),
-                      (1804, '2004 Dec 9'),
-                      (1733, '2004 Sep 29'),
-                      (1633, '2004 Jun 21'),
-                      (1628, '16 June 2004'),
-                      (1586, '2004 May 05'),
-                      (3897, '2010-SEP-02'),
-                      (3897, '2010 Sep 02'),
-                      (3028, '2008 Apr 16'),
-                      (1804, '2004 Dec 09'),
-                      (1748, '2004 Oct 14'),
-                      (1633, '2004 Jun 21'),
-                      (1628, '16 June 2004'),
-                      (1525, '2004 Mar 05'),
-                      (1490, '1/30/2004'),
-                      (1496, '2/5/2004'),
-                      (1424, '25 Nov 2003'),
-                      (1004, '2002 Oct 01'),
-                      (0, '1/1/2000'),
-                      (-1437, '25 January 1996'),
-                      (-80, '13 Oct 1999'),
-                      (1490, '1/30/2004'),
-                      (1496, '2/5/2004'),
-                      (1628, '16 June 2004'),
-                      (1726, '2004 September 22')]
-
-        self.assertEqual(days_in_strings(strings, substrings=True), PCK_ANSWER)
+    assert days_in_strings(strings, substrings=True) == PCK_ANSWER
 
 ##########################################################################################

--- a/tests/test_date_pyparser.py
+++ b/tests/test_date_pyparser.py
@@ -3,997 +3,958 @@
 ##########################################################################################
 
 import numbers
-import unittest
-import warnings
 
+import pytest
 from pyparsing import ParseException, StringEnd
 
 from julian.date_pyparser import date_pyparser
-
-
-class Test_date_pyparser(unittest.TestCase):
-
-    def _confirm_failure(self, parser, test, msg):
-
-        try:
-            pairs = parser.parse_string(test).as_list()
-
-        except ParseException:                      # correct exception; proceed
-            self.assertRaises(ParseException, parser.parse_string, test)
-
-        except Exception as e:  # pragma: no cover  # wrong exception; warn and proceed
-            warnings.warn(msg + f'; Incorrect exception {type(e)}: {e}')
-            self.assertRaises(Exception, parser.parse_string, test)
-
-        else:
-            # It could be that the reason this was not an exception is that a partial
-            # match did succeed. This is a valid outcome.
-            parse_dict = {pair[0]:pair[1] for pair in pairs}
-            msg += f'; {parse_dict}'    # add diagnostic info to the message
-            remainder = test[parse_dict['~']:].lstrip()
-            self.assertNotIn(remainder, ('', 'xxx'), msg=msg)
-
-    def _confirm_success(self, parser, test, msg, values=[]):
-
-        error = None
-        try:
-            pairs = parser.parse_string(test).as_list()
-        except Exception as e:  # pragma: no cover
-            error = e
-
-        # Print the error info and then the message
-        self.assertIsNone(error, msg)
-
-        parse_dict = {pair[0]:pair[1] for pair in pairs}
-        msg += f'; {parse_dict}'
-
-        for name, value in values:
-            self.assertIn(name, parse_dict, msg=msg)
-            self.assertEqual(parse_dict[name], value, msg=msg)
-
-        remainder = test[parse_dict['~']:].lstrip()
-        self.assertIn(remainder, ('', 'xxx'), msg=msg)
-
-        return parse_dict
-
-    ####################################################################
-    # year
-    ####################################################################
-
-    def test_year(self):
-
-        from julian.date_pyparser import year, year_strict
-
-        ################################
-        # year_strict
-        ################################
-
-        p = year_strict
-
-        # Success
-        self.assertEqual(p.parse_string('1000')[0][0], 'YEAR')
-        self.assertEqual(p.parse_string('1000')[0][1], 1000)
-        self.assertEqual(p.parse_string('2000')[0][1], 2000)
-        self.assertEqual(p.parse_string('2000a ')[0][1], 2000)
-        self.assertEqual(p.parse_string('20000 ')[0][1], 2000)
-        self.assertEqual(p.parse_string('17760704')[0][1], 1776)
-
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, '50')
-        self.assertRaises(ParseException, p.parse_string, '3000')
-        self.assertRaises(ParseException, p.parse_string, '0300')
-        self.assertRaises(ParseException, p.parse_string, ' 2000')
-        self.assertRaises(ParseException, p.parse_string, '   00')
-        self.assertRaises(ParseException, p.parse_string, ' ')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
-
-        ################################
-        # year
-        ################################
-
-        p = year
-
-        # Success
-        self.assertEqual(p.parse_string('1000')[0][0], 'YEAR')
-        self.assertEqual(p.parse_string('1000')[0][1], 1000)
-        self.assertEqual(p.parse_string('2000')[0][1], 2000)
-        self.assertEqual(p.parse_string('00')[0][1],   2000)
-        self.assertEqual(p.parse_string('50')[0][1],   1950)
-        self.assertEqual(p.parse_string('49')[0][1],   2049)
-        self.assertEqual(p.parse_string('2000a ')[0][1], 2000)
-        self.assertEqual(p.parse_string('20000 ')[0][1], 2000)
-        self.assertEqual(p.parse_string('17760704')[0][1], 1776)
-        self.assertEqual(p.parse_string('3000')[0][1], 3000)
-        self.assertEqual(p.parse_string('0300')[0][1],  300)
-        self.assertEqual(p.parse_string('0000')[0][1],    0)
-        self.assertEqual(p.parse_string('100')[0][1],  2010)
-
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, ' 300')
-        self.assertRaises(ParseException, p.parse_string, '  30')
-        self.assertRaises(ParseException, p.parse_string, ' 2000')
-        self.assertRaises(ParseException, p.parse_string, ' ')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-
-    ####################################################################
-    # month
-    ####################################################################
-
-    def test_month(self):
-
-        from julian.date_pyparser import month_2digit, numeric_month, month, month_strict
-
-        NAMES = ['JANUARY', 'FEBRUARY', 'MARCH', 'APRIL','MAY', 'JUNE',
-                 'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER']
-
-        ################################
-        # month_2digit
-        ################################
-
-        p = month_2digit + StringEnd()
-
-        self.assertEqual(p.parse_string('01').as_list()[0][0], 'MONTH')
-
-        # Success
-        for m in range(1, 13):
-            tests = ['%02d' % m]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], m)
-
-        # Failure
-        for m in range(1, 9):
-            tests = [str(m), ' ' + str(m), '0' + str(m) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for m in range(10, 13):
-            tests = [' ' + str(m), '0' + str(m), str(m) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, ' 0')
-        self.assertRaises(ParseException, p.parse_string, '13')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, ' 01')
-        self.assertRaises(ParseException, p.parse_string, '001')
-
-        ################################
-        # numeric_month
-        ################################
-
-        p = numeric_month
-        pp = p + StringEnd()
-
-        self.assertEqual(p.parse_string('01').as_list()[0][0], 'MONTH')
-
-        # Success
-        for m in range(1, 13):
-            tests = [str(m), '%2d' % m, '%02d' % m, str(m) + 'x', '%2dx' % m, '%02dx' % m]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], m)
-
-        # Failure
-        for m in range(1, 9):
-            tests = [' ' + str(m) + '1', '0' + str(m) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, pp.parse_string, test)
-
-        self.assertRaises(ParseException, pp.parse_string, '0')
-        self.assertRaises(ParseException, pp.parse_string, ' 0')
-        self.assertRaises(ParseException, pp.parse_string, '13')
-        self.assertRaises(ParseException, pp.parse_string, '00')
-        self.assertRaises(ParseException, pp.parse_string, ' 01')
-        self.assertRaises(ParseException, pp.parse_string, '001')
-
-        ################################
-        # month
-        ################################
-
-        p = month
-        pp = p + StringEnd()
-
-        self.assertEqual(p.parse_string('JAN').as_list()[0][0], 'MONTH')
-
-        # Success
-        for m in range(1, 13):
-            tests = [str(m), '%2d'%m, '%02d'%m, str(m) + 'x', '%2dx'%m, '%02dx'%m,
-                     NAMES[m-1], NAMES[m-1].lower(), NAMES[m-1].capitalize(),
-                     NAMES[m-1][:3], NAMES[m-1][:3].capitalize(),
-                     NAMES[m-1][:3] + '.', NAMES[m-1][:3].capitalize() + '.',
-                     NAMES[m-1] + ',', NAMES[m-1][:3] + '.x', NAMES[m-1][:3] + '.1']
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], m)
-
-        # Failure
-        for m in range(1, 9):
-            tests = [' ' + str(m) + '1', '0' + str(m) + '1',
-                     NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
-            for test in tests:
-                self.assertRaises(ParseException, pp.parse_string, test)
-
-        self.assertRaises(ParseException, pp.parse_string, 'xxx')
-        self.assertRaises(ParseException, pp.parse_string, 'JANU')
-        self.assertRaises(ParseException, pp.parse_string, ' 0')
-        self.assertRaises(ParseException, pp.parse_string, '13')
-        self.assertRaises(ParseException, pp.parse_string, '00')
-        self.assertRaises(ParseException, pp.parse_string, ' 01')
-        self.assertRaises(ParseException, pp.parse_string, '001')
-
-        ################################
-        # month_strict
-        ################################
-
-        p = month_strict
-
-        self.assertEqual(p.parse_string('JAN').as_list()[0][0], 'MONTH')
-
-        # Success
-        for m in range(1, 13):
-            tests = [NAMES[m-1], NAMES[m-1].lower(), NAMES[m-1].capitalize(),
-                     NAMES[m-1][:3], NAMES[m-1][:3].capitalize(),
-                     NAMES[m-1][:3] + '.', NAMES[m-1][:3].capitalize() + '.',
-                     NAMES[m-1] + ',', NAMES[m-1][:3] + '.x', NAMES[m-1][:3] + '.1']
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], m)
-
-        # Failure
-        for m in range(1, 9):
-            tests = [str(m), '%2d'%m, '%02d'%m, str(m) + 'x', '%2dx'%m, '%02dx'%m,
-                     ' ' + str(m) + '1', '0' + str(m) + '1',
-                     NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, 'xxx')
-        self.assertRaises(ParseException, p.parse_string, 'JANU')
-        self.assertRaises(ParseException, p.parse_string, ' 0')
-        self.assertRaises(ParseException, p.parse_string, '13')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, ' 01')
-        self.assertRaises(ParseException, p.parse_string, '001')
-
-    ####################################################################
-    # date
-    ####################################################################
-
-    def test_date(self):
-
-        from julian.date_pyparser import date, date_2digit, date_float
-
-        ################################
-        # date_2digit
-        ################################
-
-        p = date_2digit
-
-        self.assertEqual(p.parse_string('01').as_list()[0][0], 'DAY')
-
-        # Success
-        for d in range(1, 32):
-            tests = ['%02d' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-        # Failure
-        for d in range(1, 9):
-            tests = [str(d), ' ' + str(d), '0' + str(d) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(10, 32):
-            tests = [' ' + str(d), '0' + str(d), str(d) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, ' 0')
-        self.assertRaises(ParseException, p.parse_string, '32')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, ' 01')
-        self.assertRaises(ParseException, p.parse_string, '001')
-
-        ################################
-        # date
-        ################################
-
-        p = date
-
-        self.assertEqual(p.parse_string('01').as_list()[0][0], 'DAY')
-
-        # Success
-        for d in range(1, 32):
-            tests = [str(d), '%2d' % d, '%02d' % d, str(d) + 'a', '%2dx' % d, '%02dx' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-        # Failure
-        for d in range(1, 9):
-            tests = [' ' + str(d) + '1', '0' + str(d) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(10, 32):
-            tests = [str(d) + '1', '0' + str(d) + '1']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, ' 0')
-        self.assertRaises(ParseException, p.parse_string, '32')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, ' 01')
-        self.assertRaises(ParseException, p.parse_string, '001')
-
-        ################################
-        # date_float
-        ################################
-
-        p = date_float
-
-        self.assertEqual(p.parse_string('01.').as_list()[0][0], 'DAY')
-        self.assertFalse(isinstance(p.parse_string('01.').as_list()[0][1],
-                                    numbers.Integral))
-
-        # Success
-        for d in range(1, 32):
-            tests = [str(d) + '.', '%2d.' % d, '%02d.' % d, '%2d.x' % d, '%02d.x' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-            tests = [str(d)+'.5', '%2d.5' % d, '%02d.5' % d, '%2d.5x' % d, '%02d.5x' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d + 0.5)
-
-        # Failure
-        for d in range(1, 9):
-            tests = [' ' + str(d) + '1.', ' ' + str(d) + '1.', '0' + str(d) + '1.']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(10, 32):
-            tests = [str(d) + '1.', '0' + str(d) + '1.']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '0.')
-        self.assertRaises(ParseException, p.parse_string, ' 0.')
-        self.assertRaises(ParseException, p.parse_string, '32.')
-        self.assertRaises(ParseException, p.parse_string, '00.')
-        self.assertRaises(ParseException, p.parse_string, ' 01.')
-        self.assertRaises(ParseException, p.parse_string, '001.')
-
-    ####################################################################
-    # doy
-    ####################################################################
-
-    def test_doy(self):
-
-        from julian.date_pyparser import doy, doy_3digit, doy_float, doy_3digit_float
-
-        ################################
-        # doy_3digit
-        ################################
-
-        p = doy_3digit
-
-        self.assertEqual(p.parse_string('001').as_list()[0][0], 'DAY')
-
-        # Success
-        for d in range(1, 367):
-            tests = ['%03d' % d, '%03dx' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-        # Failure
-        for d in range(1, 100):
-            tests = [str(d), '%2d'%d, '%3d'%d, '%02d'%d]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(100, 367):
-            tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '000')
-        self.assertRaises(ParseException, p.parse_string, '367')
-
-        ################################
-        # doy_3digit_float
-        ################################
-
-        p = doy_3digit_float
-
-        self.assertEqual(p.parse_string('001.').as_list()[0][0], 'DAY')
-        self.assertFalse(isinstance(p.parse_string('001.').as_list()[0][1],
-                                    numbers.Integral))
-
-        # Success
-        for d in range(1, 367):
-            tests = ['%03d.' % d, '%03d.x' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-            tests = ['%03d.5' % d, '%03d.5x' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d + 0.5)
-
-        # Failure
-        for d in range(1, 100):
-            tests = [str(d) + '.', '%2d.'%d, '%3d.'%d, '%02d.'%d]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(100, 367):
-            tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '000.')
-        self.assertRaises(ParseException, p.parse_string, '367.')
-
-        ################################
-        # doy
-        ################################
-
-        p = doy
-
-        self.assertEqual(p.parse_string('001').as_list()[0][0], 'DAY')
-
-        # Success
-        for d in range(1, 367):
-            tests = [str(d), '%3d' % d, '%03d' % d, '%3dx' % d, '%03dx' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-        # Failure
-        for d in range(1, 10):
-            tests = ['%2d' % d, '%02d' % d]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(100, 367):
-            tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '000')
-        self.assertRaises(ParseException, p.parse_string, '367')
-
-        ################################
-        # doy_float
-        ################################
-
-        p = doy_float
-
-        self.assertEqual(p.parse_string('001.').as_list()[0][0], 'DAY')
-        self.assertFalse(isinstance(p.parse_string('001.').as_list()[0][1],
-                                    numbers.Integral))
-
-        # Success
-        for d in range(1, 367):
-            tests = [str(d) + '.', '%3d.' % d, '%03d.' % d, '%3d.x' % d, '%03d.x' % d]
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], d)
-
-        # Failure
-        for d in range(1, 10):
-            tests = ['%2d.' % d, '%02d.' % d]
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        for d in range(100, 367):
-            tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-        self.assertRaises(ParseException, p.parse_string, '000.')
-        self.assertRaises(ParseException, p.parse_string, '367.')
-
-    ####################################################################
-    # weekday
-    ####################################################################
-
-    def test_weekday(self):
-
-        from julian.date_pyparser import weekday
-
-        NAMES = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY',
-                 'SATURDAY']
-
-        p = weekday
-        self.assertEqual(p.parse_string('SuN').as_list()[0][0], 'WEEKDAY')
-
-        # Success
-        for name in NAMES:
-            tests = [name, name.lower(), name.capitalize(),
-                     name[:3], name[:3].capitalize(),
-                     name[:3] + '.', name[:3].capitalize() + '.',
-                     name + ',', name[:3] + '.x', name[:3] + '.1']
-            for test in tests:
-                self.assertEqual(p.parse_string(test).as_list()[0][1], name[:3])
-
-        # Failure
-        for name in NAMES:
-            tests = [' ' + name, name + 'x', name[:4], name[:3] + 'x']
-            for test in tests:
-                self.assertRaises(ParseException, p.parse_string, test)
-
-    ####################################################################
-    # ISO_DATE_PYPARSERS
-    ####################################################################
-
-    def test_ISO_DATE_PYPARSERS(self):
-
-        from julian.date_pyparser import ISO_DATE_PYPARSERS
-
-        for extended in (0,1):
-          for floating in (0,1):
-            for doy in (0,1):
-                self.my_iso_date_tester(ISO_DATE_PYPARSERS[extended,floating,doy],
-                                        doy=bool(doy), floating=bool(floating),
-                                        extended=bool(extended))
-
-    def my_iso_date_tester(self, parser, *, doy=False, floating=False, extended=False,
-                                 padding=False, embedded=False, failure=False):
-
-        # 0 = valid; invalid=5
-        YEARS = []
-        for y in (1900,1999,2000,2099,3000,9999,100,10,1,0):
-            YEARS.append((0, '%04d' % y, y))
-        for y in (0,49,50,99):
-            YEARS.append((0, '%02d' % y, 2000 + y - 100 * (y//50)))
-
-        if extended:
-            for ystr in ('+20001', '-20001', '+0010', '-0099'):
-                YEARS.append((1, ystr, int(ystr)))
-            YEARS.append((9, '+10', 10))
-
-        MONTHS = []
-        for m in (1,9,10,12):
-            MONTHS.append((0, '%02d' % m, m))
-        for m in (1,9):
-            MONTHS.append((5, '%2d' % m, m))
-        for m in (0,13):
-            MONTHS.append((5, '%02d' % m, m))
-
-        DATES = []
-        for d in (1,9,10,20,29,30,31):
-            DATES.append((0, '%02d' % d, d))
-        for d in (1,9):
-            DATES.append((5, '%2d' % d, d))
-        for d in (0,32,40):
-            DATES.append((5, '%02d' % d, d))
-
-        DOYS = []
-        for d in (1,9,10,99,100,200,300,359,360,366):
-            DOYS.append((0, '%03d' % d, d))
-            if d < 100:
-                DOYS.append((5, '%3d' % d, d))
-        for d in (0, 367, 370, 400):
+from tests._helpers import confirm_failure, confirm_success
+
+
+##########################################################################################
+# Helper test functions
+##########################################################################################
+
+def iso_date_tester(parser, *, doy=False, floating=False, extended=False,
+                    padding=False, embedded=False, failure=False):
+
+    YEARS = []
+    for y in (1900,1999,2000,2099,3000,9999,100,10,1,0):
+        YEARS.append((0, '%04d' % y, y))
+    for y in (0,49,50,99):
+        YEARS.append((0, '%02d' % y, 2000 + y - 100 * (y//50)))
+
+    if extended:
+        for ystr in ('+20001', '-20001', '+0010', '-0099'):
+            YEARS.append((1, ystr, int(ystr)))
+        YEARS.append((9, '+10', 10))
+
+    MONTHS = []
+    for m in (1,9,10,12):
+        MONTHS.append((0, '%02d' % m, m))
+    for m in (1,9):
+        MONTHS.append((5, '%2d' % m, m))
+    for m in (0,13):
+        MONTHS.append((5, '%02d' % m, m))
+
+    DATES = []
+    for d in (1,9,10,20,29,30,31):
+        DATES.append((0, '%02d' % d, d))
+    for d in (1,9):
+        DATES.append((5, '%2d' % d, d))
+    for d in (0,32,40):
+        DATES.append((5, '%02d' % d, d))
+
+    DOYS = []
+    for d in (1,9,10,99,100,200,300,359,360,366):
+        DOYS.append((0, '%03d' % d, d))
+        if d < 100:
             DOYS.append((5, '%3d' % d, d))
-        DOYS.append((5, '000', 0))
+    for d in (0, 367, 370, 400):
+        DOYS.append((5, '%3d' % d, d))
+    DOYS.append((5, '000', 0))
 
-        if floating:
-            saved = DATES.copy()
-            for dstat, dword, dval in saved:
-                DATES.append((dstat, dword + '.5', dval + 0.5))
+    if floating:
+        saved = DATES.copy()
+        for dstat, dword, dval in saved:
+            DATES.append((dstat, dword + '.5', dval + 0.5))
 
-            saved = DOYS.copy()
-            for dstat, dword, dval in saved:
-                DOYS.append((dstat, dword + '.5', dval + 0.5))
+        saved = DOYS.copy()
+        for dstat, dword, dval in saved:
+            DOYS.append((dstat, dword + '.5', dval + 0.5))
 
-        if padding:
-            before = '  '
-            after = '  '
-        else:
-            before = ''
-            after = ''
+    if padding:
+        before = '  '
+        after = '  '
+    else:
+        before = ''
+        after = ''
 
-        if embedded:
-            after = ' xxx'
+    if embedded:
+        after = ' xxx'
 
-        count = 0
-        for sep in ('-', ''):
-          for ystat, yword, yval in YEARS:
-            for mstat, mword, mval in MONTHS:
-              for dstat, dword, dval in DATES:
-                test = before + yword + sep + mword + sep + dword + after
-                status = ystat + mstat + dstat + (0 if sep else 1)
-                expect_failure = status > 1 or failure
+    count = 0
+    for sep in ('-', ''):
+      for ystat, yword, yval in YEARS:
+        for mstat, mword, mval in MONTHS:
+          for dstat, dword, dval in DATES:
+            test = before + yword + sep + mword + sep + dword + after
+            status = ystat + mstat + dstat + (0 if sep else 1)
+            expect_failure = status > 1 or failure
 
-                count += 1
-                msg = (f'**** ISO PYPARSER test {count} expected %s: "{test}"; '
-                       f'doy={doy}, floating={floating}, extended={extended}, '
-                       f'padding={padding}, embedded={embedded}')
+            count += 1
+            msg = (f'**** ISO PYPARSER test {count} expected %s: "{test}"; '
+                   f'doy={doy}, floating={floating}, extended={extended}, '
+                   f'padding={padding}, embedded={embedded}')
 
-                if expect_failure:
-                    self._confirm_failure(parser, test, msg=msg % 'FAILURE')
-                else:
-                    self._confirm_success(parser, test, msg=msg % 'SUCCESS',
-                                          values=[('YEAR', yval), ('MONTH', mval),
-                                                  ('DAY', dval)])
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg % 'FAILURE')
+            else:
+                confirm_success(parser, test, msg=msg % 'SUCCESS',
+                                values=[('YEAR', yval), ('MONTH', mval),
+                                        ('DAY', dval)])
 
-        if doy:
-          for sep in ('-', ''):
-            for ystat, yword, yval in YEARS:
-              for dstat, dword, dval in DOYS:
-                test = before + yword + sep + dword + after
-                status = ystat + dstat + (0 if sep else 1)
-                expect_failure = status > 1 or failure
-
-                count += 1
-                msg = (f'**** ISO PYPARSER test {count} expected %s: "{test}"; '
-                       f'doy={doy}, floating={floating}, extended={extended}, '
-                       f'padding={padding}, embedded={embedded}')
-
-                if expect_failure:
-                    self._confirm_failure(parser, test, msg=msg % 'FAILURE')
-                else:
-                    self._confirm_success(parser, test, msg=msg % 'SUCCESS',
-                                          values=[('YEAR', yval), ('DAY', dval)])
-
-    ####################################################################
-    # YD_PYPARSERS
-    ####################################################################
-
-    def test_YD_PYPARSERS(self):
-
-        from julian.date_pyparser import YD_PYPARSERS
-
-        self.my_yd_tester(YD_PYPARSERS[0,0,0], YD_PYPARSERS[0,0,1], floating=False)
-        self.my_yd_tester(YD_PYPARSERS[0,1,0], YD_PYPARSERS[0,1,1], floating=True)
-
-    def my_yd_tester(self, parser_loose, parser_strict, *, floating=False, extended=False,
-                           padding=False, embedded=False, failure=False):
-
-        # 0 = strict; 1 = loose; invalid=9
-        YEARS = []
-        for y in (1900,1999,2000,2099,3000,9999,100,10,1,0):
-            YEARS.append((2*(1 - int(1000 <= y <= 2999)), '%04d' % y, y))
-        for y in (0,49,50,99):
-            YEARS.append((2, '%02d' % y, 2000 + y - 100 * (y//50)))
-
-        if extended:
-            for ystr in ('+20001', '-20001', '+0010', '-0099'):
-                YEARS.append((1, ystr, int(ystr)))
-            YEARS.append((9, '+10', 10))
-
-        DOYS = []
-        for d in (1,9,10,99,100,200,300,359,360,366):
-            DOYS.append((0, '%03d' % d, d))
-            if d < 100:
-                DOYS.append((2, str(d), d))
-        for d in (0, 367, 370, 400):
-            DOYS.append((9, str(d), d))
-        DOYS.append((9, '000', 0))
-
-        PUNC = [(0, '/'), (2, ' '), (2, '.')]
-
-        if padding:
-            before = '  '
-            after = '  '
-        else:
-            before = ''
-            after = ''
-
-        if embedded:
-            after = ' xxx'
-
-        count = 0
+    if doy:
+      for sep in ('-', ''):
         for ystat, yword, yval in YEARS:
-          for pstat, pword in PUNC:
-            for dstat, dword, dval in DOYS:
-                test = before + yword + pword + dword + after
-                status = ystat + pstat + dstat
-                if len(test.split('.')) > 2:    # pragma: no cover
-                    status = 9
+          for dstat, dword, dval in DOYS:
+            test = before + yword + sep + dword + after
+            status = ystat + dstat + (0 if sep else 1)
+            expect_failure = status > 1 or failure
 
-                if status >= 9 or failure:
+            count += 1
+            msg = (f'**** ISO PYPARSER test {count} expected %s: "{test}"; '
+                   f'doy={doy}, floating={floating}, extended={extended}, '
+                   f'padding={padding}, embedded={embedded}')
+
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg % 'FAILURE')
+            else:
+                confirm_success(parser, test, msg=msg % 'SUCCESS',
+                                values=[('YEAR', yval), ('DAY', dval)])
+
+
+def yd_tester(parser_loose, parser_strict, *, floating=False, extended=False,
+              padding=False, embedded=False, failure=False):
+
+    YEARS = []
+    for y in (1900,1999,2000,2099,3000,9999,100,10,1,0):
+        YEARS.append((2*(1 - int(1000 <= y <= 2999)), '%04d' % y, y))
+    for y in (0,49,50,99):
+        YEARS.append((2, '%02d' % y, 2000 + y - 100 * (y//50)))
+
+    if extended:
+        for ystr in ('+20001', '-20001', '+0010', '-0099'):
+            YEARS.append((1, ystr, int(ystr)))
+        YEARS.append((9, '+10', 10))
+
+    DOYS = []
+    for d in (1,9,10,99,100,200,300,359,360,366):
+        DOYS.append((0, '%03d' % d, d))
+        if d < 100:
+            DOYS.append((2, str(d), d))
+    for d in (0, 367, 370, 400):
+        DOYS.append((9, str(d), d))
+    DOYS.append((9, '000', 0))
+
+    PUNC = [(0, '/'), (2, ' '), (2, '.')]
+
+    if padding:
+        before = '  '
+        after = '  '
+    else:
+        before = ''
+        after = ''
+
+    if embedded:
+        after = ' xxx'
+
+    count = 0
+    for ystat, yword, yval in YEARS:
+      for pstat, pword in PUNC:
+        for dstat, dword, dval in DOYS:
+            test = before + yword + pword + dword + after
+            status = ystat + pstat + dstat
+            if len(test.split('.')) > 2:    # pragma: no cover
+                status = 9
+
+            if status >= 9 or failure:
+                success_parsers = ()
+                failure_parsers = (parser_loose, parser_strict)
+            elif status <= 1:
+                success_parsers = (parser_loose, parser_strict)
+                failure_parsers = ()
+            else:
+                success_parsers = (parser_loose,)
+                failure_parsers = (parser_strict,)
+
+            msg = (f'**** YD PYPARSER test %d expected %s: "{test}"; '
+                   f'strict=%s, floating={floating}, '
+                   f'extended={extended}, '
+                   f'padding={padding}, embedded={embedded}')
+
+            for p in success_parsers:
+                count += 1
+                strict = 'True' if p is parser_strict else 'False'
+                confirm_success(p, test, msg=msg % (count, 'SUCCESS', strict),
+                                values=[('YEAR', yval), ('DAY', dval)])
+
+            for p in failure_parsers:
+                count += 1
+                strict = 'True' if p is parser_strict else 'False'
+                confirm_failure(p, test, msg=msg % (count, 'FAILURE', strict))
+
+    # Compressed
+    for case in [('2000001', 2000,   1),
+                 ('1999365', 1999, 365),
+                 ('0000001',    0,   1),
+                 (  '00001', 2000,   1),
+                 (  '50100', 1950, 100)]:
+        test, y, d = case
+        test = before + test + after
+        msg = 'Failure on ' + repr(test)
+        try:
+            pairs = parser_loose.parse_string(test).as_list()
+        except Exception as e:      # pragma: no cover
+            assert False, type(e).__name__ + ' on ' + repr(test) + ': ' + str(e)
+        else:
+            parse_dict = {pair[0]:pair[1] for pair in pairs}
+            assert parse_dict['YEAR'] == y, msg
+            assert parse_dict['DAY'] == d, msg
+
+
+def date_tester(parser_loose, parser_strict, order, *, weekdays=False,
+                floating=False, extended=False,
+                padding=False, embedded=False, failure=False,
+                _fmt_range=None, _skip_extras=False):
+    """Test date parsing with given parameters.
+
+    _fmt_range: if set, only test these format indices (0=YMD, 1=MDY, 2=DMY)
+    _skip_extras: if True, skip compressed and ordering tests
+    """
+
+    YEARS  = [(0, '2000', 2000), (0, '3000', 3000),
+              (0, '00', 2000), (0, '49', 2049), (0, '50', 1950),
+              (9, '300', 0)]
+
+    if extended:
+        YEARS += [('signed', '+20001', 20001), ('signed', '-0011', -11),
+                  ('suffix', '44 BC', -43), ('prefix', 'AD 10', 10)]
+
+    MONTHS = [(0, 'jan', 1), (0, 'DEC.', 12),
+              (0, '02', 2), (0, '12', 12), (0, '1' , 1)]
+
+    DATES  = [(0, '01', 1), (0, '31', 31), (0, '01.5', 1.5),
+              (0, '1', 1), (0, ' 1', 1), (0, '1.5', 1.5),
+              (9, '00', 0), (9, '32', 0)]
+
+    WEEKDAYS = ['', 'MON ', 'TUE. ', 'Thu,', 'fri.,']
+    if not weekdays:
+        WEEKDAYS = ['']
+
+    PUNC = {
+        False: [(0, '-'), (0, '/'), (0, '.'), (0, ' ')],
+        True:  [(0, '-'), (0, '/'), (5, '.'), (0, ' ')],
+    }
+
+    if padding:
+        before = '  '
+        after = '  '
+    else:
+        before = ''
+        after = ''
+
+    if embedded:
+        after = ' xxx'
+
+    count = 0
+    for ystat_, yword, yval in YEARS:
+      for mstat, mword, mval in MONTHS:
+        for dstat, dword, dval in DATES:
+          has_decimal = '.5' in dword
+          if has_decimal and not floating:
+            continue
+
+          all_fmts = [(0, f'{yword}%s{mword}%s{dword}'),
+                      (1, f'{mword}%s{dword}%s{yword}'),
+                      (2, f'{dword}%s{mword}%s{yword}')]
+
+          if _fmt_range is not None:
+              fmts = [all_fmts[i] for i in _fmt_range]
+          else:
+              fmts = all_fmts
+
+          for fk, fmt in fmts:
+            for pstat, punc in PUNC[has_decimal]:
+              test0 = fmt % (punc, punc)
+              if '..' in test0:
+                continue
+
+              if ystat_ == 'signed':
+                  ystat = 0 if fk == 0 or punc == ' ' else 9
+              elif ystat_ == 'suffix':
+                  ystat = 0 if fk > 0 else 9
+              elif ystat_ == 'prefix':
+                  ystat = 0 if fk > 0 and punc == ' ' else 9
+              else:
+                  ystat = ystat_
+
+              status = ystat + mstat + dstat + pstat
+
+              if punc == ' ' and mword.isnumeric():
+                status += 1
+
+              for weekday in WEEKDAYS:
+                if punc == '.' and '.' in dword:
+                    continue
+
+                test = before + weekday + test0 + after
+
+                if status > 4 or failure:
                     success_parsers = ()
                     failure_parsers = (parser_loose, parser_strict)
-                elif status <= 1:
+                elif status == 0:
                     success_parsers = (parser_loose, parser_strict)
                     failure_parsers = ()
                 else:
                     success_parsers = (parser_loose,)
                     failure_parsers = (parser_strict,)
 
-                msg = (f'**** YD PYPARSER test %d expected %s: "{test}"; '
-                       f'strict=%s, floating={floating}, '
-                       f'extended={extended}, '
-                       f'padding={padding}, embedded={embedded}')
-
                 for p in success_parsers:
                     count += 1
-                    strict = 'True' if p is parser_strict else 'False'
-                    self._confirm_success(p, test, msg=msg % (count, 'SUCCESS', strict),
-                                          values=[('YEAR', yval), ('DAY', dval)])
+                    msg = (f'**** {order} PYPARSER test {count} expected SUCCESS: '
+                           f'"{test}"; strict={p is parser_strict}, '
+                           f'weekdays={weekdays}, floating={floating}, '
+                           f'extended={extended}, '
+                           f'padding={padding}, embedded={embedded}')
+
+                    parse_dict = confirm_success(p, test, msg=msg,
+                                                 values=[('YEAR', yval)])
+                    if dval == 1 and mword in ('02', '12'):
+                        assert parse_dict['MONTH'] in (dval, mval), msg
+                        assert parse_dict['DAY'] in (dval, mval), msg
+                    else:
+                        assert parse_dict['MONTH'] == mval, msg
+                        assert parse_dict['DAY'] == dval, msg
 
                 for p in failure_parsers:
                     count += 1
-                    strict = 'True' if p is parser_strict else 'False'
-                    self._confirm_failure(p, test, msg=msg % (count, 'FAILURE', strict))
+                    msg = (f'**** {order} PYPARSER test {count} expected FAILURE: '
+                           f'"{test}"; strict={p is parser_strict}, '
+                           f'weekdays={weekdays}, floating={floating}, '
+                           f'extended={extended}, '
+                           f'padding={padding}, embedded={embedded}')
 
-        # Compressed
-        for case in [('2000001', 2000,   1),
-                     ('1999365', 1999, 365),
-                     ('0000001',    0,   1),
-                     (  '00001', 2000,   1),
-                     (  '50100', 1950, 100)]:
-            test, y, d = case
-            test = before + test + after
-            msg = 'Failure on ' + repr(test)
-            try:
-                pairs = parser_loose.parse_string(test).as_list()
-            except Exception as e:      # pragma: no cover
-                self.assertTrue(False, type(e).__name__ + ' on ' + repr(test) + ': '
-                                       + str(e))
-            else:
-                parse_dict = {pair[0]:pair[1] for pair in pairs}
-                self.assertEqual(parse_dict['YEAR'], y, msg)
-                self.assertEqual(parse_dict['DAY'], d, msg)
+                    confirm_failure(p, test, msg=msg)
 
-    ####################################################################
-    # DATE_PYPARSERS
-    ####################################################################
+    if _skip_extras:
+        return
 
-    def test_DATE_PYPARSERS(self):
-
-        from julian.date_pyparser import DATE_PYPARSERS
-
-        for key in ('YMD', 'MDY', 'DMY'):
-          for ext in (0,1):
-            for floating in (0,1):
-                self.my_date_tester(DATE_PYPARSERS[key][ext,floating,0] + StringEnd(),
-                                    DATE_PYPARSERS[key][ext,floating,1] + StringEnd(),
-                                    order=key, weekdays=False, floating=bool(floating),
-                                    extended=bool(ext))
-
-    def my_date_tester(self, parser_loose, parser_strict, order, *, weekdays=False,
-                             floating=False, extended=False,
-                             padding=False, embedded=False, failure=False):
-
-        # 0 = strict; 1 = loose; invalid=5
-        YEARS  = [(0, '2000', 2000), (0, '3000', 3000),
-                  (0, '00', 2000), (0, '49', 2049), (0, '50', 1950),
-                  (9, '300', 0)]
-
-        if extended:
-            YEARS += [('signed', '+20001', 20001), ('signed', '-0011', -11),
-                      ('suffix', '44 BC', -43), ('prefix', 'AD 10', 10)]
-
-        MONTHS = [(0, 'jan', 1), (0, 'DEC.', 12),
-                  (0, '02', 2), (0, '12', 12), (0, '1' , 1)]
-
-        DATES  = [(0, '01', 1), (0, '31', 31), (0, '01.5', 1.5),
-                  (0, '1', 1), (0, ' 1', 1), (0, '1.5', 1.5),
-                  (9, '00', 0), (9, '32', 0)]
-
-        WEEKDAYS = ['', 'MON ', 'TUE. ', 'Thu,', 'fri.,']
-        if not weekdays:
-            WEEKDAYS = ['']
-
-        PUNC = {        # index is floating = True or False
-            False: [(0, '-'), (0, '/'), (0, '.'), (0, ' ')],
-            True:  [(0, '-'), (0, '/'), (5, '.'), (0, ' ')],
-        }
-
-        if padding:
-            before = '  '
-            after = '  '
+    # Compressed
+    for case in [('20000101', 2000,  1,  1),
+                 ('19991231', 1999, 12, 31),
+                 ('00000101',    0,  1,  1),
+                 (  '000101', 2000,  1,  1),
+                 (  '500630', 1950,  6, 30)]:
+        test, y, m, d = case
+        test = before + test + after
+        try:
+            pairs = parser_loose.parse_string(test).as_list()
+        except Exception as e:      # pragma: no cover
+            assert False, type(e).__name__ + ' on ' + repr(test) + ': ' + str(e)
         else:
-            before = ''
-            after = ''
+            parse_dict = {pair[0]:pair[1] for pair in pairs}
+            assert parse_dict['YEAR'] == y
+            assert parse_dict['MONTH'] == m
+            assert parse_dict['DAY'] == d
 
-        if embedded:
-            after = ' xxx'
+    # Ordering
+    for case in [('YMD', '05/06/07', 2005, 6,  7),
+                 ('MDY', '05/06/07', 2007, 5,  6),
+                 ('DMY', '05/06/07', 2007, 6,  5),
+                 ('YMD', '05/13/07', 2007, 5, 13),
+                 ('MDY', '13/06/07', 2013, 6,  7),
+                 ('DMY', '05/13/07', 2007, 5, 13)]:
+        key, test, y, m, d = case
+        test = before + test + after
+        if key == order:
+            for p in (parser_loose, parser_strict):
+                try:
+                    pairs = p.parse_string(test).as_list()
+                except Exception as e:      # pragma: no cover
+                    assert False, (type(e).__name__ + ' on ' + repr(test)
+                                   + ': ' + str(e))
+                else:
+                    parse_dict = {pair[0]:pair[1] for pair in pairs}
+                    assert parse_dict['YEAR'] == y
+                    assert parse_dict['MONTH'] == m
+                    assert parse_dict['DAY'] == d
 
-        count = 0
-        for ystat_, yword, yval in YEARS:
-          for mstat, mword, mval in MONTHS:
-            for dstat, dword, dval in DATES:
-              has_decimal = '.5' in dword
-              if has_decimal and not floating:
-                continue
 
-              for fk, fmt in enumerate([f'{yword}%s{mword}%s{dword}',
-                                        f'{mword}%s{dword}%s{yword}',
-                                        f'{dword}%s{mword}%s{yword}']):
-                for pstat, punc in PUNC[has_decimal]:
-                  test0 = fmt % (punc, punc)
-                  if '..' in test0:
-                    continue
+def _make_date_parsers(order, doy, weekdays, floating):
+    parsers = []
+    for strict in (False, True):
+        parser = date_pyparser(order, strict=strict, doy=doy,
+                               weekdays=weekdays, floating=floating,
+                               extended=True, padding=True, embedded=True)
+        parsers.append(parser)
+    return parsers
 
-                  if ystat_ == 'signed':
-                      ystat = 0 if fk == 0 or punc == ' ' else 9
-                  elif ystat_ == 'suffix':
-                      ystat = 0 if fk > 0 else 9
-                  elif ystat_ == 'prefix':
-                      ystat = 0 if fk > 0 and punc == ' ' else 9
-                  else:
-                      ystat = ystat_
 
-                  status = ystat + mstat + dstat + pstat
+##########################################################################################
+# Simple unit tests
+##########################################################################################
 
-                  # Cases where the separator is white require a strict month
-                  if punc == ' ' and mword.isnumeric():
-                    status += 1
+def test_year():
 
-                  for weekday in WEEKDAYS:
-                    if punc == '.' and '.' in dword:
-                        continue                    # no period separators in floats
+    from julian.date_pyparser import year, year_strict
 
-                    test = before + weekday + test0 + after
+    ################################
+    # year_strict
+    ################################
 
-                    if status > 4 or failure:
-                        success_parsers = ()
-                        failure_parsers = (parser_loose, parser_strict)
-                    elif status == 0:
-                        success_parsers = (parser_loose, parser_strict)
-                        failure_parsers = ()
-                    else:
-                        success_parsers = (parser_loose,)
-                        failure_parsers = (parser_strict,)
+    p = year_strict
 
-                    for p in success_parsers:
-                        count += 1
-                        msg = (f'**** {order} PYPARSER test {count} expected SUCCESS: '
-                               f'"{test}"; strict={p is parser_strict}, '
-                               f'weekdays={weekdays}, floating={floating}, '
-                               f'extended={extended}, '
-                               f'padding={padding}, embedded={embedded}')
+    # Success
+    assert p.parse_string('1000')[0][0] == 'YEAR'
+    assert p.parse_string('1000')[0][1] == 1000
+    assert p.parse_string('2000')[0][1] == 2000
+    assert p.parse_string('2000a ')[0][1] == 2000
+    assert p.parse_string('20000 ')[0][1] == 2000
+    assert p.parse_string('17760704')[0][1] == 1776
 
-                        parse_dict = self._confirm_success(p, test, msg=msg,
-                                                           values=[('YEAR', yval)])
-                        if dval == 1 and mword in ('02', '12'):
-                            # Check ambiguous orders below
-                            self.assertIn(parse_dict['MONTH'], (dval, mval), msg=msg)
-                            self.assertIn(parse_dict['DAY'], (dval, mval), msg=msg)
-                        else:
-                            self.assertEqual(parse_dict['MONTH'], mval, msg=msg)
-                            self.assertEqual(parse_dict['DAY'], dval, msg=msg)
+    # Failure
+    with pytest.raises(ParseException): p.parse_string('00')
+    with pytest.raises(ParseException): p.parse_string('50')
+    with pytest.raises(ParseException): p.parse_string('3000')
+    with pytest.raises(ParseException): p.parse_string('0300')
+    with pytest.raises(ParseException): p.parse_string(' 2000')
+    with pytest.raises(ParseException): p.parse_string('   00')
+    with pytest.raises(ParseException): p.parse_string(' ')
+    with pytest.raises(ParseException): p.parse_string('a')
+    with pytest.raises(ParseException): p.parse_string('0')
+    with pytest.raises(ParseException): p.parse_string('000')
 
-                    for p in failure_parsers:
-                        count += 1
-                        msg = (f'**** {order} PYPARSER test {count} expected FAILURE: '
-                               f'"{test}"; strict={p is parser_strict}, '
-                               f'weekdays={weekdays}, floating={floating}, '
-                               f'extended={extended}, '
-                               f'padding={padding}, embedded={embedded}')
+    ################################
+    # year
+    ################################
 
-                        self._confirm_failure(p, test, msg=msg)
+    p = year
 
-        # Compressed
-        for case in [('20000101', 2000,  1,  1),
-                     ('19991231', 1999, 12, 31),
-                     ('00000101',    0,  1,  1),
-                     (  '000101', 2000,  1,  1),
-                     (  '500630', 1950,  6, 30)]:
-            test, y, m, d = case
-            test = before + test + after
-            try:
-                pairs = parser_loose.parse_string(test).as_list()
-            except Exception as e:      # pragma: no cover
-                self.assertTrue(False, type(e).__name__ + ' on ' + repr(test) + ': '
-                                       + str(e))
-            else:
-                parse_dict = {pair[0]:pair[1] for pair in pairs}
-                self.assertEqual(parse_dict['YEAR'], y)
-                self.assertEqual(parse_dict['MONTH'], m)
-                self.assertEqual(parse_dict['DAY'], d)
+    # Success
+    assert p.parse_string('1000')[0][0] == 'YEAR'
+    assert p.parse_string('1000')[0][1] == 1000
+    assert p.parse_string('2000')[0][1] == 2000
+    assert p.parse_string('00')[0][1] == 2000
+    assert p.parse_string('50')[0][1] == 1950
+    assert p.parse_string('49')[0][1] == 2049
+    assert p.parse_string('2000a ')[0][1] == 2000
+    assert p.parse_string('20000 ')[0][1] == 2000
+    assert p.parse_string('17760704')[0][1] == 1776
+    assert p.parse_string('3000')[0][1] == 3000
+    assert p.parse_string('0300')[0][1] == 300
+    assert p.parse_string('0000')[0][1] == 0
+    assert p.parse_string('100')[0][1] == 2010
 
-        # Ordering
-        for case in [('YMD', '05/06/07', 2005, 6,  7),
-                     ('MDY', '05/06/07', 2007, 5,  6),
-                     ('DMY', '05/06/07', 2007, 6,  5),
-                     ('YMD', '05/13/07', 2007, 5, 13),
-                     ('MDY', '13/06/07', 2013, 6,  7),
-                     ('DMY', '05/13/07', 2007, 5, 13)]:
-            key, test, y, m, d = case
-            test = before + test + after
-            if key == order:
-                for p in (parser_loose, parser_strict):
-                    try:
-                        pairs = p.parse_string(test).as_list()
-                    except Exception as e:      # pragma: no cover
-                        self.assertTrue(False, type(e).__name__ + ' on ' + repr(test)
-                                               + ': ' + str(e))
-                    else:
-                        parse_dict = {pair[0]:pair[1] for pair in pairs}
-                        self.assertEqual(parse_dict['YEAR'], y)
-                        self.assertEqual(parse_dict['MONTH'], m)
-                        self.assertEqual(parse_dict['DAY'], d)
+    # Failure
+    with pytest.raises(ParseException): p.parse_string(' 300')
+    with pytest.raises(ParseException): p.parse_string('  30')
+    with pytest.raises(ParseException): p.parse_string(' 2000')
+    with pytest.raises(ParseException): p.parse_string(' ')
+    with pytest.raises(ParseException): p.parse_string('a')
+    with pytest.raises(ParseException): p.parse_string('0')
 
-    ####################################################################
-    # date_pyparser function
-    ####################################################################
 
-    def test_date_pyparser_dates(self):
+def test_month():
 
-        for padding in (True,):
-          for embedded in (True,):
-            for floating in (False, True):
-              for order, doy in [('YMD', False), ('DMY', True)]:
-                                            # other combos tested by test_DATE_PYPARSERS
-                for weekdays in (False, True):
-                    parsers = []
-                    for strict in (False, True):
-                        parser = date_pyparser(order, strict=strict, doy=doy,
-                                               weekdays=weekdays, floating=floating,
-                                               extended=True,
-                                               padding=padding, embedded=embedded)
-                        parsers.append(parser)
+    from julian.date_pyparser import month_2digit, numeric_month, month, month_strict
 
-                    self.my_date_tester(parsers[0], parsers[1], order=order,
-                                        weekdays=weekdays, floating=floating,
-                                        extended=True,
-                                        padding=padding, embedded=embedded)
+    NAMES = ['JANUARY', 'FEBRUARY', 'MARCH', 'APRIL','MAY', 'JUNE',
+             'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER']
 
-                    if doy:
-                        self.my_yd_tester(parsers[0], parsers[1], floating=floating,
-                                          extended=True,
-                                          padding=padding, embedded=embedded)
+    ################################
+    # month_2digit
+    ################################
 
-        # Quick tests with padding != embedded
-        for padding in (True, False):
-            parser_loose = date_pyparser(order='YMD', strict=False, doy=False,
-                                         weekdays=False, floating=False,
-                                         padding=padding, embedded=(not padding))
-            parser_strict = date_pyparser(order='YMD', strict=True, doy=False,
-                                          weekdays=False, floating=False,
-                                          padding=padding, embedded=(not padding))
-            self.my_date_tester(parser_loose, parser_strict, order='YMD',
-                                weekdays=False, floating=False,
-                                padding=padding, embedded=(not padding))
+    p = month_2digit + StringEnd()
 
-            parser_loose = date_pyparser(order='YMD', strict=False, doy=True,
-                                         weekdays=False, floating=False,
-                                         padding=padding, embedded=(not padding))
-            parser_strict = date_pyparser(order='YMD', strict=True, doy=True,
-                                          weekdays=False, floating=False,
-                                          padding=padding, embedded=(not padding))
-            self.my_yd_tester(parser_loose, parser_strict,
-                              padding=padding, embedded=(not padding))
+    assert p.parse_string('01').as_list()[0][0] == 'MONTH'
 
-    def test_date_pyparser_mjd(self):
+    for m in range(1, 13):
+        tests = ['%02d' % m]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == m
 
-        from tests.test_mjd_pyparser import Test_mjd_pyparser
+    for m in range(1, 9):
+        tests = [str(m), ' ' + str(m), '0' + str(m) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
 
-        for padding in (True,):
-          for embedded in (True,):
-            for floating in (False, True):
-              parser = date_pyparser(mjd=True, floating=floating, padding=padding,
-                                     embedded=embedded)
-              Test_mjd_pyparser.my_mjd_tester(self, parser, floating=floating,
-                                              timesys=floating, padding=padding,
-                                              embedded=embedded)
+    for m in range(10, 13):
+        tests = [' ' + str(m), '0' + str(m), str(m) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
 
-    def test_date_pyparser_iso_only(self):
+    with pytest.raises(ParseException): p.parse_string('0')
+    with pytest.raises(ParseException): p.parse_string(' 0')
+    with pytest.raises(ParseException): p.parse_string('13')
+    with pytest.raises(ParseException): p.parse_string('00')
+    with pytest.raises(ParseException): p.parse_string(' 01')
+    with pytest.raises(ParseException): p.parse_string('001')
 
-        for padding in (True,):
-          for embedded in (True,):
-            for floating in (False, True):
-              for doy in (False, True):
-                for extended in (False, True):
-                    parser = date_pyparser(iso_only=True, doy=doy, floating=floating,
-                                           extended=extended,
-                                           padding=padding, embedded=embedded)
+    ################################
+    # numeric_month
+    ################################
 
-                    self.my_iso_date_tester(parser, doy=doy, floating=floating,
-                                            extended=extended,
-                                            padding=padding, embedded=embedded)
+    p = numeric_month
+    pp = p + StringEnd()
 
-############################################
-# Execute from command line...
-############################################
+    assert p.parse_string('01').as_list()[0][0] == 'MONTH'
 
-if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    for m in range(1, 13):
+        tests = [str(m), '%2d' % m, '%02d' % m, str(m) + 'x', '%2dx' % m, '%02dx' % m]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == m
+
+    for m in range(1, 9):
+        tests = [' ' + str(m) + '1', '0' + str(m) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): pp.parse_string(test)
+
+    with pytest.raises(ParseException): pp.parse_string('0')
+    with pytest.raises(ParseException): pp.parse_string(' 0')
+    with pytest.raises(ParseException): pp.parse_string('13')
+    with pytest.raises(ParseException): pp.parse_string('00')
+    with pytest.raises(ParseException): pp.parse_string(' 01')
+    with pytest.raises(ParseException): pp.parse_string('001')
+
+    ################################
+    # month
+    ################################
+
+    p = month
+    pp = p + StringEnd()
+
+    assert p.parse_string('JAN').as_list()[0][0] == 'MONTH'
+
+    for m in range(1, 13):
+        tests = [str(m), '%2d'%m, '%02d'%m, str(m) + 'x', '%2dx'%m, '%02dx'%m,
+                 NAMES[m-1], NAMES[m-1].lower(), NAMES[m-1].capitalize(),
+                 NAMES[m-1][:3], NAMES[m-1][:3].capitalize(),
+                 NAMES[m-1][:3] + '.', NAMES[m-1][:3].capitalize() + '.',
+                 NAMES[m-1] + ',', NAMES[m-1][:3] + '.x', NAMES[m-1][:3] + '.1']
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == m
+
+    for m in range(1, 9):
+        tests = [' ' + str(m) + '1', '0' + str(m) + '1',
+                 NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
+        for test in tests:
+            with pytest.raises(ParseException): pp.parse_string(test)
+
+    with pytest.raises(ParseException): pp.parse_string('xxx')
+    with pytest.raises(ParseException): pp.parse_string('JANU')
+    with pytest.raises(ParseException): pp.parse_string(' 0')
+    with pytest.raises(ParseException): pp.parse_string('13')
+    with pytest.raises(ParseException): pp.parse_string('00')
+    with pytest.raises(ParseException): pp.parse_string(' 01')
+    with pytest.raises(ParseException): pp.parse_string('001')
+
+    ################################
+    # month_strict
+    ################################
+
+    p = month_strict
+
+    assert p.parse_string('JAN').as_list()[0][0] == 'MONTH'
+
+    for m in range(1, 13):
+        tests = [NAMES[m-1], NAMES[m-1].lower(), NAMES[m-1].capitalize(),
+                 NAMES[m-1][:3], NAMES[m-1][:3].capitalize(),
+                 NAMES[m-1][:3] + '.', NAMES[m-1][:3].capitalize() + '.',
+                 NAMES[m-1] + ',', NAMES[m-1][:3] + '.x', NAMES[m-1][:3] + '.1']
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == m
+
+    for m in range(1, 9):
+        tests = [str(m), '%2d'%m, '%02d'%m, str(m) + 'x', '%2dx'%m, '%02dx'%m,
+                 ' ' + str(m) + '1', '0' + str(m) + '1',
+                 NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('xxx')
+    with pytest.raises(ParseException): p.parse_string('JANU')
+    with pytest.raises(ParseException): p.parse_string(' 0')
+    with pytest.raises(ParseException): p.parse_string('13')
+    with pytest.raises(ParseException): p.parse_string('00')
+    with pytest.raises(ParseException): p.parse_string(' 01')
+    with pytest.raises(ParseException): p.parse_string('001')
+
+
+def test_date():
+
+    from julian.date_pyparser import date, date_2digit, date_float
+
+    ################################
+    # date_2digit
+    ################################
+
+    p = date_2digit
+
+    assert p.parse_string('01').as_list()[0][0] == 'DAY'
+
+    for d in range(1, 32):
+        tests = ['%02d' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+    for d in range(1, 9):
+        tests = [str(d), ' ' + str(d), '0' + str(d) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(10, 32):
+        tests = [' ' + str(d), '0' + str(d), str(d) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('0')
+    with pytest.raises(ParseException): p.parse_string(' 0')
+    with pytest.raises(ParseException): p.parse_string('32')
+    with pytest.raises(ParseException): p.parse_string('00')
+    with pytest.raises(ParseException): p.parse_string(' 01')
+    with pytest.raises(ParseException): p.parse_string('001')
+
+    ################################
+    # date
+    ################################
+
+    p = date
+
+    assert p.parse_string('01').as_list()[0][0] == 'DAY'
+
+    for d in range(1, 32):
+        tests = [str(d), '%2d' % d, '%02d' % d, str(d) + 'a', '%2dx' % d, '%02dx' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+    for d in range(1, 9):
+        tests = [' ' + str(d) + '1', '0' + str(d) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(10, 32):
+        tests = [str(d) + '1', '0' + str(d) + '1']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('0')
+    with pytest.raises(ParseException): p.parse_string(' 0')
+    with pytest.raises(ParseException): p.parse_string('32')
+    with pytest.raises(ParseException): p.parse_string('00')
+    with pytest.raises(ParseException): p.parse_string(' 01')
+    with pytest.raises(ParseException): p.parse_string('001')
+
+    ################################
+    # date_float
+    ################################
+
+    p = date_float
+
+    assert p.parse_string('01.').as_list()[0][0] == 'DAY'
+    assert not isinstance(p.parse_string('01.').as_list()[0][1], numbers.Integral)
+
+    for d in range(1, 32):
+        tests = [str(d) + '.', '%2d.' % d, '%02d.' % d, '%2d.x' % d, '%02d.x' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+        tests = [str(d)+'.5', '%2d.5' % d, '%02d.5' % d, '%2d.5x' % d, '%02d.5x' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d + 0.5
+
+    for d in range(1, 9):
+        tests = [' ' + str(d) + '1.', ' ' + str(d) + '1.', '0' + str(d) + '1.']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(10, 32):
+        tests = [str(d) + '1.', '0' + str(d) + '1.']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('0.')
+    with pytest.raises(ParseException): p.parse_string(' 0.')
+    with pytest.raises(ParseException): p.parse_string('32.')
+    with pytest.raises(ParseException): p.parse_string('00.')
+    with pytest.raises(ParseException): p.parse_string(' 01.')
+    with pytest.raises(ParseException): p.parse_string('001.')
+
+
+def test_doy():
+
+    from julian.date_pyparser import doy, doy_3digit, doy_float, doy_3digit_float
+
+    ################################
+    # doy_3digit
+    ################################
+
+    p = doy_3digit
+
+    assert p.parse_string('001').as_list()[0][0] == 'DAY'
+
+    for d in range(1, 367):
+        tests = ['%03d' % d, '%03dx' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+    for d in range(1, 100):
+        tests = [str(d), '%2d'%d, '%3d'%d, '%02d'%d]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(100, 367):
+        tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('000')
+    with pytest.raises(ParseException): p.parse_string('367')
+
+    ################################
+    # doy_3digit_float
+    ################################
+
+    p = doy_3digit_float
+
+    assert p.parse_string('001.').as_list()[0][0] == 'DAY'
+    assert not isinstance(p.parse_string('001.').as_list()[0][1], numbers.Integral)
+
+    for d in range(1, 367):
+        tests = ['%03d.' % d, '%03d.x' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+        tests = ['%03d.5' % d, '%03d.5x' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d + 0.5
+
+    for d in range(1, 100):
+        tests = [str(d) + '.', '%2d.'%d, '%3d.'%d, '%02d.'%d]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(100, 367):
+        tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('000.')
+    with pytest.raises(ParseException): p.parse_string('367.')
+
+    ################################
+    # doy
+    ################################
+
+    p = doy
+
+    assert p.parse_string('001').as_list()[0][0] == 'DAY'
+
+    for d in range(1, 367):
+        tests = [str(d), '%3d' % d, '%03d' % d, '%3dx' % d, '%03dx' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+    for d in range(1, 10):
+        tests = ['%2d' % d, '%02d' % d]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(100, 367):
+        tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('000')
+    with pytest.raises(ParseException): p.parse_string('367')
+
+    ################################
+    # doy_float
+    ################################
+
+    p = doy_float
+
+    assert p.parse_string('001.').as_list()[0][0] == 'DAY'
+    assert not isinstance(p.parse_string('001.').as_list()[0][1], numbers.Integral)
+
+    for d in range(1, 367):
+        tests = [str(d) + '.', '%3d.' % d, '%03d.' % d, '%3d.x' % d, '%03d.x' % d]
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == d
+
+    for d in range(1, 10):
+        tests = ['%2d.' % d, '%02d.' % d]
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    for d in range(100, 367):
+        tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+    with pytest.raises(ParseException): p.parse_string('000.')
+    with pytest.raises(ParseException): p.parse_string('367.')
+
+
+def test_weekday():
+
+    from julian.date_pyparser import weekday
+
+    NAMES = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY',
+             'SATURDAY']
+
+    p = weekday
+    assert p.parse_string('SuN').as_list()[0][0] == 'WEEKDAY'
+
+    for name in NAMES:
+        tests = [name, name.lower(), name.capitalize(),
+                 name[:3], name[:3].capitalize(),
+                 name[:3] + '.', name[:3].capitalize() + '.',
+                 name + ',', name[:3] + '.x', name[:3] + '.1']
+        for test in tests:
+            assert p.parse_string(test).as_list()[0][1] == name[:3]
+
+    for name in NAMES:
+        tests = [' ' + name, name + 'x', name[:4], name[:3] + 'x']
+        for test in tests:
+            with pytest.raises(ParseException): p.parse_string(test)
+
+
+##########################################################################################
+# Parametrized tests for ISO_DATE_PYPARSERS
+##########################################################################################
+
+@pytest.mark.parametrize('extended,floating,doy_flag', [
+    (ext, flt, d)
+    for ext in (0, 1) for flt in (0, 1) for d in (0, 1)
+])
+def test_ISO_DATE_PYPARSERS(extended, floating, doy_flag):
+    from julian.date_pyparser import ISO_DATE_PYPARSERS
+    iso_date_tester(ISO_DATE_PYPARSERS[extended, floating, doy_flag],
+                    doy=bool(doy_flag), floating=bool(floating),
+                    extended=bool(extended))
+
+
+##########################################################################################
+# Parametrized tests for YD_PYPARSERS
+##########################################################################################
+
+@pytest.mark.parametrize('floating', [False, True])
+def test_YD_PYPARSERS(floating):
+    from julian.date_pyparser import YD_PYPARSERS
+    yd_tester(YD_PYPARSERS[0, int(floating), 0], YD_PYPARSERS[0, int(floating), 1],
+              floating=floating)
+
+
+##########################################################################################
+# Parametrized tests for DATE_PYPARSERS
+##########################################################################################
+
+@pytest.mark.parametrize('key,ext,floating', [
+    (k, e, f)
+    for k in ('YMD', 'MDY', 'DMY') for e in (0, 1) for f in (0, 1)
+])
+def test_DATE_PYPARSERS(key, ext, floating):
+    from julian.date_pyparser import DATE_PYPARSERS
+    date_tester(DATE_PYPARSERS[key][ext, floating, 0] + StringEnd(),
+                DATE_PYPARSERS[key][ext, floating, 1] + StringEnd(),
+                order=key, weekdays=False, floating=bool(floating),
+                extended=bool(ext))
+
+
+##########################################################################################
+# Parametrized tests for date_pyparser (main) - no weekdays
+##########################################################################################
+
+@pytest.mark.parametrize('floating,order,doy', [
+    (False, 'YMD', False), (False, 'DMY', True),
+    (True,  'YMD', False), (True,  'DMY', True),
+])
+def test_date_pyparser_dates(floating, order, doy):
+    parsers = _make_date_parsers(order, doy, weekdays=False, floating=floating)
+    date_tester(parsers[0], parsers[1], order=order,
+                weekdays=False, floating=floating,
+                extended=True, padding=True, embedded=True)
+    if doy:
+        yd_tester(parsers[0], parsers[1], floating=floating,
+                  extended=True, padding=True, embedded=True)
+
+
+##########################################################################################
+# Parametrized tests for date_pyparser (main) - with weekdays, split by fmt_idx
+##########################################################################################
+
+@pytest.mark.parametrize('floating,order,doy,fmt_idx', [
+    (fl, o, d, fi)
+    for fl in (False, True) for o, d in [('YMD', False), ('DMY', True)]
+    for fi in (0, 1, 2)
+])
+def test_date_pyparser_dates_weekdays(floating, order, doy, fmt_idx):
+    parsers = _make_date_parsers(order, doy, weekdays=True, floating=floating)
+    date_tester(parsers[0], parsers[1], order=order,
+                weekdays=True, floating=floating,
+                extended=True, padding=True, embedded=True,
+                _fmt_range=[fmt_idx], _skip_extras=True)
+
+
+@pytest.mark.parametrize('floating,order,doy', [
+    (fl, o, d)
+    for fl in (False, True) for o, d in [('YMD', False), ('DMY', True)]
+])
+def test_date_pyparser_dates_weekdays_extras(floating, order, doy):
+    parsers = _make_date_parsers(order, doy, weekdays=True, floating=floating)
+    date_tester(parsers[0], parsers[1], order=order,
+                weekdays=True, floating=floating,
+                extended=True, padding=True, embedded=True,
+                _fmt_range=[], _skip_extras=False)
+    if doy:
+        yd_tester(parsers[0], parsers[1], floating=floating,
+                  extended=True, padding=True, embedded=True)
+
+
+##########################################################################################
+# Parametrized tests for date_pyparser - quick tests (padding != embedded)
+##########################################################################################
+
+@pytest.mark.parametrize('padding', [True, False])
+def test_date_pyparser_dates_quick(padding):
+    parser_loose = date_pyparser(order='YMD', strict=False, doy=False,
+                                 weekdays=False, floating=False,
+                                 padding=padding, embedded=(not padding))
+    parser_strict = date_pyparser(order='YMD', strict=True, doy=False,
+                                  weekdays=False, floating=False,
+                                  padding=padding, embedded=(not padding))
+    date_tester(parser_loose, parser_strict, order='YMD',
+                weekdays=False, floating=False,
+                padding=padding, embedded=(not padding))
+
+    parser_loose = date_pyparser(order='YMD', strict=False, doy=True,
+                                 weekdays=False, floating=False,
+                                 padding=padding, embedded=(not padding))
+    parser_strict = date_pyparser(order='YMD', strict=True, doy=True,
+                                  weekdays=False, floating=False,
+                                  padding=padding, embedded=(not padding))
+    yd_tester(parser_loose, parser_strict,
+              padding=padding, embedded=(not padding))
+
+
+##########################################################################################
+# test_date_pyparser_mjd
+##########################################################################################
+
+@pytest.mark.parametrize('floating', [False, True])
+def test_date_pyparser_mjd(floating):
+    from tests.test_mjd_pyparser import mjd_tester
+
+    parser = date_pyparser(mjd=True, floating=floating, padding=True, embedded=True)
+    mjd_tester(parser, floating=floating, timesys=floating,
+               padding=True, embedded=True)
+
+
+##########################################################################################
+# Parametrized tests for date_pyparser iso_only
+##########################################################################################
+
+@pytest.mark.parametrize('floating,doy,extended', [
+    (fl, d, e)
+    for fl in (False, True) for d in (False, True) for e in (False, True)
+])
+def test_date_pyparser_iso_only(floating, doy, extended):
+    parser = date_pyparser(iso_only=True, doy=doy, floating=floating,
+                           extended=extended, padding=True, embedded=True)
+    iso_date_tester(parser, doy=doy, floating=floating,
+                    extended=extended, padding=True, embedded=True)
+
 
 ##########################################################################################

--- a/tests/test_date_pyparser.py
+++ b/tests/test_date_pyparser.py
@@ -655,7 +655,7 @@ def test_date():
             assert p.parse_string(test).as_list()[0][1] == d + 0.5
 
     for d in range(1, 9):
-        tests = [' ' + str(d) + '1.', ' ' + str(d) + '1.', '0' + str(d) + '1.']
+        tests = [' ' + str(d) + '1.', '0' + str(d) + '1.']
         for test in tests:
             with pytest.raises(ParseException): p.parse_string(test)
 

--- a/tests/test_date_pyparser.py
+++ b/tests/test_date_pyparser.py
@@ -404,16 +404,26 @@ def test_year():
     assert p.parse_string('17760704')[0][1] == 1776
 
     # Failure
-    with pytest.raises(ParseException): p.parse_string('00')
-    with pytest.raises(ParseException): p.parse_string('50')
-    with pytest.raises(ParseException): p.parse_string('3000')
-    with pytest.raises(ParseException): p.parse_string('0300')
-    with pytest.raises(ParseException): p.parse_string(' 2000')
-    with pytest.raises(ParseException): p.parse_string('   00')
-    with pytest.raises(ParseException): p.parse_string(' ')
-    with pytest.raises(ParseException): p.parse_string('a')
-    with pytest.raises(ParseException): p.parse_string('0')
-    with pytest.raises(ParseException): p.parse_string('000')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string('50')
+    with pytest.raises(ParseException):
+        p.parse_string('3000')
+    with pytest.raises(ParseException):
+        p.parse_string('0300')
+    with pytest.raises(ParseException):
+        p.parse_string(' 2000')
+    with pytest.raises(ParseException):
+        p.parse_string('   00')
+    with pytest.raises(ParseException):
+        p.parse_string(' ')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
     ################################
     # year
@@ -437,12 +447,18 @@ def test_year():
     assert p.parse_string('100')[0][1] == 2010
 
     # Failure
-    with pytest.raises(ParseException): p.parse_string(' 300')
-    with pytest.raises(ParseException): p.parse_string('  30')
-    with pytest.raises(ParseException): p.parse_string(' 2000')
-    with pytest.raises(ParseException): p.parse_string(' ')
-    with pytest.raises(ParseException): p.parse_string('a')
-    with pytest.raises(ParseException): p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string(' 300')
+    with pytest.raises(ParseException):
+        p.parse_string('  30')
+    with pytest.raises(ParseException):
+        p.parse_string(' 2000')
+    with pytest.raises(ParseException):
+        p.parse_string(' ')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
 
 
 def test_month():
@@ -468,19 +484,27 @@ def test_month():
     for m in range(1, 9):
         tests = [str(m), ' ' + str(m), '0' + str(m) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for m in range(10, 13):
         tests = [' ' + str(m), '0' + str(m), str(m) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('0')
-    with pytest.raises(ParseException): p.parse_string(' 0')
-    with pytest.raises(ParseException): p.parse_string('13')
-    with pytest.raises(ParseException): p.parse_string('00')
-    with pytest.raises(ParseException): p.parse_string(' 01')
-    with pytest.raises(ParseException): p.parse_string('001')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0')
+    with pytest.raises(ParseException):
+        p.parse_string('13')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string(' 01')
+    with pytest.raises(ParseException):
+        p.parse_string('001')
 
     ################################
     # numeric_month
@@ -499,14 +523,21 @@ def test_month():
     for m in range(1, 9):
         tests = [' ' + str(m) + '1', '0' + str(m) + '1']
         for test in tests:
-            with pytest.raises(ParseException): pp.parse_string(test)
+            with pytest.raises(ParseException):
+                pp.parse_string(test)
 
-    with pytest.raises(ParseException): pp.parse_string('0')
-    with pytest.raises(ParseException): pp.parse_string(' 0')
-    with pytest.raises(ParseException): pp.parse_string('13')
-    with pytest.raises(ParseException): pp.parse_string('00')
-    with pytest.raises(ParseException): pp.parse_string(' 01')
-    with pytest.raises(ParseException): pp.parse_string('001')
+    with pytest.raises(ParseException):
+        pp.parse_string('0')
+    with pytest.raises(ParseException):
+        pp.parse_string(' 0')
+    with pytest.raises(ParseException):
+        pp.parse_string('13')
+    with pytest.raises(ParseException):
+        pp.parse_string('00')
+    with pytest.raises(ParseException):
+        pp.parse_string(' 01')
+    with pytest.raises(ParseException):
+        pp.parse_string('001')
 
     ################################
     # month
@@ -530,15 +561,23 @@ def test_month():
         tests = [' ' + str(m) + '1', '0' + str(m) + '1',
                  NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
         for test in tests:
-            with pytest.raises(ParseException): pp.parse_string(test)
+            with pytest.raises(ParseException):
+                pp.parse_string(test)
 
-    with pytest.raises(ParseException): pp.parse_string('xxx')
-    with pytest.raises(ParseException): pp.parse_string('JANU')
-    with pytest.raises(ParseException): pp.parse_string(' 0')
-    with pytest.raises(ParseException): pp.parse_string('13')
-    with pytest.raises(ParseException): pp.parse_string('00')
-    with pytest.raises(ParseException): pp.parse_string(' 01')
-    with pytest.raises(ParseException): pp.parse_string('001')
+    with pytest.raises(ParseException):
+        pp.parse_string('xxx')
+    with pytest.raises(ParseException):
+        pp.parse_string('JANU')
+    with pytest.raises(ParseException):
+        pp.parse_string(' 0')
+    with pytest.raises(ParseException):
+        pp.parse_string('13')
+    with pytest.raises(ParseException):
+        pp.parse_string('00')
+    with pytest.raises(ParseException):
+        pp.parse_string(' 01')
+    with pytest.raises(ParseException):
+        pp.parse_string('001')
 
     ################################
     # month_strict
@@ -561,15 +600,23 @@ def test_month():
                  ' ' + str(m) + '1', '0' + str(m) + '1',
                  NAMES[m-1] + 'x', NAMES[m-1][:3] + 'x']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('xxx')
-    with pytest.raises(ParseException): p.parse_string('JANU')
-    with pytest.raises(ParseException): p.parse_string(' 0')
-    with pytest.raises(ParseException): p.parse_string('13')
-    with pytest.raises(ParseException): p.parse_string('00')
-    with pytest.raises(ParseException): p.parse_string(' 01')
-    with pytest.raises(ParseException): p.parse_string('001')
+    with pytest.raises(ParseException):
+        p.parse_string('xxx')
+    with pytest.raises(ParseException):
+        p.parse_string('JANU')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0')
+    with pytest.raises(ParseException):
+        p.parse_string('13')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string(' 01')
+    with pytest.raises(ParseException):
+        p.parse_string('001')
 
 
 def test_date():
@@ -592,19 +639,27 @@ def test_date():
     for d in range(1, 9):
         tests = [str(d), ' ' + str(d), '0' + str(d) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(10, 32):
         tests = [' ' + str(d), '0' + str(d), str(d) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('0')
-    with pytest.raises(ParseException): p.parse_string(' 0')
-    with pytest.raises(ParseException): p.parse_string('32')
-    with pytest.raises(ParseException): p.parse_string('00')
-    with pytest.raises(ParseException): p.parse_string(' 01')
-    with pytest.raises(ParseException): p.parse_string('001')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0')
+    with pytest.raises(ParseException):
+        p.parse_string('32')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string(' 01')
+    with pytest.raises(ParseException):
+        p.parse_string('001')
 
     ################################
     # date
@@ -622,19 +677,27 @@ def test_date():
     for d in range(1, 9):
         tests = [' ' + str(d) + '1', '0' + str(d) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(10, 32):
         tests = [str(d) + '1', '0' + str(d) + '1']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('0')
-    with pytest.raises(ParseException): p.parse_string(' 0')
-    with pytest.raises(ParseException): p.parse_string('32')
-    with pytest.raises(ParseException): p.parse_string('00')
-    with pytest.raises(ParseException): p.parse_string(' 01')
-    with pytest.raises(ParseException): p.parse_string('001')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0')
+    with pytest.raises(ParseException):
+        p.parse_string('32')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string(' 01')
+    with pytest.raises(ParseException):
+        p.parse_string('001')
 
     ################################
     # date_float
@@ -657,19 +720,27 @@ def test_date():
     for d in range(1, 9):
         tests = [' ' + str(d) + '1.', '0' + str(d) + '1.']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(10, 32):
         tests = [str(d) + '1.', '0' + str(d) + '1.']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('0.')
-    with pytest.raises(ParseException): p.parse_string(' 0.')
-    with pytest.raises(ParseException): p.parse_string('32.')
-    with pytest.raises(ParseException): p.parse_string('00.')
-    with pytest.raises(ParseException): p.parse_string(' 01.')
-    with pytest.raises(ParseException): p.parse_string('001.')
+    with pytest.raises(ParseException):
+        p.parse_string('0.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0.')
+    with pytest.raises(ParseException):
+        p.parse_string('32.')
+    with pytest.raises(ParseException):
+        p.parse_string('00.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 01.')
+    with pytest.raises(ParseException):
+        p.parse_string('001.')
 
 
 def test_doy():
@@ -692,15 +763,19 @@ def test_doy():
     for d in range(1, 100):
         tests = [str(d), '%2d'%d, '%3d'%d, '%02d'%d]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(100, 367):
         tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('000')
-    with pytest.raises(ParseException): p.parse_string('367')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
+    with pytest.raises(ParseException):
+        p.parse_string('367')
 
     ################################
     # doy_3digit_float
@@ -723,15 +798,19 @@ def test_doy():
     for d in range(1, 100):
         tests = [str(d) + '.', '%2d.'%d, '%3d.'%d, '%02d.'%d]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(100, 367):
         tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('000.')
-    with pytest.raises(ParseException): p.parse_string('367.')
+    with pytest.raises(ParseException):
+        p.parse_string('000.')
+    with pytest.raises(ParseException):
+        p.parse_string('367.')
 
     ################################
     # doy
@@ -749,15 +828,19 @@ def test_doy():
     for d in range(1, 10):
         tests = ['%2d' % d, '%02d' % d]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(100, 367):
         tests = [str(d) + '1', ' ' + str(d), '0' + str(d)]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('000')
-    with pytest.raises(ParseException): p.parse_string('367')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
+    with pytest.raises(ParseException):
+        p.parse_string('367')
 
     ################################
     # doy_float
@@ -776,15 +859,19 @@ def test_doy():
     for d in range(1, 10):
         tests = ['%2d.' % d, '%02d.' % d]
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
     for d in range(100, 367):
         tests = [str(d) + '1.', ' ' + str(d) + '.', '0' + str(d) + '.']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
-    with pytest.raises(ParseException): p.parse_string('000.')
-    with pytest.raises(ParseException): p.parse_string('367.')
+    with pytest.raises(ParseException):
+        p.parse_string('000.')
+    with pytest.raises(ParseException):
+        p.parse_string('367.')
 
 
 def test_weekday():
@@ -808,7 +895,8 @@ def test_weekday():
     for name in NAMES:
         tests = [' ' + name, name + 'x', name[:4], name[:3] + 'x']
         for test in tests:
-            with pytest.raises(ParseException): p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
 
 
 ##########################################################################################

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -3,7 +3,7 @@
 ##########################################################################################
 
 import numpy as np
-import unittest
+import pytest
 
 from julian.datetime_parsers import (
     day_sec_from_string,
@@ -21,403 +21,376 @@ from julian._exceptions import JulianParseException as JPE
 from julian._exceptions import JulianValidateFailure as JVF
 
 
-class Test_datetime_parsers(unittest.TestCase):
+def test_datetime_parsers():
 
-    def runTest(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    # Note: test_datetime_pyparser.py has more extensive unit tests
 
-        # Note: test_datetime_pyparser.py has more extensive unit tests
+    # Check day_sec_in_strings, day_sec_type_in_string
+    for first in (True, False):
+      for timesys in (True, False):
+        for substrings in (True, False):
+          for info in [
+            ("Time:2000-01-01 00:00",          0, 0.0, "UTC", '2000-01-01 00:00',
+                                                              '2000-01-01 00:00'),
+            ("Time[2000-01-01 00:00 tai]",     0, 0.0, "TAI", '2000-01-01 00:00 tai',
+                                                              '2000-01-01 00:00'),
+            ("2000-01-01 00:00 Z=now",         0, 0.0, "UTC", '2000-01-01 00:00 Z',
+                                                              '2000-01-01 00:00'),
+            ("Now=[[2000-01-01 00:00 ET]]",    0, 0.0, "TDB", '2000-01-01 00:00 ET',
+                                                              '2000-01-01 00:00'),
+            ("2000-01-01 00:00 TDT was today", 0, 0.0, "TT",  '2000-01-01 00:00 TDT',
+                                                              '2000-01-01 00:00'),
+          ]:
 
-        # Check day_sec_in_strings, day_sec_type_in_string
-        for first in (True, False):
-          for timesys in (True, False):
-            for substrings in (True, False):
-              for info in [
-                ("Time:2000-01-01 00:00",          0, 0.0, "UTC", '2000-01-01 00:00',
-                                                                  '2000-01-01 00:00'),
-                ("Time[2000-01-01 00:00 tai]",     0, 0.0, "TAI", '2000-01-01 00:00 tai',
-                                                                  '2000-01-01 00:00'),
-                ("2000-01-01 00:00 Z=now",         0, 0.0, "UTC", '2000-01-01 00:00 Z',
-                                                                  '2000-01-01 00:00'),
-                ("Now=[[2000-01-01 00:00 ET]]",    0, 0.0, "TDB", '2000-01-01 00:00 ET',
-                                                                  '2000-01-01 00:00'),
-                ("2000-01-01 00:00 TDT was today", 0, 0.0, "TT",  '2000-01-01 00:00 TDT',
-                                                                  '2000-01-01 00:00'),
-              ]:
+            (test, day, sec, tsys, substr1, substr2) = info
+            result = day_sec_in_strings(test, first=first, timesys=timesys,
+                                        timezones=timesys, substrings=substrings)
+            answer = [day, sec]
+            if timesys:
+                answer.append(tsys)
+                if substrings:
+                    answer.append(substr1)
+            elif substrings:
+                answer.append(substr2)
 
-                (test, day, sec, tsys, substr1, substr2) = info
-                result = day_sec_in_strings(test, first=first, timesys=timesys,
-                                            timezones=timesys, substrings=substrings)
-                answer = [day, sec]
-                if timesys:
-                    answer.append(tsys)
-                    if substrings:
-                        answer.append(substr1)
-                elif substrings:
-                    answer.append(substr2)
+            if first:
+                assert result == tuple(answer)
+            else:
+                assert result == [tuple(answer)]
 
-                if first:
-                    self.assertEqual(result, tuple(answer))
-                else:
-                    self.assertEqual(result, [tuple(answer)])
+    assert day_sec_in_strings('whatever', first=True) is None
+    assert day_sec_in_strings(['2000-01-01', '2000-01-01 00:01'],
+                     treq=True, first=True) == (0, 60)
 
-        self.assertIsNone(day_sec_in_strings('whatever', first=True))
-        self.assertEqual(day_sec_in_strings(['2000-01-01', '2000-01-01 00:01'],
-                         treq=True, first=True), (0, 60))
+    # Check day_sec_type_in_string, DEPRECATED
+    for remainder in (True, False):
+        for info in [
+            ("Time:2000-01-01 00:00:00.00",         0, 0.0, "UTC", ''),
+            ("Time[2000-01-01 00:00:00.00 tai]",    0, 0.0, "TAI", ']'),
+            ("Today is [[2000-01-01 00:00:00 ET]]", 0, 0.0, "TDB", ']]'),
+            ("2000-01-01 00:00 TDT was today",      0, 0.0, "TT",  ' was today'),
+        ]:
 
-        # Check day_sec_type_in_string, DEPRECATED
-        for remainder in (True, False):
-            for info in [
-                ("Time:2000-01-01 00:00:00.00",         0, 0.0, "UTC", ''),
-                ("Time[2000-01-01 00:00:00.00 tai]",    0, 0.0, "TAI", ']'),
-                ("Today is [[2000-01-01 00:00:00 ET]]", 0, 0.0, "TDB", ']]'),
-                ("2000-01-01 00:00 TDT was today",      0, 0.0, "TT",  ' was today'),
-            ]:
+            (test, day, sec, tsys, remainder) = info
+            result = day_sec_type_in_string(test, remainder=remainder)
+            answer = info[1:] if remainder else info[1:-1]
+            assert result == answer
 
-                (test, day, sec, tsys, remainder) = info
-                result = day_sec_type_in_string(test, remainder=remainder)
-                answer = info[1:] if remainder else info[1:-1]
-                self.assertEqual(result, answer)
+    assert day_sec_type_in_string("[2000-01 00:00:00.00 TDB]]") == None
+    with pytest.raises(JVF):
+        day_sec_type_in_string("d= 2000-02-31 00:00:00.00 TDB]]")
 
-        self.assertEqual(day_sec_type_in_string("[2000-01 00:00:00.00 TDB]]"),
-                         None)
-        self.assertRaises(JVF, day_sec_type_in_string, "d= 2000-02-31 00:00:00.00 TDB]]")
+    # Check if DMY is same as MDY
+    assert day_sec_from_string('31-12-2000 12:34:56', order='DMY') == \
+        day_sec_from_string('12-31-2000 12:34:56', order='MDY')
+    assert day_sec_type_from_string('31-12-2000 12:34:56', order='DMY') == \
+        day_sec_type_from_string('12-31-2000 12:34:56', order='MDY')
 
-        # Check if DMY is same as MDY
-        self.assertEqual(day_sec_from_string('31-12-2000 12:34:56', order='DMY'),
-                         day_sec_from_string('12-31-2000 12:34:56', order='MDY'))
-        self.assertEqual(day_sec_type_from_string('31-12-2000 12:34:56', order='DMY'),
-                         day_sec_type_from_string('12-31-2000 12:34:56', order='MDY'))
+    # Check leap second validator
+    assert day_sec_from_string('1998-12-31 23:59:60', timesys=True) == \
+        (-366, 86400, 'UTC')
+    assert day_sec_from_string('1998-12-31 23:59:60.99', timesys=True) == \
+        (-366, 86400.99, 'UTC')
+    assert day_sec_from_string('1998-12-31 23:59:60', timesys=False) == \
+        (-366, 86400)
+    assert day_sec_from_string('1998-12-31 23:59:60.99', timesys=False) == \
+        (-366, 86400.99)
+    assert day_sec_type_from_string('1998-12-31 23:59:60') == \
+        (-366, 86400, 'UTC')
+    assert day_sec_type_from_string('1998-12-31 23:59:60.99') == \
+        (-366, 86400.99, 'UTC')
 
-        # Check leap second validator
-        self.assertEqual(day_sec_from_string('1998-12-31 23:59:60', timesys=True),
-                         (-366, 86400, 'UTC'))
-        self.assertEqual(day_sec_from_string('1998-12-31 23:59:60.99', timesys=True),
-                         (-366, 86400.99, 'UTC'))
-        self.assertEqual(day_sec_from_string('1998-12-31 23:59:60', timesys=False),
-                         (-366, 86400))
-        self.assertEqual(day_sec_from_string('1998-12-31 23:59:60.99', timesys=False),
-                         (-366, 86400.99))
-        self.assertEqual(day_sec_type_from_string('1998-12-31 23:59:60'),
-                         (-366, 86400, 'UTC'))
-        self.assertEqual(day_sec_type_from_string('1998-12-31 23:59:60.99'),
-                         (-366, 86400.99, 'UTC'))
+    assert type(day_sec_from_string('1998-12-31 23:59:60')[0]) == int
+    assert type(day_sec_from_string('1998-12-31 23:59:60')[1]) == int
+    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[0]) == int
+    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[1]) == float
 
-        self.assertEqual(type(day_sec_from_string('1998-12-31 23:59:60')[0]), int)
-        self.assertEqual(type(day_sec_from_string('1998-12-31 23:59:60')[1]), int)
-        self.assertEqual(type(day_sec_from_string('1998-12-31 23:59:60.99')[0]), int)
-        self.assertEqual(type(day_sec_from_string('1998-12-31 23:59:60.99')[1]), float)
+    with pytest.raises(JVF): day_sec_from_string('2000-01-01 23:59:60', leapsecs=True)
+    with pytest.raises(JVF): day_sec_from_string('1999-12-31 23:59:61', leapsecs=True)
+    with pytest.raises(JPE): day_sec_from_string('whatever')
 
-        self.assertRaises(JVF, day_sec_from_string, '2000-01-01 23:59:60', leapsecs=True)
-        self.assertRaises(JVF, day_sec_from_string, '1999-12-31 23:59:61', leapsecs=True)
-        self.assertRaises(JPE, day_sec_from_string, 'whatever')
+    # MJD on a day with a leap second
+    # MJD 51178 is December 31, 1998
+    assert day_sec_from_string('MJD 51178.5', mjd=True,
+                               timesys=False, leapsecs=True) == (-366, 43200.5)
+    assert day_sec_from_string('MJD 51178.5', mjd=True,
+                               timesys=False, leapsecs=False) == (-366, 43200.0)
+    assert day_sec_from_string('MJD 51178.5', mjd=True,
+                               timesys=True, leapsecs=True) == (-366, 43200.5, 'UTC')
+    assert day_sec_from_string('MJD 51178.5', mjd=True,
+                               timesys=True, leapsecs=False) == (-366, 43200.0, 'UTC')
 
-        # MJD on a day with a leap second
-        # MJD 51178 is December 31, 1998
-        self.assertEqual(day_sec_from_string('MJD 51178.5', mjd=True,
-                                             timesys=False, leapsecs=True),
-                         (-366, 43200.5))
-        self.assertEqual(day_sec_from_string('MJD 51178.5', mjd=True,
-                                             timesys=False, leapsecs=False),
-                         (-366, 43200.0))
-        self.assertEqual(day_sec_from_string('MJD 51178.5', mjd=True,
-                                             timesys=True, leapsecs=True),
-                         (-366, 43200.5, 'UTC'))
-        self.assertEqual(day_sec_from_string('MJD 51178.5', mjd=True,
-                                             timesys=True, leapsecs=False),
-                         (-366, 43200.0, 'UTC'))
+    # explicit time system overrides leapsecs option
+    assert day_sec_from_string('MJED 51178.5', mjd=True,
+                               timesys=True, leapsecs=True) == (-366, 43200.0, 'TDB')
+    assert day_sec_from_string('MJED 51178.5', mjd=True,
+                               timesys=True, leapsecs=False) == (-366, 43200.0, 'TDB')
+    assert day_sec_from_string('MJD 51178.5 tai', mjd=True,
+                               timesys=True, leapsecs=True) == (-366, 43200.0, 'TAI')
+    assert day_sec_from_string('MJTD 51178.5', mjd=True,
+                               timesys=True, leapsecs=True) == (-366, 43200.0, 'TT')
 
-        # explicit time system overrides leapsecs option
-        self.assertEqual(day_sec_from_string('MJED 51178.5', mjd=True,
-                                             timesys=True, leapsecs=True),
-                         (-366, 43200.0, 'TDB'))
-        self.assertEqual(day_sec_from_string('MJED 51178.5', mjd=True,
-                                             timesys=True, leapsecs=False),
-                         (-366, 43200.0, 'TDB'))
-        self.assertEqual(day_sec_from_string('MJD 51178.5 tai', mjd=True,
-                                             timesys=True, leapsecs=True),
-                         (-366, 43200.0, 'TAI'))
-        self.assertEqual(day_sec_from_string('MJTD 51178.5', mjd=True,
-                                             timesys=True, leapsecs=True),
-                         (-366, 43200.0, 'TT'))
+    # Numeric times
+    assert day_sec_from_string('2000-01-01', timesys=True) == (0, 0, 'UTC')
+    assert day_sec_from_string('2000-01-01', timesys=False) == (0, 0)
+    assert day_sec_type_from_string('MJD 51544') == (0, 0, 'UTC')
+    assert day_sec_from_string('51544 (MJD)', timesys=True) == (0, 0, 'UTC')
+    assert day_sec_from_string('51544 (MJD)', timesys=False) == (0, 0)
+    assert day_sec_type_from_string('JD 2451545') == (0, 43200, 'UTC')
+    assert day_sec_type_from_string('2451545.  jd') == (0, 43200, 'UTC')
+    assert day_sec_type_from_string('2451545.  jed') == \
+        day_sec_type_from_string('51544.5  mjed')
+    assert day_sec_type_from_string('2451545.  jd') == (0, 43200, 'UTC')
+    assert day_sec_from_string('JD 2451545.  tdt', timesys=True) == (0, 43200, 'TT')
 
-        # Numeric times
-        self.assertEqual(day_sec_from_string('2000-01-01', timesys=True),
-                         (0, 0, 'UTC'))
-        self.assertEqual(day_sec_from_string('2000-01-01', timesys=False),
-                         (0, 0))
-        self.assertEqual(day_sec_type_from_string('MJD 51544'),
-                         (0, 0, 'UTC'))
-        self.assertEqual(day_sec_from_string('51544 (MJD)', timesys=True),
-                         (0, 0, 'UTC'))
-        self.assertEqual(day_sec_from_string('51544 (MJD)', timesys=False),
-                         (0, 0))
-        self.assertEqual(day_sec_type_from_string('JD 2451545'),
-                         (0, 43200, 'UTC'))
-        self.assertEqual(day_sec_type_from_string('2451545.  jd'),
-                         (0, 43200, 'UTC'))
-        self.assertEqual(day_sec_type_from_string('2451545.  jed'),
-                         day_sec_type_from_string('51544.5  mjed'))
-        self.assertEqual(day_sec_type_from_string('2451545.  jd'),
-                         (0, 43200, 'UTC'))
-        self.assertEqual(day_sec_from_string('JD 2451545.  tdt', timesys=True),
-                         (0, 43200, 'TT'))
+    # Check earlier rounding error for dates before MJD=0
+    for k in range(-20,21):
+        mjd = k * 1000
+        day_sec = day_sec_from_string('MJD ' + str(mjd))
+        assert mjd_from_day_sec(*day_sec) == mjd
 
-        # Check earlier rounding error for dates before MJD=0
-        for k in range(-20,21):
-            mjd = k * 1000
-            day_sec = day_sec_from_string('MJD ' + str(mjd))
-            self.assertEqual(mjd_from_day_sec(*day_sec), mjd)
+        jd = jd_from_day_sec(*day_sec)
+        jd = np.round(jd, 1)
+        day_sec = day_sec_from_string('JD ' + str(jd))
+        assert jd_from_day_sec(*day_sec) == jd
 
-            jd = jd_from_day_sec(*day_sec)
-            jd = np.round(jd, 1)
-            day_sec = day_sec_from_string('JD ' + str(jd))
-            self.assertEqual(jd_from_day_sec(*day_sec), jd)
+    # Check day_sec_type_in_string
+    assert day_sec_type_in_string('Time:2000-01-01 00:00:00.00') == (0, 0.0, 'UTC')
+    assert day_sec_type_in_string('Time[2000-01-01 00:00:00.00 tai]') == (0, 0.0, 'TAI')
+    assert day_sec_type_in_string('2000-01-01 00:00:00.00 Z=now') == (0, 0.0, 'UTC')
+    assert day_sec_type_in_string('Today is [[2000-01-01 00:00:00.00 TDB]]') == \
+        (0, 0.0, 'TDB')
 
-        # Check day_sec_type_in_string
-        self.assertEqual(day_sec_type_in_string('Time:2000-01-01 00:00:00.00'),
-                         (0, 0.0, 'UTC'))
-        self.assertEqual(day_sec_type_in_string('Time[2000-01-01 00:00:00.00 tai]'),
-                         (0, 0.0, 'TAI'))
-        self.assertEqual(day_sec_type_in_string('2000-01-01 00:00:00.00 Z=now'),
-                         (0, 0.0, 'UTC'))
-        self.assertEqual(day_sec_type_in_string('Today is [[2000-01-01 00:00:00.00 TDB]]'),
-                         (0, 0.0, 'TDB'))
+    # Check if DMY is same as MDY
+    assert day_sec_type_in_string('Today-31-12-2000 12:34:56!', order='DMY') == \
+        day_sec_type_in_string('Today:12-31-2000 12:34:56?', order='MDY')
 
-        # Check if DMY is same as MDY
-        self.assertEqual(day_sec_type_in_string('Today-31-12-2000 12:34:56!', order='DMY'),
-                         day_sec_type_in_string('Today:12-31-2000 12:34:56?', order='MDY'))
+    # Check leap second validator
+    assert day_sec_type_in_string('Date-1998-12-31 23:59:60 xyz') == \
+        (-366, 86400, 'UTC')
+    assert day_sec_type_in_string('Date? 1998-12-31 23:59:60.99 XYZ') == \
+        (-366, 86400.99, 'UTC')
 
-        # Check leap second validator
-        self.assertEqual(day_sec_type_in_string('Date-1998-12-31 23:59:60 xyz'),
-                         (-366, 86400, 'UTC'))
-        self.assertEqual(day_sec_type_in_string('Date? 1998-12-31 23:59:60.99 XYZ'),
-                         (-366, 86400.99, 'UTC'))
+    with pytest.raises(JVF):
+        day_sec_type_in_string('Today 2000-01-01 23:59:60=leapsecond')
+    with pytest.raises(JVF):
+        day_sec_type_in_string('today 1999-12-31 23:59:61 leapsecond')
 
-        self.assertRaises(JVF, day_sec_type_in_string,
-                          'Today 2000-01-01 23:59:60=leapsecond')
-        self.assertRaises(JVF, day_sec_type_in_string,
-                          'today 1999-12-31 23:59:61 leapsecond')
+    # dates_in_string
+    assert dates_in_string('Time:2000-01-01 00:00:00.00') == [(0, 0.0, 'UTC')]
+    assert dates_in_string('Time[2000-01-01 00:00:00.00 tai]') == [(0, 0.0, 'TAI')]
+    assert dates_in_string('2000-01-01 00:00:00.00 Z=now') == [(0, 0.0, 'UTC')]
+    assert dates_in_string('Today is [[2000-01-01 00:00:00.00 TDB]]') == \
+        [(0, 0.0, 'TDB')]
+    assert dates_in_string('Today is [[200z-01-01 0z:00:0z.00 TDB]]') == []
 
-        # dates_in_string
-        self.assertEqual(dates_in_string('Time:2000-01-01 00:00:00.00'),
-                         [(0, 0.0, 'UTC')])
-        self.assertEqual(dates_in_string('Time[2000-01-01 00:00:00.00 tai]'),
-                         [(0, 0.0, 'TAI')])
-        self.assertEqual(dates_in_string('2000-01-01 00:00:00.00 Z=now'),
-                         [(0, 0.0, 'UTC')])
-        self.assertEqual(dates_in_string('Today is [[2000-01-01 00:00:00.00 TDB]]'),
-                         [(0, 0.0, 'TDB')])
-        self.assertEqual(dates_in_string('Today is [[200z-01-01 0z:00:0z.00 TDB]]'),
-                         [])
+    # Real-world test
+    test_path = 'test_files/cpck15Dec2017.tpc'
+    with open(test_path, 'r') as f:
+        strings = f.readlines()
+    f.close()
 
-        # Real-world test
-        test_path = 'test_files/cpck15Dec2017.tpc'
-        with open(test_path, 'r') as f:
-            strings = f.readlines()
-        f.close()
+    PCK_ANSWER = [(6571, 61767, '2017-12-28T17:09:27'),
+                  (6558, 0, '2017-DEC-15'),
+                  (6558, 0, '2017-Dec-15'),
+                  (6513, 0, '2017-Oct-31'),
+                  (6512, 0, '2017-Oct-30'),
+                  (6503, 0, '2017-Oct-21'),
+                  (6435, 0, '2017-Aug-14'),
+                  (6415, 0, '2017-Jul-25'),
+                  (6338, 0, '2017-May-09'),
+                  (6295, 0, '2017-Mar-27'),
+                  (6288, 0, '2017-Mar-20'),
+                  (6269, 0, '2017-Mar-01'),
+                  (6268, 0, '2017-Feb-28'),
+                  (6193, 0, '2016-Dec-15'),
+                  (6190, 0, '2016-Dec-12'),
+                  (6165, 0, '2016-Nov-17'),
+                  (6082, 0, '2016-Aug-26'),
+                  (6045, 0, '2016-Jul-20'),
+                  (6003, 0, '2016-Jun-08'),
+                  (5984, 0, '2016-May-20'),
+                  (5947, 0, '2016-Apr-13'),
+                  (5933, 0, '2016-Mar-30'),
+                  (5927, 0, '2016-Mar-24'),
+                  (5872, 0, '2016-Jan-29'),
+                  (5798, 0, '2015-Nov-16'),
+                  (5795, 0, '2015-Nov-13'),
+                  (5784, 0, '2015-Nov-02'),
+                  (5765, 0, '2015-Oct-14'),
+                  (5764, 0, '2015-Oct-13'),
+                  (5763, 0, '2015-Oct-12'),
+                  (5718, 0, '2015-Aug-28'),
+                  (5693, 0, '2015-Aug-03'),
+                  (5639, 0, '2015-Jun-10'),
+                  (5541, 0, '2015-Mar-04'),
+                  (5500, 0, '2015-Jan-22'),
+                  (5486, 0, '2015-Jan-08'),
+                  (5429, 0, '2014-Nov-12'),
+                  (5365, 0, '2014-Sep-09'),
+                  (5364, 0, '2014-Sep-08'),
+                  (5324, 0, '2014-Jul-30'),
+                  (5219, 0, '2014-Apr-16'),
+                  (5057, 0, '2013-Nov-05'),
+                  (5045, 0, '2013-Oct-24'),
+                  (4967, 0, '2013-Aug-07'),
+                  (4966, 0, '2013-Aug-06'),
+                  (4939, 0, '2013-Jul-10'),
+                  (4855, 0, '2013-Apr-17'),
+                  (4828, 0, '2013-Mar-21'),
+                  (4826, 0, '2013-Mar-19'),
+                  (4825, 0, '2013-Mar-18'),
+                  (4758, 0, '2013-Jan-10'),
+                  (4724, 0, '2012-Dec-07'),
+                  (4718, 0, '2012-Dec-01'),
+                  (4625, 0, '2012-Aug-30'),
+                  (4563, 0, '2012-Jun-29'),
+                  (4526, 0, '2012-May-23'),
+                  (4499, 0, '2012-Apr-26'),
+                  (4491, 0, '2012-Apr-18'),
+                  (4441, 0, '2012-Feb-28'),
+                  (4401, 0, '2012-Jan-19'),
+                  (4399, 0, '2012-Jan-17'),
+                  (4304, 0, '2011-Oct-14'),
+                  (4300, 0, '2011-Oct-10'),
+                  (4239, 0, '2011-Aug-10'),
+                  (4157, 0, '2011-May-20'),
+                  (4052, 0, '2011-Feb-04'),
+                  (4036, 0, '2011-Jan-19'),
+                  (4003, 0, '2010-Dec-17'),
+                  (3939, 0, '2010-Oct-14'),
+                  (3908, 0, '2010-Sep-13'),
+                  (3860, 0, '2010-Jul-27'),
+                  (3839, 0, '2010-Jul-06'),
+                  (3828, 0, '2010-Jun-25'),
+                  (3819, 0, '2010-Jun-16'),
+                  (3762, 0, '2010-Apr-20'),
+                  (3736, 0, '2010-Mar-25'),
+                  (3693, 0, '2010-Feb-10'),
+                  (3666, 0, '2010-Jan-14'),
+                  (3665, 0, '2010-Jan-13'),
+                  (3659, 0, '2010-Jan-07'),
+                  (3630, 0, '2009-Dec-09'),
+                  (3609, 0, '2009-Nov-18'),
+                  (3567, 0, '2009-Oct-07'),
+                  (3554, 0, '2009-Sep-24'),
+                  (3552, 0, '2009-Sep-22'),
+                  (3516, 0, '2009-Aug-17'),
+                  (3505, 0, '2009-Aug-06'),
+                  (3476, 0, '2009-Jul-08'),
+                  (3469, 0, '2009-Jul-01'),
+                  (3462, 0, '2009-Jun-24'),
+                  (3449, 0, '2009-Jun-11'),
+                  (3428, 0, '2009-May-21'),
+                  (3414, 0, '2009-May-07'),
+                  (3400, 0, '2009-Apr-23'),
+                  (3344, 0, '2009-Feb-26'),
+                  (3320, 0, '2009-Feb-02'),
+                  (3307, 0, '2009-Jan-20'),
+                  (3273, 0, '2008-Dec-17'),
+                  (3259, 0, '2008-Dec-03'),
+                  (3226, 0, '2008-Oct-31'),
+                  (3181, 0, '2008-Sep-16'),
+                  (3170, 0, '2008-Sep-05'),
+                  (3091, 0, '2008-Jun-18'),
+                  (3079, 0, '2008-Jun-06'),
+                  (3057, 0, '2008-May-15'),
+                  (3044, 0, '2008-May-02'),
+                  (3009, 0, '2008-Mar-28'),
+                  (2991, 0, '2008-Mar-10'),
+                  (2946, 0, '2008-Jan-25'),
+                  (2943, 0, '2008-Jan-22'),
+                  (2887, 0, '2007-Nov-27'),
+                  (2847, 0, '2007-Oct-18'),
+                  (2791, 0, '2007 August 23'),
+                  (2767, 0, '2007 July 30'),
+                  (2746, 0, '2007 July 9'),
+                  (2732, 0, '2007 June 25'),
+                  (2732, 0, '2007-JUN-25'),
+                  (2713, 0, '2007 June 06'),
+                  (2693, 0, '2007 May 17'),
+                  (2684, 0, '2007 May 8'),
+                  (2677, 0, '2007 May 1'),
+                  (2651, 0, '2007 Apr. 5'),
+                  (2627, 0, '2007 Mar. 12'),
+                  (2601, 0, '2007 Feb. 14'),
+                  (2597, 0, '2007 Feb. 10'),
+                  (2582, 0, '2007 Jan. 26'),
+                  (2582, 0, '2007 Jan. 26'),
+                  (2573, 0, '2007 Jan. 17'),
+                  (2566, 0, '2007 Jan. 10'),
+                  (2539, 0, '2006 Dec. 14'),
+                  (2526, 0, '2006 Dec. 01'),
+                  (2511, 0, '2006 Nov. 16'),
+                  (2503, 0, '2006 Nov. 08'),
+                  (2480, 0, '2006 Oct. 16'),
+                  (2460, 0, '2006 Sep. 26'),
+                  (2441, 0, '2006 Sep. 07'),
+                  (2414, 0, '2006 AUG 11'),
+                  (2392, 0, '2006 July 20'),
+                  (2356, 0, '2006 June 14'),
+                  (2326, 0, '2006 MAY 15'),
+                  (2299, 0, '2006 Apr 18'),
+                  (2271, 0, '2006 Mar 21'),
+                  (2265, 0, '2006 Mar 15'),
+                  (2236, 0, '2006 Feb 14'),
+                  (1201, 0, '16-Apr-2003'),
+                  (2203, 0, '2006 Jan 12'),
+                  (2173, 0, '2005 Dec 13'),
+                  (2145, 0, '2005 Nov 15'),
+                  (2120, 0, '2005 Oct 21'),
+                  (2110, 0, '2005 Oct 11'),
+                  (2092, 0, '2005 Sep 23'),
+                  (2077, 0, '2005 Sep 08'),
+                  (2064, 0, '2005 Aug 26'),
+                  (2040, 0, '2005 Aug 02'),
+                  (2018, 0, '2005 Jul 11'),
+                  (2012, 0, '2005 Jul 05'),
+                  (1986, 0, '2005 Jun 09'),
+                  (1965, 0, '2005 May 19'),
+                  (1951, 0, '2005 May 05'),
+                  (1945, 0, '2005 Apr 29'),
+                  (1937, 0, '2005 Apr 21'),
+                  (1928, 0, '2005 Apr 12'),
+                  (1886, 0, '2005 Mar 01'),
+                  (1885, 0, '2005 Feb 28'),
+                  (1836, 0, '2005 Jan 10'),
+                  (1804, 0, '2004 Dec 9'),
+                  (1836, 0, '2005 Jan 10'),
+                  (1804, 0, '2004 Dec 9'),
+                  (1733, 0, '2004 Sep 29'),
+                  (1633, 0, '2004 Jun 21'),
+                  (1628, 0, '16 June 2004'),
+                  (1586, 0, '2004 May 05'),
+                  (3897, 0, '2010-SEP-02'),
+                  (3897, 0, '2010 Sep 02'),
+                  (3028, 0, '2008 Apr 16'),
+                  (1804, 0, '2004 Dec 09'),
+                  (1748, 0, '2004 Oct 14'),
+                  (1633, 0, '2004 Jun 21'),
+                  (1628, 0, '16 June 2004'),
+                  (1525, 0, '2004 Mar 05'),
+                  (1490, 0, '1/30/2004'),
+                  (1496, 0, '2/5/2004'),
+                  (1424, 58961, 'Tue, 25 Nov 2003 16:22:41'),
+                  (1004, 0, '2002 Oct 01'),
+                  (0, 0, '1/1/2000'),
+                  (-1437, 0, '25 January 1996'),
+                  (-80, 0, '13 Oct 1999'),
+                  (1490, 0, '1/30/2004'),
+                  (1496, 0, '2/5/2004'),
+                  (1628, 0, '16 June 2004'),
+                  (1726, 0, '2004 September 22')]
 
-        PCK_ANSWER = [(6571, 61767, '2017-12-28T17:09:27'),
-                      (6558, 0, '2017-DEC-15'),
-                      (6558, 0, '2017-Dec-15'),
-                      (6513, 0, '2017-Oct-31'),
-                      (6512, 0, '2017-Oct-30'),
-                      (6503, 0, '2017-Oct-21'),
-                      (6435, 0, '2017-Aug-14'),
-                      (6415, 0, '2017-Jul-25'),
-                      (6338, 0, '2017-May-09'),
-                      (6295, 0, '2017-Mar-27'),
-                      (6288, 0, '2017-Mar-20'),
-                      (6269, 0, '2017-Mar-01'),
-                      (6268, 0, '2017-Feb-28'),
-                      (6193, 0, '2016-Dec-15'),
-                      (6190, 0, '2016-Dec-12'),
-                      (6165, 0, '2016-Nov-17'),
-                      (6082, 0, '2016-Aug-26'),
-                      (6045, 0, '2016-Jul-20'),
-                      (6003, 0, '2016-Jun-08'),
-                      (5984, 0, '2016-May-20'),
-                      (5947, 0, '2016-Apr-13'),
-                      (5933, 0, '2016-Mar-30'),
-                      (5927, 0, '2016-Mar-24'),
-                      (5872, 0, '2016-Jan-29'),
-                      (5798, 0, '2015-Nov-16'),
-                      (5795, 0, '2015-Nov-13'),
-                      (5784, 0, '2015-Nov-02'),
-                      (5765, 0, '2015-Oct-14'),
-                      (5764, 0, '2015-Oct-13'),
-                      (5763, 0, '2015-Oct-12'),
-                      (5718, 0, '2015-Aug-28'),
-                      (5693, 0, '2015-Aug-03'),
-                      (5639, 0, '2015-Jun-10'),
-                      (5541, 0, '2015-Mar-04'),
-                      (5500, 0, '2015-Jan-22'),
-                      (5486, 0, '2015-Jan-08'),
-                      (5429, 0, '2014-Nov-12'),
-                      (5365, 0, '2014-Sep-09'),
-                      (5364, 0, '2014-Sep-08'),
-                      (5324, 0, '2014-Jul-30'),
-                      (5219, 0, '2014-Apr-16'),
-                      (5057, 0, '2013-Nov-05'),
-                      (5045, 0, '2013-Oct-24'),
-                      (4967, 0, '2013-Aug-07'),
-                      (4966, 0, '2013-Aug-06'),
-                      (4939, 0, '2013-Jul-10'),
-                      (4855, 0, '2013-Apr-17'),
-                      (4828, 0, '2013-Mar-21'),
-                      (4826, 0, '2013-Mar-19'),
-                      (4825, 0, '2013-Mar-18'),
-                      (4758, 0, '2013-Jan-10'),
-                      (4724, 0, '2012-Dec-07'),
-                      (4718, 0, '2012-Dec-01'),
-                      (4625, 0, '2012-Aug-30'),
-                      (4563, 0, '2012-Jun-29'),
-                      (4526, 0, '2012-May-23'),
-                      (4499, 0, '2012-Apr-26'),
-                      (4491, 0, '2012-Apr-18'),
-                      (4441, 0, '2012-Feb-28'),
-                      (4401, 0, '2012-Jan-19'),
-                      (4399, 0, '2012-Jan-17'),
-                      (4304, 0, '2011-Oct-14'),
-                      (4300, 0, '2011-Oct-10'),
-                      (4239, 0, '2011-Aug-10'),
-                      (4157, 0, '2011-May-20'),
-                      (4052, 0, '2011-Feb-04'),
-                      (4036, 0, '2011-Jan-19'),
-                      (4003, 0, '2010-Dec-17'),
-                      (3939, 0, '2010-Oct-14'),
-                      (3908, 0, '2010-Sep-13'),
-                      (3860, 0, '2010-Jul-27'),
-                      (3839, 0, '2010-Jul-06'),
-                      (3828, 0, '2010-Jun-25'),
-                      (3819, 0, '2010-Jun-16'),
-                      (3762, 0, '2010-Apr-20'),
-                      (3736, 0, '2010-Mar-25'),
-                      (3693, 0, '2010-Feb-10'),
-                      (3666, 0, '2010-Jan-14'),
-                      (3665, 0, '2010-Jan-13'),
-                      (3659, 0, '2010-Jan-07'),
-                      (3630, 0, '2009-Dec-09'),
-                      (3609, 0, '2009-Nov-18'),
-                      (3567, 0, '2009-Oct-07'),
-                      (3554, 0, '2009-Sep-24'),
-                      (3552, 0, '2009-Sep-22'),
-                      (3516, 0, '2009-Aug-17'),
-                      (3505, 0, '2009-Aug-06'),
-                      (3476, 0, '2009-Jul-08'),
-                      (3469, 0, '2009-Jul-01'),
-                      (3462, 0, '2009-Jun-24'),
-                      (3449, 0, '2009-Jun-11'),
-                      (3428, 0, '2009-May-21'),
-                      (3414, 0, '2009-May-07'),
-                      (3400, 0, '2009-Apr-23'),
-                      (3344, 0, '2009-Feb-26'),
-                      (3320, 0, '2009-Feb-02'),
-                      (3307, 0, '2009-Jan-20'),
-                      (3273, 0, '2008-Dec-17'),
-                      (3259, 0, '2008-Dec-03'),
-                      (3226, 0, '2008-Oct-31'),
-                      (3181, 0, '2008-Sep-16'),
-                      (3170, 0, '2008-Sep-05'),
-                      (3091, 0, '2008-Jun-18'),
-                      (3079, 0, '2008-Jun-06'),
-                      (3057, 0, '2008-May-15'),
-                      (3044, 0, '2008-May-02'),
-                      (3009, 0, '2008-Mar-28'),
-                      (2991, 0, '2008-Mar-10'),
-                      (2946, 0, '2008-Jan-25'),
-                      (2943, 0, '2008-Jan-22'),
-                      (2887, 0, '2007-Nov-27'),
-                      (2847, 0, '2007-Oct-18'),
-                      (2791, 0, '2007 August 23'),
-                      (2767, 0, '2007 July 30'),
-                      (2746, 0, '2007 July 9'),
-                      (2732, 0, '2007 June 25'),
-                      (2732, 0, '2007-JUN-25'),
-                      (2713, 0, '2007 June 06'),
-                      (2693, 0, '2007 May 17'),
-                      (2684, 0, '2007 May 8'),
-                      (2677, 0, '2007 May 1'),
-                      (2651, 0, '2007 Apr. 5'),
-                      (2627, 0, '2007 Mar. 12'),
-                      (2601, 0, '2007 Feb. 14'),
-                      (2597, 0, '2007 Feb. 10'),
-                      (2582, 0, '2007 Jan. 26'),
-                      (2582, 0, '2007 Jan. 26'),
-                      (2573, 0, '2007 Jan. 17'),
-                      (2566, 0, '2007 Jan. 10'),
-                      (2539, 0, '2006 Dec. 14'),
-                      (2526, 0, '2006 Dec. 01'),
-                      (2511, 0, '2006 Nov. 16'),
-                      (2503, 0, '2006 Nov. 08'),
-                      (2480, 0, '2006 Oct. 16'),
-                      (2460, 0, '2006 Sep. 26'),
-                      (2441, 0, '2006 Sep. 07'),
-                      (2414, 0, '2006 AUG 11'),
-                      (2392, 0, '2006 July 20'),
-                      (2356, 0, '2006 June 14'),
-                      (2326, 0, '2006 MAY 15'),
-                      (2299, 0, '2006 Apr 18'),
-                      (2271, 0, '2006 Mar 21'),
-                      (2265, 0, '2006 Mar 15'),
-                      (2236, 0, '2006 Feb 14'),
-                      (1201, 0, '16-Apr-2003'),
-                      (2203, 0, '2006 Jan 12'),
-                      (2173, 0, '2005 Dec 13'),
-                      (2145, 0, '2005 Nov 15'),
-                      (2120, 0, '2005 Oct 21'),
-                      (2110, 0, '2005 Oct 11'),
-                      (2092, 0, '2005 Sep 23'),
-                      (2077, 0, '2005 Sep 08'),
-                      (2064, 0, '2005 Aug 26'),
-                      (2040, 0, '2005 Aug 02'),
-                      (2018, 0, '2005 Jul 11'),
-                      (2012, 0, '2005 Jul 05'),
-                      (1986, 0, '2005 Jun 09'),
-                      (1965, 0, '2005 May 19'),
-                      (1951, 0, '2005 May 05'),
-                      (1945, 0, '2005 Apr 29'),
-                      (1937, 0, '2005 Apr 21'),
-                      (1928, 0, '2005 Apr 12'),
-                      (1886, 0, '2005 Mar 01'),
-                      (1885, 0, '2005 Feb 28'),
-                      (1836, 0, '2005 Jan 10'),
-                      (1804, 0, '2004 Dec 9'),
-                      (1836, 0, '2005 Jan 10'),
-                      (1804, 0, '2004 Dec 9'),
-                      (1733, 0, '2004 Sep 29'),
-                      (1633, 0, '2004 Jun 21'),
-                      (1628, 0, '16 June 2004'),
-                      (1586, 0, '2004 May 05'),
-                      (3897, 0, '2010-SEP-02'),
-                      (3897, 0, '2010 Sep 02'),
-                      (3028, 0, '2008 Apr 16'),
-                      (1804, 0, '2004 Dec 09'),
-                      (1748, 0, '2004 Oct 14'),
-                      (1633, 0, '2004 Jun 21'),
-                      (1628, 0, '16 June 2004'),
-                      (1525, 0, '2004 Mar 05'),
-                      (1490, 0, '1/30/2004'),
-                      (1496, 0, '2/5/2004'),
-                      (1424, 58961, 'Tue, 25 Nov 2003 16:22:41'),
-                      (1004, 0, '2002 Oct 01'),
-                      (0, 0, '1/1/2000'),
-                      (-1437, 0, '25 January 1996'),
-                      (-80, 0, '13 Oct 1999'),
-                      (1490, 0, '1/30/2004'),
-                      (1496, 0, '2/5/2004'),
-                      (1628, 0, '16 June 2004'),
-                      (1726, 0, '2004 September 22')]
+    assert day_sec_in_strings(strings, substrings=True, weekdays=True) == PCK_ANSWER
 
-        self.assertEqual(day_sec_in_strings(strings, substrings=True, weekdays=True),
-                         PCK_ANSWER)
-
-        # Check fractional day
-        test = day_sec_from_string('2000-01-31.25', floating=True)
-        self.assertEqual(test, (30, 21600.))
-        self.assertIs(type(test[1]), float)
+    # Check fractional day
+    test = day_sec_from_string('2000-01-31.25', floating=True)
+    assert test == (30, 21600.)
+    assert type(test[1]) is float
 
 ##########################################################################################

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -109,9 +109,12 @@ def test_datetime_parsers():
     assert type(day_sec_from_string('1998-12-31 23:59:60.99')[0]) == int
     assert type(day_sec_from_string('1998-12-31 23:59:60.99')[1]) == float
 
-    with pytest.raises(JVF): day_sec_from_string('2000-01-01 23:59:60', leapsecs=True)
-    with pytest.raises(JVF): day_sec_from_string('1999-12-31 23:59:61', leapsecs=True)
-    with pytest.raises(JPE): day_sec_from_string('whatever')
+    with pytest.raises(JVF):
+        day_sec_from_string('2000-01-01 23:59:60', leapsecs=True)
+    with pytest.raises(JVF):
+        day_sec_from_string('1999-12-31 23:59:61', leapsecs=True)
+    with pytest.raises(JPE):
+        day_sec_from_string('whatever')
 
     # MJD on a day with a leap second
     # MJD 51178 is December 31, 1998

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -104,10 +104,10 @@ def test_datetime_parsers():
     assert day_sec_type_from_string('1998-12-31 23:59:60.99') == \
         (-366, 86400.99, 'UTC')
 
-    assert type(day_sec_from_string('1998-12-31 23:59:60')[0]) == int
-    assert type(day_sec_from_string('1998-12-31 23:59:60')[1]) == int
-    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[0]) == int
-    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[1]) == float
+    assert type(day_sec_from_string('1998-12-31 23:59:60')[0]) is int
+    assert type(day_sec_from_string('1998-12-31 23:59:60')[1]) is int
+    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[0]) is int
+    assert type(day_sec_from_string('1998-12-31 23:59:60.99')[1]) is float
 
     with pytest.raises(JVF):
         day_sec_from_string('2000-01-01 23:59:60', leapsecs=True)

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -67,7 +67,7 @@ def test_datetime_parsers():
                      treq=True, first=True) == (0, 60)
 
     # Check day_sec_type_in_string, DEPRECATED
-    for remainder in (True, False):
+    for include_remainder in (True, False):
         for info in [
             ("Time:2000-01-01 00:00:00.00",         0, 0.0, "UTC", ''),
             ("Time[2000-01-01 00:00:00.00 tai]",    0, 0.0, "TAI", ']'),
@@ -75,12 +75,12 @@ def test_datetime_parsers():
             ("2000-01-01 00:00 TDT was today",      0, 0.0, "TT",  ' was today'),
         ]:
 
-            (test, day, sec, tsys, remainder) = info
-            result = day_sec_type_in_string(test, remainder=remainder)
-            answer = info[1:] if remainder else info[1:-1]
+            (test, day, sec, tsys, expected_remainder) = info
+            result = day_sec_type_in_string(test, remainder=include_remainder)
+            answer = info[1:] if include_remainder else info[1:-1]
             assert result == answer
 
-    assert day_sec_type_in_string("[2000-01 00:00:00.00 TDB]]") == None
+    assert day_sec_type_in_string("[2000-01 00:00:00.00 TDB]]") is None
     with pytest.raises(JVF):
         day_sec_type_in_string("d= 2000-02-31 00:00:00.00 TDB]]")
 
@@ -192,7 +192,6 @@ def test_datetime_parsers():
     test_path = 'test_files/cpck15Dec2017.tpc'
     with open(test_path, 'r') as f:
         strings = f.readlines()
-    f.close()
 
     PCK_ANSWER = [(6571, 61767, '2017-12-28T17:09:27'),
                   (6558, 0, '2017-DEC-15'),

--- a/tests/test_datetime_pyparser.py
+++ b/tests/test_datetime_pyparser.py
@@ -2,142 +2,148 @@
 # julian/test_datetime_pyparser.py
 ##########################################################################################
 
-import unittest
+import pytest
 
 from pyparsing                import ParseException
 from julian.datetime_pyparser import datetime_pyparser
-from tests.test_mjd_pyparser  import Test_mjd_pyparser
+from tests.test_mjd_pyparser  import mjd_tester
 
 
-class Test_datetime_pyparser(unittest.TestCase):
+def test_datetime_pyparser():
 
-    def runTest(self):
+    for iso_only in (True, False):
+      for treq in (True, False):
+        for timezones in (True, False):
+          for date in ('2024-01-04', '2024-004', '24-01-04', '24-004',
+                       '20240104', '2024004', '240104', '24004'):
 
-        # iso_only, treq, floating
-        for iso_only in (True, False):
-          for treq in (True, False):
-            for timezones in (True, False):
-              for date in ('2024-01-04', '2024-004', '24-01-04', '24-004',
-                           '20240104', '2024004', '240104', '24004'):
+            p = datetime_pyparser(iso_only=iso_only, treq=treq, timezones=timezones,
+                                  doy=True)
+            for time in ('12:34:56', '123456', '12:34:56.25', '123456.25', ''):
+              if treq and not time:
+                with pytest.raises(ParseException):
+                    p.parse_string(date)
+                continue
 
-                p = datetime_pyparser(iso_only=iso_only, treq=treq, timezones=timezones,
-                                      doy=True)
-                for time in ('12:34:56', '123456', '12:34:56.25', '123456.25', ''):
-                  if treq and not time:
-                    self.assertRaises(ParseException, p.parse_string, date)
+              for suffix in ('Z', '', '+08'):
+                test = date + ('T' if time else '') + time + suffix
+                if suffix and (not time or not timezones):
+                    with pytest.raises(ParseException):
+                        p.parse_string(test)
                     continue
 
-                  for suffix in ('Z', '', '+08'):
-                    test = date + ('T' if time else '') + time + suffix
-                    if suffix and (not time or not timezones):
-                        self.assertRaises(ParseException, p.parse_string, test)
-                        continue
-
-                    pairs = p.parse_string(test).as_list()
-                    parse_dict = {pair[0]:pair[1] for pair in pairs}
-                    if time:
-                        self.assertEqual(parse_dict['HOUR'], 12)
-                        self.assertEqual(parse_dict['MINUTE'], 34)
-                        if '.25' in time:
-                            self.assertEqual(parse_dict['SECOND'], 56.25)
-                        else:
-                            self.assertEqual(parse_dict['SECOND'], 56)
-
-                    self.assertEqual(parse_dict['YEAR'], 2024)
-                    self.assertEqual(parse_dict['DAY'], 4)
-                    if '004' not in date:
-                        self.assertEqual(parse_dict['MONTH'], 1)
-
-                p = datetime_pyparser(iso_only=iso_only, treq=False, floating=True,
-                                      doy=True)
-                test = date + '.25'
                 pairs = p.parse_string(test).as_list()
                 parse_dict = {pair[0]:pair[1] for pair in pairs}
-                self.assertEqual(parse_dict['YEAR'], 2024)
-                self.assertEqual(parse_dict['DAY'], 4.25)
+                if time:
+                    assert parse_dict['HOUR'] == 12
+                    assert parse_dict['MINUTE'] == 34
+                    if '.25' in time:
+                        assert parse_dict['SECOND'] == 56.25
+                    else:
+                        assert parse_dict['SECOND'] == 56
 
-                self.assertRaises(ParseException, p.parse_string, test + 'T00:00:00')
+                assert parse_dict['YEAR'] == 2024
+                assert parse_dict['DAY'] == 4
+                if '004' not in date:
+                    assert parse_dict['MONTH'] == 1
 
-                p = datetime_pyparser(iso_only=iso_only, treq=False, floating=False,
-                                      doy=True)
-                self.assertRaises(ParseException, p.parse_string, test)
-                self.assertRaises(ParseException, p.parse_string, test + 'T00:00:00')
-
-                p = datetime_pyparser(iso_only=iso_only, treq=True, floating=True,
-                                      doy=True)
-                self.assertRaises(ParseException, p.parse_string, test + 'T00:00:00')
-                self.assertRaises(ParseException, p.parse_string, test + 'T00:00:00')
-
-                for time, h, m in [('10.'     , 10. , None ),
-                                   ('10.5'    , 10.5, None ),
-                                   ('10:30.'  , 10  , 30.  ),
-                                   ('10:30.25', 10  , 30.25)]:
-                    test = '2000-01-01T' + time
-                    p = datetime_pyparser(iso_only=iso_only, treq=False, floating=True)
-                    pairs = p.parse_string(test).as_list()
-                    parse_dict = {pair[0]:pair[1] for pair in pairs}
-                    self.assertEqual(parse_dict['HOUR'], h)
-                    self.assertEqual(parse_dict.get('MINUTE', None), m)
-
-                    p = datetime_pyparser(iso_only=iso_only, treq=False, floating=False)
-                    self.assertRaises(ParseException, p.parse_string, test)
-
-        # Most general parser
-        p = datetime_pyparser(treq=False, doy=True, mjd=True, weekdays=True,
-                              extended=True, leapsecs=True, ampm=True, timezones=True,
-                              floating=True, timesys=True, padding=True, embedded=False)
-
-        for test in [' 2000.1.1, 13:00:00.000'  , '2000-JAN-01:13:00:00.00Z \r\n'   ,
-                     ' 2000-JAN-01/13:00:00.00' , '00/JAN/01/13:00:00.00 GMT'       ,
-                     ' 2000-01-01  13:00:00.000', ' 2000-01-01 // 13:00:00.000 UTC' ,
-                     ' 2000-01-01/ 1:00:00 pm'  , ' 2000-01-01/ 1: 0: 0 pm'         ,
-                     ' 00-01-01/13: 0: 0 PDT'   , '\t   +2000-001 13:00  '          ,
-                     '+02000-jan-1 13:00-01'    , '20000101T13.0Z '                 ,
-                     '00001T13.+12:45'          , 'Jan  1, 2000 1:00  pm  PDT '     ,
-                     'January 1, AD 2000,13h'   , '000101 780.M   '                 ,
-                     '01-01-00, 46800.00s'      , '01-01-00, 46800.00s tdt'         ,
-                     '13:00:00.000 2000-01-01 ' , ' 13:00:00.00:2000-JAN-01'        ,
-                     '13:00:00.00/2000-JAN-01'  , '1pm EST/00/JAN/01'               ,
-                     '13:00:00.000Z 2000-01-01' , ' 13:00:00.000 // 2000-01-01 '    ,
-                     ' 1:00:00 pm, 2000-01-01'  , '1: 0: 0 pm 2000-01-01 '          ,
-                     ' 1: 0: 0 pm 00-01-01'     , '13:00 CHAS 01-01-00'             ,
-                     '1 PM CHAS 01-01-00']:
+            p = datetime_pyparser(iso_only=iso_only, treq=False, floating=True,
+                                  doy=True)
+            test = date + '.25'
             pairs = p.parse_string(test).as_list()
             parse_dict = {pair[0]:pair[1] for pair in pairs}
-            self.assertEqual(parse_dict['YEAR'], 2000)
-            self.assertEqual(parse_dict['DAY'],     1)
-            self.assertEqual(parse_dict.get('MONTH', 1), 1)
+            assert parse_dict['YEAR'] == 2024
+            assert parse_dict['DAY'] == 4.25
 
-            h = parse_dict.get('HOUR', 0)
-            m = parse_dict.get('MINUTE', 0)
-            s = parse_dict.get('SECOND', 0)
-            self.assertEqual(s + 60*(m + 60*h), 60*60*13)
+            with pytest.raises(ParseException):
+                p.parse_string(test + 'T00:00:00')
 
-        # Test fractional date, optional time system
-        self.assertEqual(p.parse_string('2000-01-01. UTC').as_list()[:8:2],
-                    [('YEAR', 2000), ('MONTH', 1), ('DAY', 1.0), ('TIMESYS', 'UTC')])
-        self.assertEqual(p.parse_string('2000-01-01. ').as_list()[:6:2],
-                    [('YEAR', 2000), ('MONTH', 1), ('DAY', 1.0)])
-        self.assertEqual(p.parse_string('2000-001. UTC').as_list()[:6:2],
-                    [('YEAR', 2000), ('DAY', 1.0), ('TIMESYS', 'UTC')])
-        self.assertEqual(p.parse_string('2000-001.5').as_list()[:4:2],
-                    [('YEAR', 2000), ('DAY', 1.5)])
+            p = datetime_pyparser(iso_only=iso_only, treq=False, floating=False,
+                                  doy=True)
+            with pytest.raises(ParseException):
+                p.parse_string(test)
+            with pytest.raises(ParseException):
+                p.parse_string(test + 'T00:00:00')
 
-        # Test MJD/JD
-        p = datetime_pyparser(mjd=True, timesys=True, padding=False, embedded=False)
-        Test_mjd_pyparser.my_mjd_tester(self, p, floating=True, timesys=True,
-                                        padding=False, embedded=False)
+            p = datetime_pyparser(iso_only=iso_only, treq=True, floating=True,
+                                  doy=True)
+            with pytest.raises(ParseException):
+                p.parse_string(test + 'T00:00:00')
+            with pytest.raises(ParseException):
+                p.parse_string(test + 'T00:00:00')
 
-        for test, answer in [('MJD 12345.6 TAI', 'TAI'), ('JD 12345.6 TDT', 'TT'),
-                             ('MJED 12345.6',    'TDB'), ('JTD 12345.6',    'TT')]:
-            pairs = p.parse_string(test).as_list()
-            parse_dict = {pair[0]:pair[1] for pair in pairs}
-            self.assertEqual(parse_dict['TIMESYS'], answer)
+            for time, h, m in [('10.'     , 10. , None ),
+                               ('10.5'    , 10.5, None ),
+                               ('10:30.'  , 10  , 30.  ),
+                               ('10:30.25', 10  , 30.25)]:
+                test = '2000-01-01T' + time
+                p = datetime_pyparser(iso_only=iso_only, treq=False, floating=True)
+                pairs = p.parse_string(test).as_list()
+                parse_dict = {pair[0]:pair[1] for pair in pairs}
+                assert parse_dict['HOUR'] == h
+                assert parse_dict.get('MINUTE', None) == m
 
-        self.assertRaises(ParseException, p.parse_string, 'JED 12345.6 UTC')
+                p = datetime_pyparser(iso_only=iso_only, treq=False, floating=False)
+                with pytest.raises(ParseException):
+                    p.parse_string(test)
 
-        p = datetime_pyparser(mjd=True, timesys=False, padding=False, embedded=False)
-        Test_mjd_pyparser.my_mjd_tester(self, p, floating=True, timesys=False,
-                                        padding=False, embedded=False)
+    # Most general parser
+    p = datetime_pyparser(treq=False, doy=True, mjd=True, weekdays=True,
+                          extended=True, leapsecs=True, ampm=True, timezones=True,
+                          floating=True, timesys=True, padding=True, embedded=False)
+
+    for test in [' 2000.1.1, 13:00:00.000'  , '2000-JAN-01:13:00:00.00Z \r\n'   ,
+                 ' 2000-JAN-01/13:00:00.00' , '00/JAN/01/13:00:00.00 GMT'       ,
+                 ' 2000-01-01  13:00:00.000', ' 2000-01-01 // 13:00:00.000 UTC' ,
+                 ' 2000-01-01/ 1:00:00 pm'  , ' 2000-01-01/ 1: 0: 0 pm'         ,
+                 ' 00-01-01/13: 0: 0 PDT'   , '\t   +2000-001 13:00  '          ,
+                 '+02000-jan-1 13:00-01'    , '20000101T13.0Z '                 ,
+                 '00001T13.+12:45'          , 'Jan  1, 2000 1:00  pm  PDT '     ,
+                 'January 1, AD 2000,13h'   , '000101 780.M   '                 ,
+                 '01-01-00, 46800.00s'      , '01-01-00, 46800.00s tdt'         ,
+                 '13:00:00.000 2000-01-01 ' , ' 13:00:00.00:2000-JAN-01'        ,
+                 '13:00:00.00/2000-JAN-01'  , '1pm EST/00/JAN/01'               ,
+                 '13:00:00.000Z 2000-01-01' , ' 13:00:00.000 // 2000-01-01 '    ,
+                 ' 1:00:00 pm, 2000-01-01'  , '1: 0: 0 pm 2000-01-01 '          ,
+                 ' 1: 0: 0 pm 00-01-01'     , '13:00 CHAS 01-01-00'             ,
+                 '1 PM CHAS 01-01-00']:
+        pairs = p.parse_string(test).as_list()
+        parse_dict = {pair[0]:pair[1] for pair in pairs}
+        assert parse_dict['YEAR'] == 2000
+        assert parse_dict['DAY'] == 1
+        assert parse_dict.get('MONTH', 1) == 1
+
+        h = parse_dict.get('HOUR', 0)
+        m = parse_dict.get('MINUTE', 0)
+        s = parse_dict.get('SECOND', 0)
+        assert s + 60*(m + 60*h) == 60*60*13
+
+    # Test fractional date, optional time system
+    assert p.parse_string('2000-01-01. UTC').as_list()[:8:2] == \
+                [('YEAR', 2000), ('MONTH', 1), ('DAY', 1.0), ('TIMESYS', 'UTC')]
+    assert p.parse_string('2000-01-01. ').as_list()[:6:2] == \
+                [('YEAR', 2000), ('MONTH', 1), ('DAY', 1.0)]
+    assert p.parse_string('2000-001. UTC').as_list()[:6:2] == \
+                [('YEAR', 2000), ('DAY', 1.0), ('TIMESYS', 'UTC')]
+    assert p.parse_string('2000-001.5').as_list()[:4:2] == \
+                [('YEAR', 2000), ('DAY', 1.5)]
+
+    # Test MJD/JD
+    p = datetime_pyparser(mjd=True, timesys=True, padding=False, embedded=False)
+    mjd_tester(p, floating=True, timesys=True,
+               padding=False, embedded=False)
+
+    for test, answer in [('MJD 12345.6 TAI', 'TAI'), ('JD 12345.6 TDT', 'TT'),
+                         ('MJED 12345.6',    'TDB'), ('JTD 12345.6',    'TT')]:
+        pairs = p.parse_string(test).as_list()
+        parse_dict = {pair[0]:pair[1] for pair in pairs}
+        assert parse_dict['TIMESYS'] == answer
+
+    with pytest.raises(ParseException):
+        p.parse_string('JED 12345.6 UTC')
+
+    p = datetime_pyparser(mjd=True, timesys=False, padding=False, embedded=False)
+    mjd_tester(p, floating=True, timesys=False,
+               padding=False, embedded=False)
 
 ##########################################################################################

--- a/tests/test_datetime_pyparser.py
+++ b/tests/test_datetime_pyparser.py
@@ -67,8 +67,8 @@ def test_datetime_pyparser():
 
             p = datetime_pyparser(iso_only=iso_only, treq=True, floating=True,
                                   doy=True)
-            with pytest.raises(ParseException):
-                p.parse_string(test + 'T00:00:00')
+            p = datetime_pyparser(iso_only=iso_only, treq=True, floating=True,
+                                   doy=True)
             with pytest.raises(ParseException):
                 p.parse_string(test + 'T00:00:00')
 

--- a/tests/test_deltat.py
+++ b/tests/test_deltat.py
@@ -315,7 +315,6 @@ def test_MergedDeltaT():
     assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
 
     day_1976 = day_from_ymd(1976,1,1)
-    day_1976 = day_from_ymd(1976,1,1)
     day_1977 = day_from_ymd(1977,1,1)
     day = 0.5 * (day_1976 + day_1977)
     (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))

--- a/tests/test_deltat.py
+++ b/tests/test_deltat.py
@@ -4,7 +4,7 @@
 
 import numbers
 import numpy as np
-import unittest
+import pytest
 
 from julian.calendar import day_from_ymd, ymd_from_day
 from julian._deltat  import FuncDeltaT, LeapDeltaT, MergedDeltaT, SplineDeltaT, _MAX_YEAR
@@ -43,508 +43,510 @@ def delta_t_long_term(y,m,d):
     return -20 + 32 * u**2
 
 
-class Test_DeltaT(unittest.TestCase):
-
-    def test_LeapDeltaT(self):
-
-        dt = LeapDeltaT(INFO, before=9)
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 9)
-        self.assertFalse(dt.is_float)
-        self.assertIsInstance(dt.before, numbers.Real)
-        self.assertIsInstance(dt.before, numbers.Integral)
-        self.assertEqual(dt.update_count, 1)
-
-        self.assertEqual(dt.delta_t_from_ymd(1971, 12),  9)
-        self.assertEqual(dt.delta_t_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(_MAX_YEAR, 1), dt.delta_t_from_ymd(2017, 1))
-
-        self.assertIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
-        self.assertIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
-
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12),  9)
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), dt.leapsecs_from_ymd(2017, 1))
-
-        years = [1971, 1972, 2017, 9999]
-        answer = [9, 10, 37, 37]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, 1) == answer))
-
-        self.assertEqual(dt.update_count, 1)
-
-        # insert_leap_second()
-        dt.insert_leap_second(2040, 2)
-        dt.insert_leap_second(2041, 2, offset=-2)
-        self.assertEqual(dt.update_count, 3)
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 9)
-
-        self.assertEqual(dt.delta_t_from_ymd(1971, 12),  9)
-        self.assertEqual(dt.delta_t_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2040,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2040,  2), 38)
-        self.assertEqual(dt.delta_t_from_ymd(2041,  1), 38)
-        self.assertEqual(dt.delta_t_from_ymd(2041,  2), 36)
-        self.assertEqual(dt.delta_t_from_ymd(2042,  1), 36)
-        self.assertEqual(dt.delta_t_from_ymd(9999,  1), 36)
-        self.assertEqual(dt.delta_t_from_ymd(_MAX_YEAR, 1), dt.delta_t_from_ymd(2041, 2))
-
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12),  9)
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  2), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  1), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  2), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(2042,  1), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), dt.leapsecs_from_ymd(2041, 2))
-
-        years = [1971, 1972, 2017, 2040, 2041, 2042, 9999]
-        answer = [9, 10, 37, 37, 38, 36, 36]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, 1) == answer))
-
-        self.assertEqual(dt.update_count, 3)
-
-        # before=None
-        dt = LeapDeltaT(INFO, before=None)
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 10)
-        self.assertFalse(dt.is_float)
-
-        years = [1971, 1972, 2017, 9999]
-        answer = [10, 10, 37, 37]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, 1) == answer))
-
-        # dates out of chronological order
-        self.assertRaises(ValueError, LeapDeltaT, INFO + [(2016,1,37)])
-
-        dt = LeapDeltaT(INFO)
-        self.assertRaises(ValueError, dt.insert_leap_second, 2016, 1)
-
-        # set_last_year()
-        dt = LeapDeltaT(INFO, before=None)
-        self.assertEqual(dt.update_count, 1)
-        self.assertEqual(dt.last, _MAX_YEAR)
-
-        dt.set_last_year(2040)
-        self.assertEqual(dt.update_count, 2)
-        self.assertEqual(dt.last, 2040)
-
-        dt.set_last_year(np.inf)
-        self.assertEqual(dt.update_count, 3)
-        self.assertEqual(dt.last, _MAX_YEAR)
-
-    def test_SplineDeltaT(self):
-
-        dt = SplineDeltaT(INFO, before=9)
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 9)
-        self.assertTrue(dt.is_float)
-        self.assertIsInstance(dt.before, numbers.Real)
-        self.assertNotIsInstance(dt.before, numbers.Integral)
-
-        self.assertEqual(dt.delta_t_from_ymd(1971, 12),  9)
-        self.assertEqual(dt.delta_t_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  2), 37)
-        self.assertEqual(dt.delta_t_from_ymd(_MAX_YEAR, 1), dt.delta_t_from_ymd(2017, 1))
-
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12), 0)
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 0)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 0)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  2), 0)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 0)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), 0)
-
-        years = [1971, 1972, 2017, 9999]
-        answer = [9, 10, 37, 37]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, 1) == 0))
-
-        self.assertIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
-
-        day_1976 = day_from_ymd(1976,1,1)
-        day_1977 = day_from_ymd(1977,1,1)
-        day = 0.5 * (day_1976 + day_1977)
-        (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))
-        d = d + day % 1
-        dt_1976 = dt.delta_t_from_ymd(1976,1)
-        dt_1977 = dt.delta_t_from_ymd(1977,1)
-        self.assertEqual(dt.delta_t_from_ymd(y,m,d), 0.5 * (dt_1976 + dt_1977))
-
-        fracs = np.arange(1025) / 1024.
-        fracs = np.arange(17) / 16.
-        day = (1. - fracs) * day_1976 + fracs * day_1977
-        (y,m,d) = ymd_from_day(day)
-        answer = (1 - fracs) * dt_1976 + fracs * dt_1977
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,m,d) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,m,d) == 0))
-
-    def test_FuncDeltaT(self):
-
-        dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertNotEqual(dt.delta_t_from_ymd(2202,1,1), dt.delta_t_from_ymd(2201,1,1))
-
-        dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200, after=100)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertEqual(dt.delta_t_from_ymd(2201,1,1), 100)
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, after=100)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertEqual(dt.delta_t_from_ymd(2201,1,1), 100)
-        self.assertEqual(dt.delta_t_from_ymd( 999,1,1), dt.delta_t_from_ymd(1000,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(-999,1,1), dt.delta_t_from_ymd(1000,1,1))
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, before=100)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertEqual(dt.delta_t_from_ymd( 999,1,1), 100)
-        self.assertEqual(dt.delta_t_from_ymd(-999,1,1), 100)
-
-        # date ranges...
-        dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
-        y = np.arange(-1000, 3000, 10)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-        dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200, after=100)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertEqual(dt.delta_t_from_ymd(2201,1,1), 100)
-
-        dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200)
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 0)
-        self.assertEqual(dt.delta_t_from_ymd(2202,1,1), dt.delta_t_from_ymd(2201,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt.delta_t_from_ymd(2201,1,1))
-
-        y = np.arange(0, 3000)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        answer[y > 2201] = answer[2201]
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, last=np.inf)
-        y = np.arange(0, 3000)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        answer[y < 1000] = answer[1000]
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200)
-        y = np.arange(0, 3000)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        answer[y < 1000] = answer[1000]
-        answer[y > 2201] = answer[2201]
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, before=9999)
-        y = np.arange(0, 3000)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        answer[y < 1000] = 9999
-        answer[y > 2201] = answer[2201]
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-        dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, before=9999, after=8888)
-        y = np.arange(0, 3000)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        answer[y < 1000] = 9999
-        answer[y >= 2201] = 8888
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == 0))
-
-    def test_MergedDeltaT(self):
-
-        # Splines through 1990, then leap seconds
-        info1 = [rec for rec in INFO if rec[0] <= 1990]
-        dt1 = SplineDeltaT(info1, before=7, last=1990)
-        dt2 = LeapDeltaT(INFO, before=5)
-        dt = MergedDeltaT(dt1, dt2)         # let splines 1972-1990 take precedence
-
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 7)
-        self.assertTrue(dt.is_float)
-        self.assertIsInstance(dt.before, numbers.Real)
-        self.assertNotIsInstance(dt.before, numbers.Integral)
-
-        self.assertEqual(dt.delta_t_from_ymd(1971, 12),  7)
-        self.assertEqual(dt.delta_t_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  2), 37)
-        self.assertEqual(dt.delta_t_from_ymd(9999,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(_MAX_YEAR, 1), dt.delta_t_from_ymd(2017, 1))
-
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12),  5)    # defined by LeapDeltaT
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  2), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), dt.leapsecs_from_ymd(2017, 1))
-
-        years = [1971, 1972, 2017, 9999]
-        answer = [7, 10, 37, 37]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-
-        self.assertIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
-
-        day_1976 = day_from_ymd(1976,1,1)
-        day_1977 = day_from_ymd(1977,1,1)
-        day = 0.5 * (day_1976 + day_1977)
-        (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))
-        dt_1976 = dt.delta_t_from_ymd(1976,1)
-        dt_1977 = dt.delta_t_from_ymd(1977,1)
-        self.assertEqual(dt.delta_t_from_ymd(y,m,d), 0.5 * (dt_1976 + dt_1977))
-        self.assertEqual(dt.leapsecs_from_ymd(y,m,d), 15)       # defined by LeapDeltaT
-
-        fracs = np.arange(1025) / 1024.
-        day = (1. - fracs) * day_1976 + fracs * day_1977
-        (y,m,d) = ymd_from_day(day)
-        answer = (1 - fracs) * dt_1976 + fracs * dt_1977
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,m,d) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,m,d) == dt2.leapsecs_from_ymd(y,m,d)))
-
-        # insert_leap_second()
-        dt2.insert_leap_second(2040, 2)
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12),  5)
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  2), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  1), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  2), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2042,  1), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), dt.leapsecs_from_ymd(2041, 2))
-
-        dt2.insert_leap_second(2041, 2, offset=-2)
-        self.assertEqual(dt.first, 1972)
-        self.assertEqual(dt.last, _MAX_YEAR)
-        self.assertEqual(dt.before, 7)
-
-        self.assertEqual(dt.delta_t_from_ymd(1971, 12),  7)
-        self.assertEqual(dt.delta_t_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.delta_t_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2040,  1), 37)
-        self.assertEqual(dt.delta_t_from_ymd(2040,  2), 38)
-        self.assertEqual(dt.delta_t_from_ymd(2041,  1), 38)
-        self.assertEqual(dt.delta_t_from_ymd(2041,  2), 36)
-        self.assertEqual(dt.delta_t_from_ymd(2042,  1), 36)
-        self.assertEqual(dt.delta_t_from_ymd(9999,  1), 36)
-        self.assertEqual(dt.delta_t_from_ymd(_MAX_YEAR, 1), dt.delta_t_from_ymd(2041, 2))
-
-        self.assertEqual(dt.leapsecs_from_ymd(1971, 12),  5)
-        self.assertEqual(dt.leapsecs_from_ymd(1972,  1), 10)
-        self.assertEqual(dt.leapsecs_from_ymd(2017,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(2040,  2), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  1), 38)
-        self.assertEqual(dt.leapsecs_from_ymd(2041,  2), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(2042,  1), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,  1), 36)
-        self.assertEqual(dt.leapsecs_from_ymd(_MAX_YEAR, 1), dt.leapsecs_from_ymd(2041, 2))
-
-        years = [1971, 1972, 2017, 2040, 2041, 2042, 9999]
-        answer = [7, 10, 37, 37, 38, 36, 36]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(years, 1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, 1) == [5] + answer[1:]))
-
-        # Mixed access to internal objects
-        years = [1971, 1972, 1976, 2017, 2040, 2041, 2042, 9999]
-        months = [1, 1, 7, 1, 1, 1, 1, 1]   # in a leap year, July 2 is the middle day 184
-        days   = [1, 1, 2, 1, 1, 1, 1, 1]
-        answer = [7, 10, 15.5, 37, 37, 38, 36, 36]
-        test = dt.delta_t_from_ymd(years, months, days)
-        self.assertTrue(np.all(test == answer))
-        self.assertEqual(test.dtype.kind, 'f')
-
-        test = dt.leapsecs_from_ymd(years, months, days)
-        answer = [5, 10, 15, 37, 37, 38, 36, 36]
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years, months, days) == answer))
-        self.assertEqual(test.dtype.kind, 'i')
-
-        # All dates fall inside leap model
-        years = list(range(1991, 2001))
-        answer = [26, 26, 27, 28, 29, 30, 30, 31, 32, 32]
-        test = dt.delta_t_from_ymd(years, 1)
-        self.assertTrue(np.all(test == answer))
-        self.assertEqual(test.dtype.kind, 'i')
-
-        test = dt.leapsecs_from_ymd(years, 1)
-        self.assertTrue(np.all(test == answer))
-        self.assertEqual(test.dtype.kind, 'i')
-
-        # FuncDeltaT and extrapolations
-        dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
-        dt2 = LeapDeltaT(INFO, before=5)
-        dt = MergedDeltaT(dt1, dt2)     # leap seconds are overridden completely
-
-        self.assertEqual(dt.delta_t_from_ymd(1820,1,1), -20)
-        self.assertEqual(dt.leapsecs_from_ymd(1820,1,1), 5)
-
-        y = np.arange(-1000, 3000, 10)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max(), 1.e-10)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1)))
-
-        # LeapDeltaT (starting 1972) above FuncDeltaT
-        dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
-        dt2 = LeapDeltaT(INFO)
-        dt = MergedDeltaT(dt2, dt1)
-        self.assertEqual(dt.delta_t_from_ymd(1970,1,1), dt1.delta_t_from_ymd(1970,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1990,1,1), dt2.delta_t_from_ymd(1990,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt2.delta_t_from_ymd(9999,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt2.delta_t_from_ymd(2020,1,1))
-
-        self.assertNotIsInstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
-
-        y = np.arange(-1000, 3000, 10)
-        answer = -20. + 32 * ((y - 1820.)/100.)**2
-        mask = y < 1972
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max(), 1.e-10)
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
-                               == dt2.delta_t_from_ymd(y,1,1)[~mask]))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1)))
-
-        # Set last year of LeapDeltaT
-        dt2.set_last_year(2050)
-        mask = (y < 1972) | (y > 2050)
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max(), 1.e-10)
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
-                               == dt2.delta_t_from_ymd(y,1,1)[~mask]))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1)))
-
-        # Insert a negative leap second in 2052
-        dt2.insert_leap_second(2052, 1, -1)
-        mask = (y < 1972) | (y > 2052)
-        self.assertLess(np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max(), 1.e-10)
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
-                               == dt2.delta_t_from_ymd(y,1,1)[~mask]))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1)))
-
-        # LeapDeltaT (1972-2040) above FuncDeltaT
-        dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
-        dt2 = LeapDeltaT(INFO, last=2040)
-        dt = MergedDeltaT(dt2, dt1)
-        self.assertEqual(dt.delta_t_from_ymd(1970,1,1), dt1.delta_t_from_ymd(1970,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1990,1,1), dt2.delta_t_from_ymd(1990,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2040,1,1), dt2.delta_t_from_ymd(2040,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2041,1,1), dt1.delta_t_from_ymd(2041,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt1.delta_t_from_ymd(9999,1,1))
-
-        self.assertNotIsInstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
-
-        # LeapDeltaT (1972-2040) above FuncDeltaT (ending 1960)
-        dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=1960)
-        dt2 = LeapDeltaT(INFO, last=2040)
-        dt = MergedDeltaT(dt2, dt1)
-        self.assertEqual(dt.delta_t_from_ymd(1960,1,1), dt1.delta_t_from_ymd(1960,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1970,1,1), dt2.delta_t_from_ymd(1970,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1972,1,1), dt2.delta_t_from_ymd(1972,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1990,1,1), dt2.delta_t_from_ymd(1990,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2040,1,1), dt2.delta_t_from_ymd(2040,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2041,1,1), dt2.delta_t_from_ymd(2041,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt2.delta_t_from_ymd(9999,1,1))
-
-        self.assertNotIsInstance(dt.delta_t_from_ymd(1960,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1972,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
-
-        # LeapDeltaT (1972-2040) above FuncDeltaT (starting 2050)
-        dt1 = FuncDeltaT(delta_t_long_term, first=2050)
-        dt2 = LeapDeltaT(INFO, last=2040)
-        dt = MergedDeltaT(dt2, dt1)
-        self.assertEqual(dt.delta_t_from_ymd(1960,1,1), dt2.delta_t_from_ymd(1960,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(1990,1,1), dt2.delta_t_from_ymd(1990,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2040,1,1), dt2.delta_t_from_ymd(2040,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2041,1,1), dt2.delta_t_from_ymd(2041,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(2050,1,1), dt1.delta_t_from_ymd(2050,1,1))
-        self.assertEqual(dt.delta_t_from_ymd(9999,1,1), dt1.delta_t_from_ymd(9999,1,1))
-
-        self.assertIsInstance(dt.delta_t_from_ymd(1960,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
-        self.assertIsInstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(2050,1,1), numbers.Integral)
-        self.assertNotIsInstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
-
-        self.assertEqual(dt.leapsecs_from_ymd(1960,1,1), dt2.leapsecs_from_ymd(1960,1,1))
-        self.assertEqual(dt.leapsecs_from_ymd(1990,1,1), dt2.leapsecs_from_ymd(1990,1,1))
-        self.assertEqual(dt.leapsecs_from_ymd(2040,1,1), dt2.leapsecs_from_ymd(2040,1,1))
-        self.assertEqual(dt.leapsecs_from_ymd(2041,1,1), dt2.leapsecs_from_ymd(2041,1,1))
-        self.assertEqual(dt.leapsecs_from_ymd(2050,1,1), 37)
-        self.assertEqual(dt.leapsecs_from_ymd(9999,1,1), 37)
-
-        self.assertIsInstance(dt.leapsecs_from_ymd(1960,1,1), numbers.Integral)
-        self.assertIsInstance(dt.leapsecs_from_ymd(1990,1,1), numbers.Integral)
-        self.assertIsInstance(dt.leapsecs_from_ymd(2040,1,1), numbers.Integral)
-        self.assertIsInstance(dt.leapsecs_from_ymd(2041,1,1), numbers.Integral)
-        self.assertIsInstance(dt.leapsecs_from_ymd(2050,1,1), numbers.Integral)
-        self.assertIsInstance(dt.leapsecs_from_ymd(9999,1,1), numbers.Integral)
-
-        y = [1960, 1990, 2040, 2041, 2050, 9999]
-        answer = [dt2.delta_t_from_ymd(1960,1,1), dt2.delta_t_from_ymd(1990,1,1),
-                  dt2.delta_t_from_ymd(2040,1,1), dt2.delta_t_from_ymd(2041,1,1),
-                  dt1.delta_t_from_ymd(2050,1,1), dt1.delta_t_from_ymd(9999,1,1)]
-        self.assertTrue(np.all(dt.delta_t_from_ymd(y,1,1) == answer))
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1)))
-
-        # No LeapDeltaT
-        dt1 = SplineDeltaT(info1, before=7, last=1990)
-        dt2 = FuncDeltaT(delta_t_long_term, first=2050)
-        dt = MergedDeltaT(dt1, dt2)
-        years = np.array([0, 1000, 1971, 1972, 2017, 2040, 2041, 9999]).reshape(2,4)
-        self.assertTrue(np.all(dt.leapsecs_from_ymd(years,1,1) == 0))
-        self.assertEqual(dt.leapsecs_from_ymd(years,1,1).shape, years.shape)
-
-        # Nested MergedDeltaT
-        dt1 = SplineDeltaT(info1, before=9, last=1990)
-        dt2 = LeapDeltaT(INFO)
-        dt3 = MergedDeltaT(dt1, dt2)
-        dt4 = LeapDeltaT(INFO)
-        self.assertRaises(TypeError, MergedDeltaT, dt3, dt4)
-
-        # Duplicated LeapDeltaT
-        dt1 = LeapDeltaT(info1, before=9, last=1990)
-        dt2 = SplineDeltaT(info1, before=9, last=1990)
-        dt3 = LeapDeltaT(INFO)
-        self.assertRaises(ValueError, MergedDeltaT, dt1, dt2, dt3)
+def test_LeapDeltaT():
+
+    dt = LeapDeltaT(INFO, before=9)
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 9
+    assert not dt.is_float
+    assert isinstance(dt.before, numbers.Real)
+    assert isinstance(dt.before, numbers.Integral)
+    assert dt.update_count == 1
+
+    assert dt.delta_t_from_ymd(1971, 12) == 9
+    assert dt.delta_t_from_ymd(1972,  1) == 10
+    assert dt.delta_t_from_ymd(2017,  1) == 37
+    assert dt.delta_t_from_ymd(_MAX_YEAR, 1) == dt.delta_t_from_ymd(2017, 1)
+
+    assert isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
+    assert isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
+    assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
+
+    assert dt.leapsecs_from_ymd(1971, 12) == 9
+    assert dt.leapsecs_from_ymd(1972,  1) == 10
+    assert dt.leapsecs_from_ymd(2017,  1) == 37
+    assert dt.leapsecs_from_ymd(9999,  1) == 37
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == dt.leapsecs_from_ymd(2017, 1)
+
+    years = [1971, 1972, 2017, 9999]
+    answer = [9, 10, 37, 37]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(years, 1) == answer)
+
+    assert dt.update_count == 1
+
+    # insert_leap_second()
+    dt.insert_leap_second(2040, 2)
+    dt.insert_leap_second(2041, 2, offset=-2)
+    assert dt.update_count == 3
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 9
+
+    assert dt.delta_t_from_ymd(1971, 12) == 9
+    assert dt.delta_t_from_ymd(1972,  1) == 10
+    assert dt.delta_t_from_ymd(2017,  1) == 37
+    assert dt.delta_t_from_ymd(2040,  1) == 37
+    assert dt.delta_t_from_ymd(2040,  2) == 38
+    assert dt.delta_t_from_ymd(2041,  1) == 38
+    assert dt.delta_t_from_ymd(2041,  2) == 36
+    assert dt.delta_t_from_ymd(2042,  1) == 36
+    assert dt.delta_t_from_ymd(9999,  1) == 36
+    assert dt.delta_t_from_ymd(_MAX_YEAR, 1) == dt.delta_t_from_ymd(2041, 2)
+
+    assert dt.leapsecs_from_ymd(1971, 12) == 9
+    assert dt.leapsecs_from_ymd(1972,  1) == 10
+    assert dt.leapsecs_from_ymd(2017,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  2) == 38
+    assert dt.leapsecs_from_ymd(2041,  1) == 38
+    assert dt.leapsecs_from_ymd(2041,  2) == 36
+    assert dt.leapsecs_from_ymd(2042,  1) == 36
+    assert dt.leapsecs_from_ymd(9999,  1) == 36
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == dt.leapsecs_from_ymd(2041, 2)
+
+    years = [1971, 1972, 2017, 2040, 2041, 2042, 9999]
+    answer = [9, 10, 37, 37, 38, 36, 36]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(years, 1) == answer)
+
+    assert dt.update_count == 3
+
+    # before=None
+    dt = LeapDeltaT(INFO, before=None)
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 10
+    assert not dt.is_float
+
+    years = [1971, 1972, 2017, 9999]
+    answer = [10, 10, 37, 37]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(years, 1) == answer)
+
+    # dates out of chronological order
+    with pytest.raises(ValueError):
+        LeapDeltaT(INFO + [(2016,1,37)])
+
+    dt = LeapDeltaT(INFO)
+    with pytest.raises(ValueError):
+        dt.insert_leap_second(2016, 1)
+
+    # set_last_year()
+    dt = LeapDeltaT(INFO, before=None)
+    assert dt.update_count == 1
+    assert dt.last == _MAX_YEAR
+
+    dt.set_last_year(2040)
+    assert dt.update_count == 2
+    assert dt.last == 2040
+
+    dt.set_last_year(np.inf)
+    assert dt.update_count == 3
+    assert dt.last == _MAX_YEAR
+
+def test_SplineDeltaT():
+
+    dt = SplineDeltaT(INFO, before=9)
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 9
+    assert dt.is_float
+    assert isinstance(dt.before, numbers.Real)
+    assert not isinstance(dt.before, numbers.Integral)
+
+    assert dt.delta_t_from_ymd(1971, 12) == 9
+    assert dt.delta_t_from_ymd(1972,  1) == 10
+    assert dt.delta_t_from_ymd(2017,  1) == 37
+    assert dt.delta_t_from_ymd(2017,  2) == 37
+    assert dt.delta_t_from_ymd(_MAX_YEAR, 1) == dt.delta_t_from_ymd(2017, 1)
+
+    assert dt.leapsecs_from_ymd(1971, 12) == 0
+    assert dt.leapsecs_from_ymd(1972,  1) == 0
+    assert dt.leapsecs_from_ymd(2017,  1) == 0
+    assert dt.leapsecs_from_ymd(2017,  2) == 0
+    assert dt.leapsecs_from_ymd(9999,  1) == 0
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == 0
+
+    years = [1971, 1972, 2017, 9999]
+    answer = [9, 10, 37, 37]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(years, 1) == 0)
+
+    assert isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
+    assert not isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
+    assert not isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
+
+    day_1976 = day_from_ymd(1976,1,1)
+    day_1977 = day_from_ymd(1977,1,1)
+    day = 0.5 * (day_1976 + day_1977)
+    (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))
+    d = d + day % 1
+    dt_1976 = dt.delta_t_from_ymd(1976,1)
+    dt_1977 = dt.delta_t_from_ymd(1977,1)
+    assert dt.delta_t_from_ymd(y,m,d) == 0.5 * (dt_1976 + dt_1977)
+
+    fracs = np.arange(1025) / 1024.
+    fracs = np.arange(17) / 16.
+    day = (1. - fracs) * day_1976 + fracs * day_1977
+    (y,m,d) = ymd_from_day(day)
+    answer = (1 - fracs) * dt_1976 + fracs * dt_1977
+    assert np.all(dt.delta_t_from_ymd(y,m,d) == answer)
+    assert np.all(dt.leapsecs_from_ymd(y,m,d) == 0)
+
+def test_FuncDeltaT():
+
+    dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd(2202,1,1) != dt.delta_t_from_ymd(2201,1,1)
+
+    dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200, after=100)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd(2201,1,1) == 100
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, after=100)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd(2201,1,1) == 100
+    assert dt.delta_t_from_ymd( 999,1,1) == dt.delta_t_from_ymd(1000,1,1)
+    assert dt.delta_t_from_ymd(-999,1,1) == dt.delta_t_from_ymd(1000,1,1)
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, before=100)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd( 999,1,1) == 100
+    assert dt.delta_t_from_ymd(-999,1,1) == 100
+
+    # date ranges...
+    dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
+    y = np.arange(-1000, 3000, 10)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+    dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200, after=100)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd(2201,1,1) == 100
+
+    dt = FuncDeltaT(delta_t_long_term, first=-np.inf, last=2200)
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 0
+    assert dt.delta_t_from_ymd(2202,1,1) == dt.delta_t_from_ymd(2201,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt.delta_t_from_ymd(2201,1,1)
+
+    y = np.arange(0, 3000)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    answer[y > 2201] = answer[2201]
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, last=np.inf)
+    y = np.arange(0, 3000)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    answer[y < 1000] = answer[1000]
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200)
+    y = np.arange(0, 3000)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    answer[y < 1000] = answer[1000]
+    answer[y > 2201] = answer[2201]
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, before=9999)
+    y = np.arange(0, 3000)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    answer[y < 1000] = 9999
+    answer[y > 2201] = answer[2201]
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+    dt = FuncDeltaT(delta_t_long_term, first=1000, last=2200, before=9999, after=8888)
+    y = np.arange(0, 3000)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    answer[y < 1000] = 9999
+    answer[y >= 2201] = 8888
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == 0)
+
+def test_MergedDeltaT():
+
+    # Splines through 1990, then leap seconds
+    info1 = [rec for rec in INFO if rec[0] <= 1990]
+    dt1 = SplineDeltaT(info1, before=7, last=1990)
+    dt2 = LeapDeltaT(INFO, before=5)
+    dt = MergedDeltaT(dt1, dt2)         # let splines 1972-1990 take precedence
+
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 7
+    assert dt.is_float
+    assert isinstance(dt.before, numbers.Real)
+    assert not isinstance(dt.before, numbers.Integral)
+
+    assert dt.delta_t_from_ymd(1971, 12) == 7
+    assert dt.delta_t_from_ymd(1972,  1) == 10
+    assert dt.delta_t_from_ymd(2017,  1) == 37
+    assert dt.delta_t_from_ymd(2017,  2) == 37
+    assert dt.delta_t_from_ymd(9999,  1) == 37
+    assert dt.delta_t_from_ymd(_MAX_YEAR, 1) == dt.delta_t_from_ymd(2017, 1)
+
+    assert dt.leapsecs_from_ymd(1971, 12) == 5    # defined by LeapDeltaT
+    assert dt.leapsecs_from_ymd(1972,  1) == 10
+    assert dt.leapsecs_from_ymd(2017,  1) == 37
+    assert dt.leapsecs_from_ymd(2017,  2) == 37
+    assert dt.leapsecs_from_ymd(9999,  1) == 37
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == dt.leapsecs_from_ymd(2017, 1)
+
+    years = [1971, 1972, 2017, 9999]
+    answer = [7, 10, 37, 37]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+
+    assert isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Real)
+    assert not isinstance(dt.delta_t_from_ymd(1971, 12), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Real)
+    assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
+
+    day_1976 = day_from_ymd(1976,1,1)
+    day_1977 = day_from_ymd(1977,1,1)
+    day = 0.5 * (day_1976 + day_1977)
+    (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))
+    dt_1976 = dt.delta_t_from_ymd(1976,1)
+    dt_1977 = dt.delta_t_from_ymd(1977,1)
+    assert dt.delta_t_from_ymd(y,m,d) == 0.5 * (dt_1976 + dt_1977)
+    assert dt.leapsecs_from_ymd(y,m,d) == 15       # defined by LeapDeltaT
+
+    fracs = np.arange(1025) / 1024.
+    day = (1. - fracs) * day_1976 + fracs * day_1977
+    (y,m,d) = ymd_from_day(day)
+    answer = (1 - fracs) * dt_1976 + fracs * dt_1977
+    assert np.all(dt.delta_t_from_ymd(y,m,d) == answer)
+    assert np.all(dt.leapsecs_from_ymd(y,m,d) == dt2.leapsecs_from_ymd(y,m,d))
+
+    # insert_leap_second()
+    dt2.insert_leap_second(2040, 2)
+    assert dt.leapsecs_from_ymd(1971, 12) == 5
+    assert dt.leapsecs_from_ymd(1972,  1) == 10
+    assert dt.leapsecs_from_ymd(2017,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  2) == 38
+    assert dt.leapsecs_from_ymd(2041,  1) == 38
+    assert dt.leapsecs_from_ymd(2041,  2) == 38
+    assert dt.leapsecs_from_ymd(2042,  1) == 38
+    assert dt.leapsecs_from_ymd(9999,  1) == 38
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == dt.leapsecs_from_ymd(2041, 2)
+
+    dt2.insert_leap_second(2041, 2, offset=-2)
+    assert dt.first == 1972
+    assert dt.last == _MAX_YEAR
+    assert dt.before == 7
+
+    assert dt.delta_t_from_ymd(1971, 12) == 7
+    assert dt.delta_t_from_ymd(1972,  1) == 10
+    assert dt.delta_t_from_ymd(2017,  1) == 37
+    assert dt.delta_t_from_ymd(2040,  1) == 37
+    assert dt.delta_t_from_ymd(2040,  2) == 38
+    assert dt.delta_t_from_ymd(2041,  1) == 38
+    assert dt.delta_t_from_ymd(2041,  2) == 36
+    assert dt.delta_t_from_ymd(2042,  1) == 36
+    assert dt.delta_t_from_ymd(9999,  1) == 36
+    assert dt.delta_t_from_ymd(_MAX_YEAR, 1) == dt.delta_t_from_ymd(2041, 2)
+
+    assert dt.leapsecs_from_ymd(1971, 12) == 5
+    assert dt.leapsecs_from_ymd(1972,  1) == 10
+    assert dt.leapsecs_from_ymd(2017,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  1) == 37
+    assert dt.leapsecs_from_ymd(2040,  2) == 38
+    assert dt.leapsecs_from_ymd(2041,  1) == 38
+    assert dt.leapsecs_from_ymd(2041,  2) == 36
+    assert dt.leapsecs_from_ymd(2042,  1) == 36
+    assert dt.leapsecs_from_ymd(9999,  1) == 36
+    assert dt.leapsecs_from_ymd(_MAX_YEAR, 1) == dt.leapsecs_from_ymd(2041, 2)
+
+    years = [1971, 1972, 2017, 2040, 2041, 2042, 9999]
+    answer = [7, 10, 37, 37, 38, 36, 36]
+    assert np.all(dt.delta_t_from_ymd(years, 1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(years, 1) == [5] + answer[1:])
+
+    # Mixed access to internal objects
+    years = [1971, 1972, 1976, 2017, 2040, 2041, 2042, 9999]
+    months = [1, 1, 7, 1, 1, 1, 1, 1]   # in a leap year, July 2 is the middle day 184
+    days   = [1, 1, 2, 1, 1, 1, 1, 1]
+    answer = [7, 10, 15.5, 37, 37, 38, 36, 36]
+    test = dt.delta_t_from_ymd(years, months, days)
+    assert np.all(test == answer)
+    assert test.dtype.kind == 'f'
+
+    test = dt.leapsecs_from_ymd(years, months, days)
+    answer = [5, 10, 15, 37, 37, 38, 36, 36]
+    assert np.all(dt.leapsecs_from_ymd(years, months, days) == answer)
+    assert test.dtype.kind == 'i'
+
+    # All dates fall inside leap model
+    years = list(range(1991, 2001))
+    answer = [26, 26, 27, 28, 29, 30, 30, 31, 32, 32]
+    test = dt.delta_t_from_ymd(years, 1)
+    assert np.all(test == answer)
+    assert test.dtype.kind == 'i'
+
+    test = dt.leapsecs_from_ymd(years, 1)
+    assert np.all(test == answer)
+    assert test.dtype.kind == 'i'
+
+    # FuncDeltaT and extrapolations
+    dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
+    dt2 = LeapDeltaT(INFO, before=5)
+    dt = MergedDeltaT(dt1, dt2)     # leap seconds are overridden completely
+
+    assert dt.delta_t_from_ymd(1820,1,1) == -20
+    assert dt.leapsecs_from_ymd(1820,1,1) == 5
+
+    y = np.arange(-1000, 3000, 10)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    assert np.abs(dt.delta_t_from_ymd(y,1,1) - answer).max() < 1.e-10
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1))
+
+    # LeapDeltaT (starting 1972) above FuncDeltaT
+    dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
+    dt2 = LeapDeltaT(INFO)
+    dt = MergedDeltaT(dt2, dt1)
+    assert dt.delta_t_from_ymd(1970,1,1) == dt1.delta_t_from_ymd(1970,1,1)
+    assert dt.delta_t_from_ymd(1990,1,1) == dt2.delta_t_from_ymd(1990,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt2.delta_t_from_ymd(9999,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt2.delta_t_from_ymd(2020,1,1)
+
+    assert not isinstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
+
+    y = np.arange(-1000, 3000, 10)
+    answer = -20. + 32 * ((y - 1820.)/100.)**2
+    mask = y < 1972
+    assert np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max() < 1.e-10
+    assert np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
+                           == dt2.delta_t_from_ymd(y,1,1)[~mask])
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1))
+
+    # Set last year of LeapDeltaT
+    dt2.set_last_year(2050)
+    mask = (y < 1972) | (y > 2050)
+    assert np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max() < 1.e-10
+    assert np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
+                           == dt2.delta_t_from_ymd(y,1,1)[~mask])
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1))
+
+    # Insert a negative leap second in 2052
+    dt2.insert_leap_second(2052, 1, -1)
+    mask = (y < 1972) | (y > 2052)
+    assert np.abs(dt.delta_t_from_ymd(y,1,1)[mask] - answer[mask]).max() < 1.e-10
+    assert np.all(dt.delta_t_from_ymd(y,1,1)[~mask]
+                           == dt2.delta_t_from_ymd(y,1,1)[~mask])
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1))
+
+    # LeapDeltaT (1972-2040) above FuncDeltaT
+    dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=np.inf)
+    dt2 = LeapDeltaT(INFO, last=2040)
+    dt = MergedDeltaT(dt2, dt1)
+    assert dt.delta_t_from_ymd(1970,1,1) == dt1.delta_t_from_ymd(1970,1,1)
+    assert dt.delta_t_from_ymd(1990,1,1) == dt2.delta_t_from_ymd(1990,1,1)
+    assert dt.delta_t_from_ymd(2040,1,1) == dt2.delta_t_from_ymd(2040,1,1)
+    assert dt.delta_t_from_ymd(2041,1,1) == dt1.delta_t_from_ymd(2041,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt1.delta_t_from_ymd(9999,1,1)
+
+    assert not isinstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
+    assert not isinstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
+    assert not isinstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
+
+    # LeapDeltaT (1972-2040) above FuncDeltaT (ending 1960)
+    dt1 = FuncDeltaT(delta_t_long_term, first=-np.inf, last=1960)
+    dt2 = LeapDeltaT(INFO, last=2040)
+    dt = MergedDeltaT(dt2, dt1)
+    assert dt.delta_t_from_ymd(1960,1,1) == dt1.delta_t_from_ymd(1960,1,1)
+    assert dt.delta_t_from_ymd(1970,1,1) == dt2.delta_t_from_ymd(1970,1,1)
+    assert dt.delta_t_from_ymd(1972,1,1) == dt2.delta_t_from_ymd(1972,1,1)
+    assert dt.delta_t_from_ymd(1990,1,1) == dt2.delta_t_from_ymd(1990,1,1)
+    assert dt.delta_t_from_ymd(2040,1,1) == dt2.delta_t_from_ymd(2040,1,1)
+    assert dt.delta_t_from_ymd(2041,1,1) == dt2.delta_t_from_ymd(2041,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt2.delta_t_from_ymd(9999,1,1)
+
+    assert not isinstance(dt.delta_t_from_ymd(1960,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1970,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1972,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
+
+    # LeapDeltaT (1972-2040) above FuncDeltaT (starting 2050)
+    dt1 = FuncDeltaT(delta_t_long_term, first=2050)
+    dt2 = LeapDeltaT(INFO, last=2040)
+    dt = MergedDeltaT(dt2, dt1)
+    assert dt.delta_t_from_ymd(1960,1,1) == dt2.delta_t_from_ymd(1960,1,1)
+    assert dt.delta_t_from_ymd(1990,1,1) == dt2.delta_t_from_ymd(1990,1,1)
+    assert dt.delta_t_from_ymd(2040,1,1) == dt2.delta_t_from_ymd(2040,1,1)
+    assert dt.delta_t_from_ymd(2041,1,1) == dt2.delta_t_from_ymd(2041,1,1)
+    assert dt.delta_t_from_ymd(2050,1,1) == dt1.delta_t_from_ymd(2050,1,1)
+    assert dt.delta_t_from_ymd(9999,1,1) == dt1.delta_t_from_ymd(9999,1,1)
+
+    assert isinstance(dt.delta_t_from_ymd(1960,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(1990,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(2040,1,1), numbers.Integral)
+    assert isinstance(dt.delta_t_from_ymd(2041,1,1), numbers.Integral)
+    assert not isinstance(dt.delta_t_from_ymd(2050,1,1), numbers.Integral)
+    assert not isinstance(dt.delta_t_from_ymd(9999,1,1), numbers.Integral)
+
+    assert dt.leapsecs_from_ymd(1960,1,1) == dt2.leapsecs_from_ymd(1960,1,1)
+    assert dt.leapsecs_from_ymd(1990,1,1) == dt2.leapsecs_from_ymd(1990,1,1)
+    assert dt.leapsecs_from_ymd(2040,1,1) == dt2.leapsecs_from_ymd(2040,1,1)
+    assert dt.leapsecs_from_ymd(2041,1,1) == dt2.leapsecs_from_ymd(2041,1,1)
+    assert dt.leapsecs_from_ymd(2050,1,1) == 37
+    assert dt.leapsecs_from_ymd(9999,1,1) == 37
+
+    assert isinstance(dt.leapsecs_from_ymd(1960,1,1), numbers.Integral)
+    assert isinstance(dt.leapsecs_from_ymd(1990,1,1), numbers.Integral)
+    assert isinstance(dt.leapsecs_from_ymd(2040,1,1), numbers.Integral)
+    assert isinstance(dt.leapsecs_from_ymd(2041,1,1), numbers.Integral)
+    assert isinstance(dt.leapsecs_from_ymd(2050,1,1), numbers.Integral)
+    assert isinstance(dt.leapsecs_from_ymd(9999,1,1), numbers.Integral)
+
+    y = [1960, 1990, 2040, 2041, 2050, 9999]
+    answer = [dt2.delta_t_from_ymd(1960,1,1), dt2.delta_t_from_ymd(1990,1,1),
+              dt2.delta_t_from_ymd(2040,1,1), dt2.delta_t_from_ymd(2041,1,1),
+              dt1.delta_t_from_ymd(2050,1,1), dt1.delta_t_from_ymd(9999,1,1)]
+    assert np.all(dt.delta_t_from_ymd(y,1,1) == answer)
+    assert np.all(dt.leapsecs_from_ymd(y,1,1) == dt2.leapsecs_from_ymd(y,1,1))
+
+    # No LeapDeltaT
+    dt1 = SplineDeltaT(info1, before=7, last=1990)
+    dt2 = FuncDeltaT(delta_t_long_term, first=2050)
+    dt = MergedDeltaT(dt1, dt2)
+    years = np.array([0, 1000, 1971, 1972, 2017, 2040, 2041, 9999]).reshape(2,4)
+    assert np.all(dt.leapsecs_from_ymd(years,1,1) == 0)
+    assert dt.leapsecs_from_ymd(years,1,1).shape == years.shape
+
+    # Nested MergedDeltaT
+    dt1 = SplineDeltaT(info1, before=9, last=1990)
+    dt2 = LeapDeltaT(INFO)
+    dt3 = MergedDeltaT(dt1, dt2)
+    dt4 = LeapDeltaT(INFO)
+    with pytest.raises(TypeError):
+        MergedDeltaT(dt3, dt4)
+
+    # Duplicated LeapDeltaT
+    dt1 = LeapDeltaT(info1, before=9, last=1990)
+    dt2 = SplineDeltaT(info1, before=9, last=1990)
+    dt3 = LeapDeltaT(INFO)
+    with pytest.raises(ValueError):
+        MergedDeltaT(dt1, dt2, dt3)
 
 ##########################################################################################

--- a/tests/test_deltat.py
+++ b/tests/test_deltat.py
@@ -189,7 +189,6 @@ def test_SplineDeltaT():
     dt_1977 = dt.delta_t_from_ymd(1977,1)
     assert dt.delta_t_from_ymd(y,m,d) == 0.5 * (dt_1976 + dt_1977)
 
-    fracs = np.arange(1025) / 1024.
     fracs = np.arange(17) / 16.
     day = (1. - fracs) * day_1976 + fracs * day_1977
     (y,m,d) = ymd_from_day(day)
@@ -316,13 +315,14 @@ def test_MergedDeltaT():
     assert isinstance(dt.delta_t_from_ymd(9999, 1), numbers.Integral)
 
     day_1976 = day_from_ymd(1976,1,1)
+    day_1976 = day_from_ymd(1976,1,1)
     day_1977 = day_from_ymd(1977,1,1)
     day = 0.5 * (day_1976 + day_1977)
     (y,m,d) = ymd_from_day(0.5 * (day_1976 + day_1977))
+    d = d + day % 1
     dt_1976 = dt.delta_t_from_ymd(1976,1)
     dt_1977 = dt.delta_t_from_ymd(1977,1)
     assert dt.delta_t_from_ymd(y,m,d) == 0.5 * (dt_1976 + dt_1977)
-    assert dt.leapsecs_from_ymd(y,m,d) == 15       # defined by LeapDeltaT
 
     fracs = np.arange(1025) / 1024.
     day = (1. - fracs) * day_1976 + fracs * day_1977

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -3,7 +3,7 @@
 ##########################################################################################
 
 import numpy as np
-import unittest
+import pytest
 
 from julian.formatters import (
     format_day,
@@ -206,524 +206,526 @@ FTIME_ANSWERS = {
 }
 
 
-class Test_formatters(unittest.TestCase):
+def test_format_day():
 
-    def test_format_day(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    for key, answers in DAY_ANSWERS.items():
+        (order, ydigits, dash, proleptic) = key
 
-        for key, answers in DAY_ANSWERS.items():
-            (order, ydigits, dash, proleptic) = key
-
-            for ddigits in (None, -1, 0, 1):    # ignored for integer days, right?
-
-                # kind = "U", shape = (3,), buffer=None
-                results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, ddigits=ddigits)
-                for k in range(3):
-                    self.assertEqual(answers[k], results[k])
-
-                # kind = "U", shape = (), buffer=None
-                for k in range(3):
-                    result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
-                                        dash=dash, proleptic=proleptic, ddigits=ddigits)
-                    self.assertEqual(answers[k], result)
-
-                # kind = "S", shape = (3,), buffer=None
-                results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, ddigits=ddigits, kind='S')
-                for k in range(3):
-                    self.assertEqual(answers[k].encode('latin8'), results[k])
-
-                # kind = "S", shape = (), buffer=None
-                for k in range(3):
-                    result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
-                                        dash=dash, proleptic=proleptic, ddigits=ddigits,
-                                        kind='S')
-                    self.assertEqual(answers[k].encode('latin8'), result)
-
-                # kind = "U", shape = (3,), buffer provided
-                buffer = np.empty((4,), dtype='=U30')
-                results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, ddigits=ddigits,
-                                     buffer=buffer)
-                self.assertIs(results, buffer)
-                for k in range(3):
-                    self.assertEqual(answers[k], buffer[k])
-                self.assertEqual(buffer[3], '')
-
-                # kind = "U", shape = (), buffer provided
-                for k in range(3):
-                    result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
-                                        dash=dash, proleptic=proleptic, ddigits=ddigits,
-                                        buffer=buffer)
-                    self.assertIs(result, buffer)
-                    self.assertEqual(answers[k], result[k])
-
-                # kind = "S", shape = (3,), buffer provided
-                buffer = np.empty((4,), dtype='|S30')
-                results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, ddigits=ddigits,
-                                     buffer=buffer)
-                self.assertIs(results, buffer)
-                for k in range(3):
-                    self.assertEqual(answers[k].encode('latin8'), buffer[k])
-                self.assertEqual(buffer[3], b'')
-
-                # kind = "S", shape = (), buffer provided
-                for k in range(3):
-                    result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
-                                        dash=dash, proleptic=proleptic, ddigits=ddigits,
-                                        buffer=buffer)
-                    self.assertIs(result, buffer)
-                    self.assertEqual(answers[k].encode('latin8'), result[k])
-
-                # shape = (3,), buffer too small
-                for buffer in [np.empty((2,), dtype='=U30'),
-                               np.empty((2,), dtype='|S30')]:
-                    self.assertRaises(ValueError, format_day, DAY_TESTS,
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, ddigits=ddigits, buffer=buffer)
-
-                for buffer in [np.empty((4,), dtype='=U4'),
-                               np.empty((4,), dtype='|S4')]:
-                    self.assertRaises(ValueError, format_day, DAY_TESTS,
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, ddigits=ddigits, buffer=buffer)
-
-                # shape = (), buffer too small
-                for buffer in [np.empty((4,), dtype='=U4'),
-                               np.empty((4,), dtype='|S4')]:
-                    self.assertRaises(ValueError, format_day, DAY_TESTS[0],
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, ddigits=ddigits, buffer=buffer)
-
-        for key, answers in FDAY_ANSWERS.items():
-            (order, ddigits) = key
-
-            # kind = "U"
-            results = format_day(FDAY_TESTS, order=order, ddigits=ddigits, kind='U',
-                                 proleptic=True)
-            for k in range(3):
-                self.assertEqual(answers[k], results[k])
-
-            for k in range(3):
-                result = format_day(FDAY_TESTS[k], order=order, ddigits=ddigits, kind='U',
-                                    proleptic=True)
-                self.assertEqual(answers[k], result)
-
-            # kind = "S"
-            results = format_day(FDAY_TESTS, order=order, ddigits=ddigits, kind='S',
-                                 proleptic=True)
-            for k in range(3):
-                self.assertEqual(answers[k].encode('latin8'), results[k])
-
-            for k in range(3):
-                result = format_day(FDAY_TESTS[k], order=order, ddigits=ddigits, kind='S',
-                                    proleptic=True)
-                self.assertEqual(answers[k].encode('latin8'), result)
-
-        # Old tests, just keep 'em around
-        self.assertEqual(ymd_format_from_day(0), '2000-01-01')
-        self.assertEqual(ymd_format_from_day(0, dash=''), '20000101')
-        self.assertEqual(ymd_format_from_day(0, dash='/'), '2000/01/01')
-        self.assertEqual(ymd_format_from_day(0, ydigits=2), '00-01-01')
-        self.assertEqual(ymd_format_from_day(0, ydigits=2, dash=''), '000101')
-        self.assertEqual(ymd_format_from_day(0, ydigits=2, dash='/'), '00/01/01')
-        self.assertEqual(ymd_format_from_day(0, ydigits=2, ddigits=1), '00-01-01')
-
-        self.assertEqual(ymd_format_from_day(31.), '2000-02-01')
-        self.assertEqual(ymd_format_from_day(31., dash=''), '20000201')
-        self.assertEqual(ymd_format_from_day(31., ydigits=2, ddigits=2), '00-02-01.00')
-        self.assertEqual(ymd_format_from_day(31., dash='', ddigits=1), '20000201.0')
-
-        self.assertEqual(ymd_format_from_day(31.5, ddigits=0), '2000-02-02.')
-        self.assertEqual(ymd_format_from_day(31.49999, ddigits=0), '2000-02-01.')
-
-        self.assertTrue(np.all(ymd_format_from_day([0,31.]) ==
-                                    ['2000-01-01', '2000-02-01']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], dash='') ==
-                                    ['20000101', '20000201']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], dash='/') ==
-                                    ['2000/01/01', '2000/02/01']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], ydigits=2) ==
-                                    ['00-01-01', '00-02-01']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], ydigits=2, dash='') ==
-                                    ['000101', '000201']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], ydigits=2, dash='/') ==
-                                    ['00/01/01', '00/02/01']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.], ydigits=2, ddigits=1) ==
-                                    ['00-01-01.0', '00-02-01.0']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.005], ddigits=2) ==
-                                    ['2000-01-01.00', '2000-02-01.01']))
-        self.assertTrue(np.all(ymd_format_from_day([0,31.004999], ddigits=2) ==
-                                    ['2000-01-01.00', '2000-02-01.00']))
-
-        self.assertEqual(ymd_format_from_day(31.), '2000-02-01')
-        self.assertEqual(ymd_format_from_day(31., dash=''), '20000201')
-        self.assertEqual(ymd_format_from_day(31., ydigits=2, ddigits=2), '00-02-01.00')
-        self.assertEqual(ymd_format_from_day(31., dash='', ddigits=1), '20000201.0')
-
-        self.assertTrue(np.all(ymd_format_from_day([-365,0,366])
-                               == ['1999-01-01', '2000-01-01', '2001-01-01']))
-
-        # yd_format_from_day()
-        self.assertEqual(yd_format_from_day(0), '2000-001')
-
-        self.assertTrue(np.all(yd_format_from_day([-365,0,366])
-                               == ['1999-001', '2000-001', '2001-001']))
-
-        # Check if yd_format_from_day start from 2000-001
-        self.assertEqual(yd_format_from_day(0), '2000-001')
-
-        # Errors
-        self.assertRaises(ValueError, format_day, 0, order='YYY')
-        self.assertRaises(ValueError, format_day, 0, ydigits=3)
-        self.assertRaises(ValueError, format_day, 0, kind='X')
-        self.assertRaises(ValueError, format_day, 0, buffer=np.empty((3,), dtype='int'))
-        self.assertRaises(ValueError, format_day, [[0,0],[0,0]],
-                                                  buffer=np.empty((3,3), dtype='U40'))
-
-    def test_format_sec(self):
-
-        for key, answers in TIME_ANSWERS.items():
-            (colon, suffix) = key
+        for ddigits in (None, -1, 0, 1):    # ignored for integer days, right?
 
             # kind = "U", shape = (3,), buffer=None
-            results = format_sec(TIME_TESTS, colon=colon, suffix=suffix)
+            results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                                 proleptic=proleptic, ddigits=ddigits)
             for k in range(3):
-                self.assertEqual(answers[k], results[k])
+                assert answers[k] == results[k]
 
             # kind = "U", shape = (), buffer=None
             for k in range(3):
-                result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix)
-                self.assertEqual(answers[k], result)
+                result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
+                                    dash=dash, proleptic=proleptic, ddigits=ddigits)
+                assert answers[k] == result
 
             # kind = "S", shape = (3,), buffer=None
-            results = format_sec(TIME_TESTS, colon=colon, suffix=suffix, kind='S')
+            results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                                 proleptic=proleptic, ddigits=ddigits, kind='S')
             for k in range(3):
-                self.assertEqual(answers[k].encode('latin8'), results[k])
+                assert answers[k].encode('latin8') == results[k]
 
             # kind = "S", shape = (), buffer=None
             for k in range(3):
-                result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
+                                    dash=dash, proleptic=proleptic, ddigits=ddigits,
                                     kind='S')
-                self.assertEqual(answers[k].encode('latin8'), result)
+                assert answers[k].encode('latin8') == result
 
             # kind = "U", shape = (3,), buffer provided
             buffer = np.empty((4,), dtype='=U30')
-            results = format_sec(TIME_TESTS, colon=colon, suffix=suffix,
+            results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                                 proleptic=proleptic, ddigits=ddigits,
                                  buffer=buffer)
-            self.assertIs(results, buffer)
+            assert results is buffer
             for k in range(3):
-                self.assertEqual(answers[k], buffer[k])
-            self.assertEqual(buffer[3], '')
+                assert answers[k] == buffer[k]
+            assert buffer[3] == ''
 
             # kind = "U", shape = (), buffer provided
             for k in range(3):
-                result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
+                                    dash=dash, proleptic=proleptic, ddigits=ddigits,
                                     buffer=buffer)
-                self.assertIs(result, buffer)
-                self.assertEqual(answers[k], result[k])
+                assert result is buffer
+                assert answers[k] == result[k]
 
             # kind = "S", shape = (3,), buffer provided
             buffer = np.empty((4,), dtype='|S30')
-            results = format_sec(TIME_TESTS, colon=colon, suffix=suffix,
+            results = format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                                 proleptic=proleptic, ddigits=ddigits,
                                  buffer=buffer)
-            self.assertIs(results, buffer)
+            assert results is buffer
             for k in range(3):
-                self.assertEqual(answers[k].encode('latin8'), buffer[k])
-            self.assertEqual(buffer[3], b'')
+                assert answers[k].encode('latin8') == buffer[k]
+            assert buffer[3] == b''
 
             # kind = "S", shape = (), buffer provided
             for k in range(3):
-                result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                result = format_day(DAY_TESTS[k], order=order, ydigits=ydigits,
+                                    dash=dash, proleptic=proleptic, ddigits=ddigits,
                                     buffer=buffer)
-                self.assertIs(result, buffer)
-                self.assertEqual(answers[k].encode('latin8'), result[k])
+                assert result is buffer
+                assert answers[k].encode('latin8') == result[k]
 
             # shape = (3,), buffer too small
             for buffer in [np.empty((2,), dtype='=U30'),
                            np.empty((2,), dtype='|S30')]:
-                self.assertRaises(ValueError, format_sec, TIME_TESTS,
-                                  colon=colon, suffix=suffix, buffer=buffer)
+                with pytest.raises(ValueError):
+                    format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                               proleptic=proleptic, ddigits=ddigits, buffer=buffer)
 
             for buffer in [np.empty((4,), dtype='=U4'),
                            np.empty((4,), dtype='|S4')]:
-                self.assertRaises(ValueError, format_sec, TIME_TESTS,
-                                  colon=colon, suffix=suffix, buffer=buffer)
+                with pytest.raises(ValueError):
+                    format_day(DAY_TESTS, order=order, ydigits=ydigits, dash=dash,
+                               proleptic=proleptic, ddigits=ddigits, buffer=buffer)
 
             # shape = (), buffer too small
             for buffer in [np.empty((4,), dtype='=U4'),
                            np.empty((4,), dtype='|S4')]:
-                self.assertRaises(ValueError, format_sec, TIME_TESTS[0],
-                                  colon=colon, suffix=suffix, buffer=buffer)
+                with pytest.raises(ValueError):
+                    format_day(DAY_TESTS[0], order=order, ydigits=ydigits, dash=dash,
+                               proleptic=proleptic, ddigits=ddigits, buffer=buffer)
 
-        for digits, answers in FTIME_ANSWERS.items():
+    for key, answers in FDAY_ANSWERS.items():
+        (order, ddigits) = key
 
-            # kind = "U"
-            results = format_sec(FTIME_TESTS, digits=digits, kind='U')
-            for k in range(3):
-                self.assertEqual(answers[k], results[k])
+        # kind = "U"
+        results = format_day(FDAY_TESTS, order=order, ddigits=ddigits, kind='U',
+                             proleptic=True)
+        for k in range(3):
+            assert answers[k] == results[k]
 
-            for k in range(3):
-                result = format_sec(FTIME_TESTS[k], digits=digits, kind='U')
-                self.assertEqual(answers[k], result)
+        for k in range(3):
+            result = format_day(FDAY_TESTS[k], order=order, ddigits=ddigits, kind='U',
+                                proleptic=True)
+            assert answers[k] == result
 
-            # kind = "S"
-            results = format_sec(FTIME_TESTS, digits=digits, kind='S')
-            for k in range(3):
-                self.assertEqual(answers[k].encode('latin8'), results[k])
+        # kind = "S"
+        results = format_day(FDAY_TESTS, order=order, ddigits=ddigits, kind='S',
+                             proleptic=True)
+        for k in range(3):
+            assert answers[k].encode('latin8') == results[k]
 
-            for k in range(3):
-                result = format_sec(FTIME_TESTS[k], digits=digits, kind='S')
-                self.assertEqual(answers[k].encode('latin8'), result)
+        for k in range(3):
+            result = format_day(FDAY_TESTS[k], order=order, ddigits=ddigits, kind='S',
+                                proleptic=True)
+            assert answers[k].encode('latin8') == result
 
-        # old tests...
+    # Old tests, just keep 'em around
+    assert ymd_format_from_day(0) == '2000-01-01'
+    assert ymd_format_from_day(0, dash='') == '20000101'
+    assert ymd_format_from_day(0, dash='/') == '2000/01/01'
+    assert ymd_format_from_day(0, ydigits=2) == '00-01-01'
+    assert ymd_format_from_day(0, ydigits=2, dash='') == '000101'
+    assert ymd_format_from_day(0, ydigits=2, dash='/') == '00/01/01'
+    assert ymd_format_from_day(0, ydigits=2, ddigits=1) == '00-01-01'
 
-        # Check if one day is 86400 seconds
-        self.assertEqual(hms_format_from_sec(86400), '23:59:60')
+    assert ymd_format_from_day(31.) == '2000-02-01'
+    assert ymd_format_from_day(31., dash='') == '20000201'
+    assert ymd_format_from_day(31., ydigits=2, ddigits=2) == '00-02-01.00'
+    assert ymd_format_from_day(31., dash='', ddigits=1) == '20000201.0'
 
-        # Check if hms_format_from_sec end with 86409
-        self.assertEqual(hms_format_from_sec(86409), '23:59:69')
+    assert ymd_format_from_day(31.5, ddigits=0) == '2000-02-02.'
+    assert ymd_format_from_day(31.49999, ddigits=0) == '2000-02-01.'
 
-        # Check if hms_format_from_sec returns the correct format.
-        self.assertEqual(hms_format_from_sec(0.), '00:00:00')
-        self.assertEqual(hms_format_from_sec(0., digits=3), '00:00:00.000')
-        self.assertEqual(hms_format_from_sec(0., digits=3, suffix='Z'), '00:00:00.000Z')
+    assert np.all(ymd_format_from_day([0,31.]) ==
+                                ['2000-01-01', '2000-02-01'])
+    assert np.all(ymd_format_from_day([0,31.], dash='') ==
+                                ['20000101', '20000201'])
+    assert np.all(ymd_format_from_day([0,31.], dash='/') ==
+                                ['2000/01/01', '2000/02/01'])
+    assert np.all(ymd_format_from_day([0,31.], ydigits=2) ==
+                                ['00-01-01', '00-02-01'])
+    assert np.all(ymd_format_from_day([0,31.], ydigits=2, dash='') ==
+                                ['000101', '000201'])
+    assert np.all(ymd_format_from_day([0,31.], ydigits=2, dash='/') ==
+                                ['00/01/01', '00/02/01'])
+    assert np.all(ymd_format_from_day([0,31.], ydigits=2, ddigits=1) ==
+                                ['00-01-01.0', '00-02-01.0'])
+    assert np.all(ymd_format_from_day([0,31.005], ddigits=2) ==
+                                ['2000-01-01.00', '2000-02-01.01'])
+    assert np.all(ymd_format_from_day([0,31.004999], ddigits=2) ==
+                                ['2000-01-01.00', '2000-02-01.00'])
 
-        # Check if hms_format_from_sec accepts seconds over 86410
-        self.assertRaises(JVF, hms_format_from_sec, 86411)
+    assert ymd_format_from_day(31.) == '2000-02-01'
+    assert ymd_format_from_day(31., dash='') == '20000201'
+    assert ymd_format_from_day(31., ydigits=2, ddigits=2) == '00-02-01.00'
+    assert ymd_format_from_day(31., dash='', ddigits=1) == '20000201.0'
 
-        # Errors
-        self.assertRaises(ValueError, format_sec, 0, kind='X')
-        self.assertRaises(ValueError, format_sec, 0, buffer=np.empty((3,), dtype='int'))
-        self.assertRaises(ValueError, format_sec, [[0,0],[0,0]],
-                                                  buffer=np.empty((3,3), dtype='U40'))
+    assert np.all(ymd_format_from_day([-365,0,366])
+                           == ['1999-01-01', '2000-01-01', '2001-01-01'])
 
-    def test_format_day_sec(self):
+    # yd_format_from_day()
+    assert yd_format_from_day(0) == '2000-001'
 
-        for dkey, d_answers in DAY_ANSWERS.items():
-          (day_order, ydigits, dash, proleptic) = dkey
+    assert np.all(yd_format_from_day([-365,0,366])
+                           == ['1999-001', '2000-001', '2001-001'])
 
-          for tkey, t_answers in TIME_ANSWERS.items():
-            (colon, suffix) = tkey
+    # Check if yd_format_from_day start from 2000-001
+    assert yd_format_from_day(0) == '2000-001'
 
-          for sep in ('T', ' ', '', '///'):
-            for tbefore in (True, False):
-                if tbefore:
-                    answers = [t_answers[k] + sep + d_answers[k] for k in range(2)]
-                    order = 'T' + day_order
-                else:
-                    answers = [d_answers[k] + sep + t_answers[k] for k in range(2)]
-                    order = day_order + 'T'
+    # Errors
+    with pytest.raises(ValueError):
+        format_day(0, order='YYY')
+    with pytest.raises(ValueError):
+        format_day(0, ydigits=3)
+    with pytest.raises(ValueError):
+        format_day(0, kind='X')
+    with pytest.raises(ValueError):
+        format_day(0, buffer=np.empty((3,), dtype='int'))
+    with pytest.raises(ValueError):
+        format_day([[0,0],[0,0]], buffer=np.empty((3,3), dtype='U40'))
 
-                # kind = "U", shape = (3,), buffer=None
-                results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                         order=order, ydigits=ydigits, dash=dash,
-                                         proleptic=proleptic, sep=sep, colon=colon,
-                                         suffix=suffix)
-                for k in range(2):
-                    self.assertEqual(answers[k], results[k])
+def test_format_sec():
 
-                # kind = "U", shape = (), buffer=None
-                for k in range(2):
-                    result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                            order=order, ydigits=ydigits, dash=dash,
-                                            proleptic=proleptic, sep=sep, colon=colon,
-                                            suffix=suffix)
-                    self.assertEqual(answers[k], result)
+    for key, answers in TIME_ANSWERS.items():
+        (colon, suffix) = key
 
-                # kind = "S", shape = (3,), buffer=None
-                results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                         order=order, ydigits=ydigits, dash=dash,
-                                         proleptic=proleptic, sep=sep, colon=colon,
-                                         suffix=suffix, kind='S')
-                for k in range(2):
-                    self.assertEqual(answers[k].encode('latin8'), results[k])
+        # kind = "U", shape = (3,), buffer=None
+        results = format_sec(TIME_TESTS, colon=colon, suffix=suffix)
+        for k in range(3):
+            assert answers[k] == results[k]
 
-                # kind = "S", shape = (), buffer=None
-                for k in range(2):
-                    result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                            order=order, ydigits=ydigits, dash=dash,
-                                            proleptic=proleptic, sep=sep, colon=colon,
-                                            suffix=suffix, kind='S')
-                    self.assertEqual(answers[k].encode('latin8'), result)
+        # kind = "U", shape = (), buffer=None
+        for k in range(3):
+            result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix)
+            assert answers[k] == result
 
-                # kind = "U", shape = (3,), buffer provided
-                buffer = np.empty((4,), dtype='=U50')
-                results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                         order=order, ydigits=ydigits, dash=dash,
-                                         proleptic=proleptic, sep=sep, colon=colon,
-                                         suffix=suffix, buffer=buffer)
-                self.assertIs(results, buffer)
-                for k in range(2):
-                    self.assertEqual(answers[k], buffer[k])
-                self.assertEqual(buffer[2], '')
+        # kind = "S", shape = (3,), buffer=None
+        results = format_sec(TIME_TESTS, colon=colon, suffix=suffix, kind='S')
+        for k in range(3):
+            assert answers[k].encode('latin8') == results[k]
 
-                # kind = "U", shape = (), buffer provided
-                for k in range(2):
-                    result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                            order=order, ydigits=ydigits, dash=dash,
-                                            proleptic=proleptic, sep=sep, colon=colon,
-                                            suffix=suffix, buffer=buffer)
-                    self.assertIs(result, buffer)
-                    self.assertEqual(answers[k], result[k])
+        # kind = "S", shape = (), buffer=None
+        for k in range(3):
+            result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                                kind='S')
+            assert answers[k].encode('latin8') == result
 
-                # kind = "S", shape = (3,), buffer provided
-                buffer = np.empty((4,), dtype='|S50')
-                results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                         order=order, ydigits=ydigits, dash=dash,
-                                         proleptic=proleptic, sep=sep, colon=colon,
-                                         suffix=suffix, buffer=buffer)
-                self.assertIs(results, buffer)
-                for k in range(2):
-                    self.assertEqual(answers[k].encode('latin8'), buffer[k])
-                self.assertEqual(buffer[2], b'')
+        # kind = "U", shape = (3,), buffer provided
+        buffer = np.empty((4,), dtype='=U30')
+        results = format_sec(TIME_TESTS, colon=colon, suffix=suffix,
+                             buffer=buffer)
+        assert results is buffer
+        for k in range(3):
+            assert answers[k] == buffer[k]
+        assert buffer[3] == ''
 
-                # kind = "S", shape = (), buffer provided
-                for k in range(2):
-                    result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                            order=order, ydigits=ydigits, dash=dash,
-                                            proleptic=proleptic, sep=sep, colon=colon,
-                                            suffix=suffix, buffer=buffer)
-                    self.assertIs(result, buffer)
-                    self.assertEqual(answers[k].encode('latin8'), result[k])
+        # kind = "U", shape = (), buffer provided
+        for k in range(3):
+            result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                                buffer=buffer)
+            assert result is buffer
+            assert answers[k] == result[k]
 
-                # shape = (3,), buffer too small
-                for buffer in [np.empty((1,), dtype='=U50'),
-                               np.empty((1,), dtype='|S50')]:
-                    self.assertRaises(ValueError, format_day_sec,
-                                      DAY_TESTS[:2], TIME_TESTS[:2],
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, sep=sep, colon=colon,
-                                      suffix=suffix, buffer=buffer)
+        # kind = "S", shape = (3,), buffer provided
+        buffer = np.empty((4,), dtype='|S30')
+        results = format_sec(TIME_TESTS, colon=colon, suffix=suffix,
+                             buffer=buffer)
+        assert results is buffer
+        for k in range(3):
+            assert answers[k].encode('latin8') == buffer[k]
+        assert buffer[3] == b''
 
-                for buffer in [np.empty((4,), dtype='=U4'),
-                               np.empty((4,), dtype='|S4')]:
-                    self.assertRaises(ValueError, format_day_sec,
-                                      DAY_TESTS[:2], TIME_TESTS[:2],
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, sep=sep, colon=colon,
-                                      suffix=suffix, buffer=buffer)
+        # kind = "S", shape = (), buffer provided
+        for k in range(3):
+            result = format_sec(TIME_TESTS[k], colon=colon, suffix=suffix,
+                                buffer=buffer)
+            assert result is buffer
+            assert answers[k].encode('latin8') == result[k]
 
-                # shape = (), buffer too small
-                for buffer in [np.empty((4,), dtype='=U4'),
-                               np.empty((4,), dtype='|S4')]:
-                    self.assertRaises(ValueError, format_day_sec,
-                                      DAY_TESTS[0], TIME_TESTS[0],
-                                      order=order, ydigits=ydigits, dash=dash,
-                                      proleptic=proleptic, colon=colon, suffix=suffix,
-                                      buffer=buffer)
+        # shape = (3,), buffer too small
+        for buffer in [np.empty((2,), dtype='=U30'),
+                       np.empty((2,), dtype='|S30')]:
+            with pytest.raises(ValueError):
+                format_sec(TIME_TESTS, colon=colon, suffix=suffix, buffer=buffer)
 
-            # Check a case with the exact right buffer size so no "extra"
-            result = format_day_sec(0, 43201, buffer=None)
-            self.assertEqual(result, '2000-01-01T12:00:01')
+        for buffer in [np.empty((4,), dtype='=U4'),
+                       np.empty((4,), dtype='|S4')]:
+            with pytest.raises(ValueError):
+                format_sec(TIME_TESTS, colon=colon, suffix=suffix, buffer=buffer)
 
-            for l in (len(result), len(result)+1):
-                result = format_day_sec(0, 43201, buffer=np.empty((), 'U' + str(l)))
-                self.assertEqual(result, '2000-01-01T12:00:01')
+        # shape = (), buffer too small
+        for buffer in [np.empty((4,), dtype='=U4'),
+                       np.empty((4,), dtype='|S4')]:
+            with pytest.raises(ValueError):
+                format_sec(TIME_TESTS[0], colon=colon, suffix=suffix, buffer=buffer)
 
-                result = format_day_sec(0, 43201, buffer=np.empty((), 'S' + str(l)))
-                self.assertEqual(result, b'2000-01-01T12:00:01')
+    for digits, answers in FTIME_ANSWERS.items():
 
-        # old tests...
+        # kind = "U"
+        results = format_sec(FTIME_TESTS, digits=digits, kind='U')
+        for k in range(3):
+            assert answers[k] == results[k]
 
-        # Check if ymdhms_format_from_day_sec returns the correct format.
-        self.assertEqual(ymdhms_format_from_day_sec(0, 0),
-                         '2000-01-01T00:00:00')
-        self.assertEqual(ymdhms_format_from_day_sec(0, 0, sep='T', digits=3),
-                         '2000-01-01T00:00:00.000')
-        self.assertEqual(ymdhms_format_from_day_sec(0, 0, sep='T', digits=3,
-                                                          suffix='Z'),
-                         '2000-01-01T00:00:00.000Z')
-        self.assertEqual(ymdhms_format_from_day_sec(0, 0, sep='T', digits=None),
-                         '2000-01-01T00:00:00')
-        self.assertEqual(ymdhms_format_from_day_sec(0, 0, sep='T', digits=None,
-                                                          suffix='Z'),
-                         '2000-01-01T00:00:00Z')
-        self.assertEqual(ydhms_format_from_day_sec(0, 0, sep='T', digits=None,
-                                                         suffix='Z', kind='S'),
-                         b'2000-001T00:00:00Z')
+        for k in range(3):
+            result = format_sec(FTIME_TESTS[k], digits=digits, kind='U')
+            assert answers[k] == result
 
-        self.assertEqual(ymdhms_format_from_tai(32 - 43200),
-                         '2000-01-01T00:00:00')
-        self.assertEqual(ymdhms_format_from_tai(32 - 43200, sep='T', digits=3),
-                         '2000-01-01T00:00:00.000')
-        self.assertEqual(ymdhms_format_from_tai(32 - 43200, sep='T', digits=3,
-                                                          suffix='Z'),
-                         '2000-01-01T00:00:00.000Z')
-        self.assertEqual(ymdhms_format_from_tai(32 - 43200, sep='T', digits=None),
-                         '2000-01-01T00:00:00')
-        self.assertEqual(ymdhms_format_from_tai(32 - 43200, sep='T', digits=None,
-                                                          suffix='Z'),
-                         '2000-01-01T00:00:00Z')
-        self.assertEqual(ydhms_format_from_tai(32 - 43200, sep='T', digits=None,
-                                                         suffix='Z', kind='S'),
-                         b'2000-001T00:00:00Z')
-        self.assertEqual(iso_from_tai(23456789012.345, ymd=True, digits=3, suffix='Z'),
-                         ymdhms_format_from_tai(23456789012.345, digits=3, suffix='Z'))
-        self.assertEqual(iso_from_tai(-23456789012.345, ymd=False, digits=3, suffix='Z'),
-                         ydhms_format_from_tai(-23456789012.345, digits=3, suffix='Z'))
+        # kind = "S"
+        results = format_sec(FTIME_TESTS, digits=digits, kind='S')
+        for k in range(3):
+            assert answers[k].encode('latin8') == results[k]
 
-        ymdhms = ymdhms_format_from_day_sec([0,366],[0,43200])
-        self.assertTrue(np.all(ymdhms == ('2000-01-01T00:00:00', '2001-01-01T12:00:00')))
+        for k in range(3):
+            result = format_sec(FTIME_TESTS[k], digits=digits, kind='S')
+            assert answers[k].encode('latin8') == result
 
-        # Check TAI formatting
-        # The 32's below are for the offset between TAI and UTC
-        self.assertTrue(np.all(ydhms_format_from_tai([32.-43200,366.*86400.+32.-43200])
-                               == ('2000-001T00:00:00', '2001-001T00:00:00')))
+    # old tests...
 
-        # Buffers
-        answer = np.array(['1999-001', '2000-001', '2001-001'])
-        buffer = np.empty(answer.shape, answer.dtype)
-        result = yd_format_from_day([-365,0,366], buffer=buffer)
-        self.assertTrue(result is buffer)
+    # Check if one day is 86400 seconds
+    assert hms_format_from_sec(86400) == '23:59:60'
 
-        # Check overflow to next day
-        self.assertEqual(format_day_sec(60, 86399  ), '2000-03-01T23:59:59')
-        self.assertEqual(format_day_sec(60, 86399.9), '2000-03-02T00:00:00')
+    # Check if hms_format_from_sec end with 86409
+    assert hms_format_from_sec(86409) == '23:59:69'
 
-        results = format_day_sec(60, np.arange(86399, 86400, 0.25))
-        self.assertEqual(results[0], '2000-03-01T23:59:59')
-        self.assertEqual(results[1], '2000-03-01T23:59:59')
-        self.assertEqual(results[2], '2000-03-02T00:00:00')
-        self.assertEqual(results[3], '2000-03-02T00:00:00')
+    # Check if hms_format_from_sec returns the correct format.
+    assert hms_format_from_sec(0.) == '00:00:00'
+    assert hms_format_from_sec(0., digits=3) == '00:00:00.000'
+    assert hms_format_from_sec(0., digits=3, suffix='Z') == '00:00:00.000Z'
 
-        # Check leap seconds
-        days = day_from_ymd([1973, 2016, 2018], 12, 31)
-        results = format_day_sec(days, 86400)
-        self.assertEqual(results[0], '1973-12-31T23:59:60')
-        self.assertEqual(results[1], '2016-12-31T23:59:60')
-        self.assertEqual(results[2], '2019-01-01T00:00:00')
+    # Check if hms_format_from_sec accepts seconds over 86410
+    with pytest.raises(JVF):
+        hms_format_from_sec(86411)
 
-        result = format_day_sec(days[0], 86400)
-        self.assertEqual(result, '1973-12-31T23:59:60')
+    # Errors
+    with pytest.raises(ValueError):
+        format_sec(0, kind='X')
+    with pytest.raises(ValueError):
+        format_sec(0, buffer=np.empty((3,), dtype='int'))
+    with pytest.raises(ValueError):
+        format_sec([[0,0],[0,0]], buffer=np.empty((3,3), dtype='U40'))
 
-        results = format_day_sec(days, 86400.96, digits=2)
-        self.assertEqual(results[0], '1973-12-31T23:59:60.96')
-        self.assertEqual(results[1], '2016-12-31T23:59:60.96')
-        self.assertEqual(results[2], '2019-01-01T00:00:00.96')
+def test_format_day_sec():
 
-        result = format_day_sec(days[2], 86400.96, digits=2)
-        self.assertEqual(result, '2019-01-01T00:00:00.96')
+    for dkey, d_answers in DAY_ANSWERS.items():
+      (day_order, ydigits, dash, proleptic) = dkey
 
-        results = format_day_sec(days, 86400.96, digits=1)
-        self.assertEqual(results[0], '1974-01-01T00:00:00.0')
-        self.assertEqual(results[1], '2017-01-01T00:00:00.0')
-        self.assertEqual(results[2], '2019-01-01T00:00:01.0')
+      for tkey, t_answers in TIME_ANSWERS.items():
+        (colon, suffix) = tkey
 
-        result = format_day_sec(days[1], 86400.96, digits=1)
-        self.assertEqual(result, '2017-01-01T00:00:00.0')
+      for sep in ('T', ' ', '', '///'):
+        for tbefore in (True, False):
+            if tbefore:
+                answers = [t_answers[k] + sep + d_answers[k] for k in range(2)]
+                order = 'T' + day_order
+            else:
+                answers = [d_answers[k] + sep + t_answers[k] for k in range(2)]
+                order = day_order + 'T'
 
-        # Errors
-        self.assertRaises(ValueError, format_day_sec, 0, 0., order='YMD')
-        self.assertRaises(ValueError, format_day_sec, 0, 0., kind='X')
-        self.assertRaises(ValueError, format_day_sec, 0, 0.,
-                                                      buffer=np.empty((3,), dtype='int'))
-        self.assertRaises(ValueError, format_day_sec, [[0,0],[0,0]], 0.,
-                                                      buffer=np.empty((3,3), dtype='U40'))
+            # kind = "U", shape = (3,), buffer=None
+            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                     order=order, ydigits=ydigits, dash=dash,
+                                     proleptic=proleptic, sep=sep, colon=colon,
+                                     suffix=suffix)
+            for k in range(2):
+                assert answers[k] == results[k]
+
+            # kind = "U", shape = (), buffer=None
+            for k in range(2):
+                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                        order=order, ydigits=ydigits, dash=dash,
+                                        proleptic=proleptic, sep=sep, colon=colon,
+                                        suffix=suffix)
+                assert answers[k] == result
+
+            # kind = "S", shape = (3,), buffer=None
+            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                     order=order, ydigits=ydigits, dash=dash,
+                                     proleptic=proleptic, sep=sep, colon=colon,
+                                     suffix=suffix, kind='S')
+            for k in range(2):
+                assert answers[k].encode('latin8') == results[k]
+
+            # kind = "S", shape = (), buffer=None
+            for k in range(2):
+                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                        order=order, ydigits=ydigits, dash=dash,
+                                        proleptic=proleptic, sep=sep, colon=colon,
+                                        suffix=suffix, kind='S')
+                assert answers[k].encode('latin8') == result
+
+            # kind = "U", shape = (3,), buffer provided
+            buffer = np.empty((4,), dtype='=U50')
+            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                     order=order, ydigits=ydigits, dash=dash,
+                                     proleptic=proleptic, sep=sep, colon=colon,
+                                     suffix=suffix, buffer=buffer)
+            assert results is buffer
+            for k in range(2):
+                assert answers[k] == buffer[k]
+            assert buffer[2] == ''
+
+            # kind = "U", shape = (), buffer provided
+            for k in range(2):
+                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                        order=order, ydigits=ydigits, dash=dash,
+                                        proleptic=proleptic, sep=sep, colon=colon,
+                                        suffix=suffix, buffer=buffer)
+                assert result is buffer
+                assert answers[k] == result[k]
+
+            # kind = "S", shape = (3,), buffer provided
+            buffer = np.empty((4,), dtype='|S50')
+            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                     order=order, ydigits=ydigits, dash=dash,
+                                     proleptic=proleptic, sep=sep, colon=colon,
+                                     suffix=suffix, buffer=buffer)
+            assert results is buffer
+            for k in range(2):
+                assert answers[k].encode('latin8') == buffer[k]
+            assert buffer[2] == b''
+
+            # kind = "S", shape = (), buffer provided
+            for k in range(2):
+                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                        order=order, ydigits=ydigits, dash=dash,
+                                        proleptic=proleptic, sep=sep, colon=colon,
+                                        suffix=suffix, buffer=buffer)
+                assert result is buffer
+                assert answers[k].encode('latin8') == result[k]
+
+            # shape = (3,), buffer too small
+            for buffer in [np.empty((1,), dtype='=U50'),
+                           np.empty((1,), dtype='|S50')]:
+                with pytest.raises(ValueError):
+                    format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                   order=order, ydigits=ydigits, dash=dash,
+                                   proleptic=proleptic, sep=sep, colon=colon,
+                                   suffix=suffix, buffer=buffer)
+
+            for buffer in [np.empty((4,), dtype='=U4'),
+                           np.empty((4,), dtype='|S4')]:
+                with pytest.raises(ValueError):
+                    format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                   order=order, ydigits=ydigits, dash=dash,
+                                   proleptic=proleptic, sep=sep, colon=colon,
+                                   suffix=suffix, buffer=buffer)
+
+            # shape = (), buffer too small
+            for buffer in [np.empty((4,), dtype='=U4'),
+                           np.empty((4,), dtype='|S4')]:
+                with pytest.raises(ValueError):
+                    format_day_sec(DAY_TESTS[0], TIME_TESTS[0],
+                                   order=order, ydigits=ydigits, dash=dash,
+                                   proleptic=proleptic, colon=colon, suffix=suffix,
+                                   buffer=buffer)
+
+        # Check a case with the exact right buffer size so no "extra"
+        result = format_day_sec(0, 43201, buffer=None)
+        assert result == '2000-01-01T12:00:01'
+
+        for l in (len(result), len(result)+1):
+            result = format_day_sec(0, 43201, buffer=np.empty((), 'U' + str(l)))
+            assert result == '2000-01-01T12:00:01'
+
+            result = format_day_sec(0, 43201, buffer=np.empty((), 'S' + str(l)))
+            assert result == b'2000-01-01T12:00:01'
+
+    # old tests...
+
+    # Check if ymdhms_format_from_day_sec returns the correct format.
+    assert ymdhms_format_from_day_sec(0, 0) == '2000-01-01T00:00:00'
+    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3)
+            == '2000-01-01T00:00:00.000')
+    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3, suffix='Z')
+            == '2000-01-01T00:00:00.000Z')
+    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None)
+            == '2000-01-01T00:00:00')
+    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None, suffix='Z')
+            == '2000-01-01T00:00:00Z')
+    assert (ydhms_format_from_day_sec(0, 0, sep='T', digits=None,
+                                            suffix='Z', kind='S')
+            == b'2000-001T00:00:00Z')
+
+    assert (ymdhms_format_from_tai(32 - 43200)
+            == '2000-01-01T00:00:00')
+    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3)
+            == '2000-01-01T00:00:00.000')
+    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3, suffix='Z')
+            == '2000-01-01T00:00:00.000Z')
+    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None)
+            == '2000-01-01T00:00:00')
+    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None, suffix='Z')
+            == '2000-01-01T00:00:00Z')
+    assert (ydhms_format_from_tai(32 - 43200, sep='T', digits=None,
+                                                     suffix='Z', kind='S')
+            == b'2000-001T00:00:00Z')
+    assert (iso_from_tai(23456789012.345, ymd=True, digits=3, suffix='Z')
+            == ymdhms_format_from_tai(23456789012.345, digits=3, suffix='Z'))
+    assert (iso_from_tai(-23456789012.345, ymd=False, digits=3, suffix='Z')
+            == ydhms_format_from_tai(-23456789012.345, digits=3, suffix='Z'))
+
+    ymdhms = ymdhms_format_from_day_sec([0,366],[0,43200])
+    assert np.all(ymdhms == ('2000-01-01T00:00:00', '2001-01-01T12:00:00'))
+
+    # Check TAI formatting
+    # The 32's below are for the offset between TAI and UTC
+    assert np.all(ydhms_format_from_tai([32.-43200,366.*86400.+32.-43200])
+                           == ('2000-001T00:00:00', '2001-001T00:00:00'))
+
+    # Buffers
+    answer = np.array(['1999-001', '2000-001', '2001-001'])
+    buffer = np.empty(answer.shape, answer.dtype)
+    result = yd_format_from_day([-365,0,366], buffer=buffer)
+    assert result is buffer
+
+    # Check overflow to next day
+    assert format_day_sec(60, 86399  ) == '2000-03-01T23:59:59'
+    assert format_day_sec(60, 86399.9) == '2000-03-02T00:00:00'
+
+    results = format_day_sec(60, np.arange(86399, 86400, 0.25))
+    assert results[0] == '2000-03-01T23:59:59'
+    assert results[1] == '2000-03-01T23:59:59'
+    assert results[2] == '2000-03-02T00:00:00'
+    assert results[3] == '2000-03-02T00:00:00'
+
+    # Check leap seconds
+    days = day_from_ymd([1973, 2016, 2018], 12, 31)
+    results = format_day_sec(days, 86400)
+    assert results[0] == '1973-12-31T23:59:60'
+    assert results[1] == '2016-12-31T23:59:60'
+    assert results[2] == '2019-01-01T00:00:00'
+
+    result = format_day_sec(days[0], 86400)
+    assert result == '1973-12-31T23:59:60'
+
+    results = format_day_sec(days, 86400.96, digits=2)
+    assert results[0] == '1973-12-31T23:59:60.96'
+    assert results[1] == '2016-12-31T23:59:60.96'
+    assert results[2] == '2019-01-01T00:00:00.96'
+
+    result = format_day_sec(days[2], 86400.96, digits=2)
+    assert result == '2019-01-01T00:00:00.96'
+
+    results = format_day_sec(days, 86400.96, digits=1)
+    assert results[0] == '1974-01-01T00:00:00.0'
+    assert results[1] == '2017-01-01T00:00:00.0'
+    assert results[2] == '2019-01-01T00:00:01.0'
+
+    result = format_day_sec(days[1], 86400.96, digits=1)
+    assert result == '2017-01-01T00:00:00.0'
+
+    # Errors
+    with pytest.raises(ValueError):
+        format_day_sec(0, 0., order='YMD')
+    with pytest.raises(ValueError):
+        format_day_sec(0, 0., kind='X')
+    with pytest.raises(ValueError):
+        format_day_sec(0, 0., buffer=np.empty((3,), dtype='int'))
+    with pytest.raises(ValueError):
+        format_day_sec([[0,0],[0,0]], 0., buffer=np.empty((3,3), dtype='U40'))
 
 ##########################################################################################

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -516,112 +516,112 @@ def test_format_day_sec():
       for tkey, t_answers in TIME_ANSWERS.items():
         (colon, suffix) = tkey
 
-      for sep in ('T', ' ', '', '///'):
-        for tbefore in (True, False):
-            if tbefore:
-                answers = [t_answers[k] + sep + d_answers[k] for k in range(2)]
-                order = 'T' + day_order
-            else:
-                answers = [d_answers[k] + sep + t_answers[k] for k in range(2)]
-                order = day_order + 'T'
+        for sep in ('T', ' ', '', '///'):
+          for tbefore in (True, False):
+              if tbefore:
+                  answers = [t_answers[k] + sep + d_answers[k] for k in range(2)]
+                  order = 'T' + day_order
+              else:
+                  answers = [d_answers[k] + sep + t_answers[k] for k in range(2)]
+                  order = day_order + 'T'
 
-            # kind = "U", shape = (3,), buffer=None
-            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                     order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, sep=sep, colon=colon,
-                                     suffix=suffix)
-            for k in range(2):
-                assert answers[k] == results[k]
+              # kind = "U", shape = (3,), buffer=None
+              results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                       order=order, ydigits=ydigits, dash=dash,
+                                       proleptic=proleptic, sep=sep, colon=colon,
+                                       suffix=suffix)
+              for k in range(2):
+                  assert answers[k] == results[k]
 
-            # kind = "U", shape = (), buffer=None
-            for k in range(2):
-                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                        order=order, ydigits=ydigits, dash=dash,
-                                        proleptic=proleptic, sep=sep, colon=colon,
-                                        suffix=suffix)
-                assert answers[k] == result
+              # kind = "U", shape = (), buffer=None
+              for k in range(2):
+                  result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                          order=order, ydigits=ydigits, dash=dash,
+                                          proleptic=proleptic, sep=sep, colon=colon,
+                                          suffix=suffix)
+                  assert answers[k] == result
 
-            # kind = "S", shape = (3,), buffer=None
-            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                     order=order, ydigits=ydigits, dash=dash,
-                                     proleptic=proleptic, sep=sep, colon=colon,
-                                     suffix=suffix, kind='S')
-            for k in range(2):
-                assert answers[k].encode('latin8') == results[k]
+              # kind = "S", shape = (3,), buffer=None
+              results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                       order=order, ydigits=ydigits, dash=dash,
+                                       proleptic=proleptic, sep=sep, colon=colon,
+                                       suffix=suffix, kind='S')
+              for k in range(2):
+                  assert answers[k].encode('latin8') == results[k]
 
-            # kind = "S", shape = (), buffer=None
-            for k in range(2):
-                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                        order=order, ydigits=ydigits, dash=dash,
-                                        proleptic=proleptic, sep=sep, colon=colon,
-                                        suffix=suffix, kind='S')
-                assert answers[k].encode('latin8') == result
+              # kind = "S", shape = (), buffer=None
+              for k in range(2):
+                  result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                          order=order, ydigits=ydigits, dash=dash,
+                                          proleptic=proleptic, sep=sep, colon=colon,
+                                          suffix=suffix, kind='S')
+                  assert answers[k].encode('latin8') == result
 
-            # kind = "U", shape = (3,), buffer provided
-            buffer = np.empty((4,), dtype='=U50')
-            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+              # kind = "U", shape = (3,), buffer provided
+              buffer = np.empty((4,), dtype='=U50')
+              results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                       order=order, ydigits=ydigits, dash=dash,
+                                       proleptic=proleptic, sep=sep, colon=colon,
+                                       suffix=suffix, buffer=buffer)
+              assert results is buffer
+              for k in range(2):
+                  assert answers[k] == buffer[k]
+              assert buffer[2] == ''
+
+              # kind = "U", shape = (), buffer provided
+              for k in range(2):
+                  result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                          order=order, ydigits=ydigits, dash=dash,
+                                          proleptic=proleptic, sep=sep, colon=colon,
+                                          suffix=suffix, buffer=buffer)
+                  assert result is buffer
+                  assert answers[k] == result[k]
+
+              # kind = "S", shape = (3,), buffer provided
+              buffer = np.empty((4,), dtype='|S50')
+              results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+                                       order=order, ydigits=ydigits, dash=dash,
+                                       proleptic=proleptic, sep=sep, colon=colon,
+                                       suffix=suffix, buffer=buffer)
+              assert results is buffer
+              for k in range(2):
+                  assert answers[k].encode('latin8') == buffer[k]
+              assert buffer[2] == b''
+
+              # kind = "S", shape = (), buffer provided
+              for k in range(2):
+                  result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
+                                          order=order, ydigits=ydigits, dash=dash,
+                                          proleptic=proleptic, sep=sep, colon=colon,
+                                          suffix=suffix, buffer=buffer)
+                  assert result is buffer
+                  assert answers[k].encode('latin8') == result[k]
+
+              # shape = (3,), buffer too small
+              for buffer in [np.empty((1,), dtype='=U50'),
+                             np.empty((1,), dtype='|S50')]:
+                  with pytest.raises(ValueError):
+                      format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
                                      order=order, ydigits=ydigits, dash=dash,
                                      proleptic=proleptic, sep=sep, colon=colon,
                                      suffix=suffix, buffer=buffer)
-            assert results is buffer
-            for k in range(2):
-                assert answers[k] == buffer[k]
-            assert buffer[2] == ''
 
-            # kind = "U", shape = (), buffer provided
-            for k in range(2):
-                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                        order=order, ydigits=ydigits, dash=dash,
-                                        proleptic=proleptic, sep=sep, colon=colon,
-                                        suffix=suffix, buffer=buffer)
-                assert result is buffer
-                assert answers[k] == result[k]
-
-            # kind = "S", shape = (3,), buffer provided
-            buffer = np.empty((4,), dtype='|S50')
-            results = format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
+              for buffer in [np.empty((4,), dtype='=U4'),
+                             np.empty((4,), dtype='|S4')]:
+                  with pytest.raises(ValueError):
+                      format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
                                      order=order, ydigits=ydigits, dash=dash,
                                      proleptic=proleptic, sep=sep, colon=colon,
                                      suffix=suffix, buffer=buffer)
-            assert results is buffer
-            for k in range(2):
-                assert answers[k].encode('latin8') == buffer[k]
-            assert buffer[2] == b''
 
-            # kind = "S", shape = (), buffer provided
-            for k in range(2):
-                result = format_day_sec(DAY_TESTS[k], TIME_TESTS[k],
-                                        order=order, ydigits=ydigits, dash=dash,
-                                        proleptic=proleptic, sep=sep, colon=colon,
-                                        suffix=suffix, buffer=buffer)
-                assert result is buffer
-                assert answers[k].encode('latin8') == result[k]
-
-            # shape = (3,), buffer too small
-            for buffer in [np.empty((1,), dtype='=U50'),
-                           np.empty((1,), dtype='|S50')]:
-                with pytest.raises(ValueError):
-                    format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                   order=order, ydigits=ydigits, dash=dash,
-                                   proleptic=proleptic, sep=sep, colon=colon,
-                                   suffix=suffix, buffer=buffer)
-
-            for buffer in [np.empty((4,), dtype='=U4'),
-                           np.empty((4,), dtype='|S4')]:
-                with pytest.raises(ValueError):
-                    format_day_sec(DAY_TESTS[:2], TIME_TESTS[:2],
-                                   order=order, ydigits=ydigits, dash=dash,
-                                   proleptic=proleptic, sep=sep, colon=colon,
-                                   suffix=suffix, buffer=buffer)
-
-            # shape = (), buffer too small
-            for buffer in [np.empty((4,), dtype='=U4'),
-                           np.empty((4,), dtype='|S4')]:
-                with pytest.raises(ValueError):
-                    format_day_sec(DAY_TESTS[0], TIME_TESTS[0],
-                                   order=order, ydigits=ydigits, dash=dash,
-                                   proleptic=proleptic, colon=colon, suffix=suffix,
-                                   buffer=buffer)
+              # shape = (), buffer too small
+              for buffer in [np.empty((4,), dtype='=U4'),
+                             np.empty((4,), dtype='|S4')]:
+                  with pytest.raises(ValueError):
+                      format_day_sec(DAY_TESTS[0], TIME_TESTS[0],
+                                     order=order, ydigits=ydigits, dash=dash,
+                                     proleptic=proleptic, colon=colon, suffix=suffix,
+                                     buffer=buffer)
 
         # Check a case with the exact right buffer size so no "extra"
         result = format_day_sec(0, 43201, buffer=None)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -209,9 +209,8 @@ FTIME_ANSWERS = {
 }
 
 
+@pytest.mark.filterwarnings('ignore::julian._warnings.JulianDeprecationWarning')
 def test_format_day():
-
-    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
     for key, answers in DAY_ANSWERS.items():
         (order, ydigits, dash, proleptic) = key

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -2,9 +2,12 @@
 # julian/test_formatters.py
 ##########################################################################################
 
+import warnings
+
 import numpy as np
 import pytest
 
+from julian._warnings import JulianDeprecationWarning
 from julian.formatters import (
     format_day,
     format_day_sec,
@@ -483,22 +486,24 @@ def test_format_sec():
             result = format_sec(FTIME_TESTS[k], digits=digits, kind='S')
             assert answers[k].encode('latin8') == result
 
-    # old tests...
+    # old tests (deprecated hms_format_from_sec)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', JulianDeprecationWarning)
 
-    # Check if one day is 86400 seconds
-    assert hms_format_from_sec(86400) == '23:59:60'
+        # Check if one day is 86400 seconds
+        assert hms_format_from_sec(86400) == '23:59:60'
 
-    # Check if hms_format_from_sec end with 86409
-    assert hms_format_from_sec(86409) == '23:59:69'
+        # Check if hms_format_from_sec end with 86409
+        assert hms_format_from_sec(86409) == '23:59:69'
 
-    # Check if hms_format_from_sec returns the correct format.
-    assert hms_format_from_sec(0.) == '00:00:00'
-    assert hms_format_from_sec(0., digits=3) == '00:00:00.000'
-    assert hms_format_from_sec(0., digits=3, suffix='Z') == '00:00:00.000Z'
+        # Check if hms_format_from_sec returns the correct format.
+        assert hms_format_from_sec(0.) == '00:00:00'
+        assert hms_format_from_sec(0., digits=3) == '00:00:00.000'
+        assert hms_format_from_sec(0., digits=3, suffix='Z') == '00:00:00.000Z'
 
-    # Check if hms_format_from_sec accepts seconds over 86410
-    with pytest.raises(JVF):
-        hms_format_from_sec(86411)
+        # Check if hms_format_from_sec accepts seconds over 86410
+        with pytest.raises(JVF):
+            hms_format_from_sec(86411)
 
     # Errors
     with pytest.raises(ValueError):
@@ -634,47 +639,49 @@ def test_format_day_sec():
             result = format_day_sec(0, 43201, buffer=np.empty((), 'S' + str(l)))
             assert result == b'2000-01-01T12:00:01'
 
-    # old tests...
+    # old tests (deprecated ymdhms/ydhms formatters)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=JulianDeprecationWarning)
 
-    # Check if ymdhms_format_from_day_sec returns the correct format.
-    assert ymdhms_format_from_day_sec(0, 0) == '2000-01-01T00:00:00'
-    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3)
-            == '2000-01-01T00:00:00.000')
-    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3, suffix='Z')
-            == '2000-01-01T00:00:00.000Z')
-    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None)
-            == '2000-01-01T00:00:00')
-    assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None, suffix='Z')
-            == '2000-01-01T00:00:00Z')
-    assert (ydhms_format_from_day_sec(0, 0, sep='T', digits=None,
-                                            suffix='Z', kind='S')
-            == b'2000-001T00:00:00Z')
+        # Check if ymdhms_format_from_day_sec returns the correct format.
+        assert ymdhms_format_from_day_sec(0, 0) == '2000-01-01T00:00:00'
+        assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3)
+                == '2000-01-01T00:00:00.000')
+        assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=3, suffix='Z')
+                == '2000-01-01T00:00:00.000Z')
+        assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None)
+                == '2000-01-01T00:00:00')
+        assert (ymdhms_format_from_day_sec(0, 0, sep='T', digits=None, suffix='Z')
+                == '2000-01-01T00:00:00Z')
+        assert (ydhms_format_from_day_sec(0, 0, sep='T', digits=None,
+                                                suffix='Z', kind='S')
+                == b'2000-001T00:00:00Z')
 
-    assert (ymdhms_format_from_tai(32 - 43200)
-            == '2000-01-01T00:00:00')
-    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3)
-            == '2000-01-01T00:00:00.000')
-    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3, suffix='Z')
-            == '2000-01-01T00:00:00.000Z')
-    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None)
-            == '2000-01-01T00:00:00')
-    assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None, suffix='Z')
-            == '2000-01-01T00:00:00Z')
-    assert (ydhms_format_from_tai(32 - 43200, sep='T', digits=None,
-                                                     suffix='Z', kind='S')
-            == b'2000-001T00:00:00Z')
-    assert (iso_from_tai(23456789012.345, ymd=True, digits=3, suffix='Z')
-            == ymdhms_format_from_tai(23456789012.345, digits=3, suffix='Z'))
-    assert (iso_from_tai(-23456789012.345, ymd=False, digits=3, suffix='Z')
-            == ydhms_format_from_tai(-23456789012.345, digits=3, suffix='Z'))
+        assert (ymdhms_format_from_tai(32 - 43200)
+                == '2000-01-01T00:00:00')
+        assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3)
+                == '2000-01-01T00:00:00.000')
+        assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=3, suffix='Z')
+                == '2000-01-01T00:00:00.000Z')
+        assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None)
+                == '2000-01-01T00:00:00')
+        assert (ymdhms_format_from_tai(32 - 43200, sep='T', digits=None, suffix='Z')
+                == '2000-01-01T00:00:00Z')
+        assert (ydhms_format_from_tai(32 - 43200, sep='T', digits=None,
+                                                         suffix='Z', kind='S')
+                == b'2000-001T00:00:00Z')
+        assert (iso_from_tai(23456789012.345, ymd=True, digits=3, suffix='Z')
+                == ymdhms_format_from_tai(23456789012.345, digits=3, suffix='Z'))
+        assert (iso_from_tai(-23456789012.345, ymd=False, digits=3, suffix='Z')
+                == ydhms_format_from_tai(-23456789012.345, digits=3, suffix='Z'))
 
-    ymdhms = ymdhms_format_from_day_sec([0,366],[0,43200])
-    assert np.all(ymdhms == ('2000-01-01T00:00:00', '2001-01-01T12:00:00'))
+        ymdhms = ymdhms_format_from_day_sec([0,366],[0,43200])
+        assert np.all(ymdhms == ('2000-01-01T00:00:00', '2001-01-01T12:00:00'))
 
-    # Check TAI formatting
-    # The 32's below are for the offset between TAI and UTC
-    assert np.all(ydhms_format_from_tai([32.-43200,366.*86400.+32.-43200])
-                           == ('2000-001T00:00:00', '2001-001T00:00:00'))
+        # Check TAI formatting
+        # The 32's below are for the offset between TAI and UTC
+        assert np.all(ydhms_format_from_tai([32.-43200,366.*86400.+32.-43200])
+                               == ('2000-001T00:00:00', '2001-001T00:00:00'))
 
     # Buffers
     answer = np.array(['1999-001', '2000-001', '2001-001'])

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -211,8 +211,6 @@ FTIME_ANSWERS = {
 
 def test_format_day():
 
-    import warnings
-    from julian._warnings import JulianDeprecationWarning
     warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
     for key, answers in DAY_ANSWERS.items():

--- a/tests/test_iso_parsers.py
+++ b/tests/test_iso_parsers.py
@@ -3,7 +3,7 @@
 ##########################################################################################
 
 import numpy as np
-import unittest
+import pytest
 
 from julian.iso_parsers import (
     day_from_iso,
@@ -19,547 +19,629 @@ from julian._exceptions    import JulianParseException as JPE
 from julian._exceptions    import JulianValidateFailure as JVF
 
 
-class Test_iso_parsers(unittest.TestCase):
-
-    def test_day_from_iso(self):
-
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
-
-        # YYYY-MM-DD
-        for x in ('-', ''):
-            self.assertEqual(day_from_iso(f'2001{x}01{x}01'), 366)
-            self.assertEqual(day_from_iso(f'2001{x}01{x}01.'), 366.)
-            self.assertEqual(day_from_iso(f'2001{x}01{x}01.5'), 366.5)
-            self.assertEqual(day_from_iso(f'  2001{x}01{x}01', strip=True), 366)
-            self.assertEqual(day_from_iso(f'  2001{x}01{x}01.5', strip=True), 366.5)
-            self.assertRaises(JPE, day_from_iso, '  2001{x}01{x}01')
-
-            self.assertIs(type(day_from_iso(f'2001{x}01{x}01')),   int)
-            self.assertIs(type(day_from_iso(f'2001{x}01{x}01.')),  float)
-            self.assertIs(type(day_from_iso(f'2001{x}01{x}01.0')), float)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}01']
-            days    = [            -365 ,                0 ,              366 ]
-            self.assertTrue(np.all(day_from_iso(strings) == days))
-
-            strings = [f'  1999{x}01{x}01', f'  2000{x}01{x}01', f'  2001{x}01{x}01']
-            self.assertTrue(np.all(day_from_iso(strings, strip=True) == days))
-            self.assertRaises(JPE, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01  ', f'2000{x}01{x}01  ', f'2001{x}01{x}01  ']
-            self.assertTrue(np.all(day_from_iso(strings, strip=True) == days))
-            self.assertRaises(JPE, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01  ', f'  2000{x}01{x}01', f' 2001{x}01{x}01 ']
-            self.assertRaises(JPE, day_from_iso, strings, strip=False)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}aa']
-            self.assertRaises(JPE, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}aa', f'2000{x}01{x}01', f'2001{x}01{x}01']
-            self.assertRaises(JPE, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x} 1']
-            self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}00']
-            self.assertRaises(JVF, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}00{x}01']
-            self.assertRaises(JVF, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}13{x}01']
-            self.assertRaises(JVF, day_from_iso, strings)
-
-            strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}02{x}29']
-            self.assertRaises(JVF, day_from_iso, strings)
-
-            strings = [[f' 2000{x}01{x}01', f' 2000{x}01{x}02'],
-                       [f' 2000{x}01{x}03', f'x2000{x}01{x}04']]
-            days    = [[                0 ,                 1 ],
-                       [                2 ,                 3 ]]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True,
-                                                syntax=False) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=True, syntax=True)
-
-            strings = [[f'2000{x}01{x}01 ', f'2000{x}01{x}02 '],
-                       [f'2000{x}01{x}03 ', f'2000{x}01{x}04x']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True,
-                                   syntax=False) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=True, syntax=True)
-
-            self.assertRaises(JVF, day_from_iso, f'2000{x}02{x}30', validate=True)
-            self.assertRaises(JVF, day_from_iso, f'2001{x}02{x}29', validate=True)
-
-        strings = ['1999-01-01', '2000-01-01', '2001-01+01']
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        strings = ['1999-01-01', '2000+01-01', '2001-01-01']
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        strings = ['1999-01-01', '2000-01-01', '2001-01 01']
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        strings = ['1999-01-01', '2000-01-01', '2001-01--1']
-        self.assertRaises(JVF, day_from_iso, strings, validate=True)
-
-        strings = [b'2000-01-01\0', b'2001-01-01\0']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=True) == [0, 366]))
-
-        strings = [b'2000-01-01\0', b'2001-01-01x']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=False) == [0, 366]))
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        strings = [b'20000101\0', b'20010101\0']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=True) == [0, 366]))
-
-        strings = [b'20000101\0', b'20010101x']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=False) == [0, 366]))
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        # YYYY-DDD
-        for x in ('-', ''):
-            strings = [[f'2000{x}001', f'2000{x}002'], [f'2000{x}003', f'2000{x}004']]
-            days    = [[           0 ,            1 ], [           2 ,            3 ]]
-            self.assertTrue(np.all(day_from_iso(strings) == days))
-
-            strings = [[f' 2000{x}001', f' 2000{x}002'], [f' 2000{x}003', f' 2000{x}004']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=False)
-
-            strings = [[f'2000{x}001 ', f'2000{x}002 '],
-                       [f'2000{x}003 ', f'2000{x}004 ']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=False)
-
-            strings = [[f' 2000{x}001 ', f' 2000{x}002 '],
-                       [f' 2000{x}003 ', f' 2000{x}004 ']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=False)
-
-            strings = [[f' 2000{x}001', f' 2000{x}002'],
-                       [f' 2000{x}003', f'x2000{x}004']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True,
-                                                syntax=False) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=True, syntax=True)
-
-            strings = [[f'2000{x}001 ', f'2000{x}002 '],
-                       [f'2000{x}003 ', f'2000{x}004x']]
-            self.assertTrue(np.all(day_from_iso(strings, strip=True,
-                                                syntax=False) == days))
-            self.assertRaises(JPE, day_from_iso, strings, strip=True, syntax=True)
-
-            self.assertRaises(JVF, day_from_iso, f'2000{x}000', validate=True)
-            self.assertRaises(JVF, day_from_iso, f'2000{x}367', validate=True)
-
-        self.assertRaises(JPE, day_from_iso, '2000+001', syntax=True)
-
-        strings = [b'2000-001\0', b'2001-001\0']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=True) == [0, 366]))
-
-        strings = [b'2000-001\0', b'2001-001x']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=False) == [0, 366]))
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        strings = [b'2000001\0', b'2001001\0']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=True) == [0, 366]))
-
-        strings = [b'2000001\0', b'2001001x']
-        self.assertTrue(np.all(day_from_iso(strings, syntax=False) == [0, 366]))
-        self.assertRaises(JPE, day_from_iso, strings, syntax=True)
-
-        self.assertRaises(JPE, day_from_iso, ['2010-01-01', '2010-01- 1'], syntax=True)
-        self.assertRaises(JPE, day_from_iso, ['20100201', '201002-1'], syntax=True)
-        self.assertRaises(JPE, day_from_iso, '2020-01-01-01')
-
-        self.assertEqual(day_from_iso('1500-01-01', proleptic=True),  -182621)
-        self.assertEqual(day_from_iso('1500-01-01', proleptic=False), -182612)
-
-        # Fractional day
-        self.assertEqual(day_from_iso('2000-01-31.25'), 30.25)
-        self.assertIs(type(day_from_iso('2000-01-31.25')), float)
-
-        self.assertEqual(list(day_from_iso(['2000-01-31.25', '2000-01-31.75'])),
-                         [30.25, 30.75])
-
-    def test_sec_from_iso(self):
-
-        for c in (':', ''):
-            self.assertEqual(sec_from_iso(f'01{c}00{c}00'),     3600)
-            self.assertEqual(sec_from_iso(f'23{c}59{c}60'),    86400)
-            self.assertEqual(sec_from_iso(f'23{c}59{c}69'),    86409)
-            self.assertEqual(sec_from_iso(f'23{c}59{c}69Z'),   86409)
-            self.assertEqual(sec_from_iso(f'23{c}59{c}69.10'), 86409.10)
-            self.assertEqual(sec_from_iso(f'23{c}59{c}69.5Z'), 86409.5)
-            self.assertEqual(sec_from_iso(f'12{c}00'),         43200)
-            self.assertEqual(sec_from_iso(f'12{c}01.5'),       43290)
-            self.assertIs(type(sec_from_iso(f'01{c}00{c}00')),   int)
-            self.assertIs(type(sec_from_iso(f'01{c}00{c}00.')),  float)
-            self.assertIs(type(sec_from_iso(f'01{c}00{c}00.0')), float)
-
-            strings = [f'00{c}00{c}00', f'00{c}01{c}00', f'00{c}02{c}00']
-            secs    = [             0 ,             60 ,            120 ]
-            self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-            strings = [f' 00{c}00{c}00', f' 00{c}01{c}00', f' 00{c}02{c}00']
-            self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-            self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-            strings = [f' 00{c}00{c}00  ', f' 00{c}01{c}00  ', f' 00{c}02{c}00  ']
-            self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-            self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-            strings = [f'00{c}00{c}00    ', f'00{c}01{c}00    ', f'00{c}02{c}00    ']
-            self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-            self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-            strings = [f'00{c}00{c}00    ', f'00{c}01{c}00    ', f'00{c}02{c}00   x']
-            self.assertTrue(np.all(sec_from_iso(strings, strip=True,
-                                                validate=False) == secs))
-            self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-            strings = [f' 00{c}00{c}00', f' 00{c}01{c}00', f'x00{c}02{c}00']
-            self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-            strings = [[f'00{c}02{c}00Z', f'00{c}04{c}00Z'],
-                       [f'00{c}06{c}00Z', f'00{c}08{c}01Z']]
-            secs    = [[           120  ,            240  ],
-                       [            360 ,             481 ]]
-            self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-            strings = [[f'00{c}02{c}00Z', f'00{c}04{c}00Z'],
-                      [f'00{c}06{c}00Z', f'00{c}08{c}01 ']]
-            secs    = [[           120  ,            240  ],
-                      [            360 ,             481 ]]
-            self.assertTrue(np.all(sec_from_iso(strings, validate=False) == secs))
-            self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'23{c}59{c}69.03']
-            secs    = [             0.01 ,             60.02 ,          86409.03 ]
-            self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-            self.assertEqual(sec_from_iso(f'00{c}00{c}69', validate=False), 69)
-            self.assertRaises(JVF, sec_from_iso, f'00{c}00{c}69', validate=True)
-            self.assertRaises(JVF, sec_from_iso, f'24{c}00{c}00', validate=True)
-            self.assertRaises(JVF, sec_from_iso, f'00{c}60{c}00', validate=True)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}02{c} 0.03']
-            self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-            strings = [f'00{c}02{c}00.1Z', f'00{c}04{c}00.2Z', f'00{c}06{c}00.3z']
-            self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'-0{c}02{c}00.03']
-            self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'24{c}02{c}00.03']
-            self.assertRaises(JVF, sec_from_iso, strings)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}60{c}00.03']
-            self.assertRaises(JVF, sec_from_iso, strings)
-
-            strings = [f'00{c}00{c}00', f'00{c}01{c}00', f'00{c}00{c}70']
-            self.assertRaises(JVF, sec_from_iso, strings)
-
-            strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}00{c}69.00']
-            self.assertRaises(JVF, sec_from_iso, strings)
-
-        strings = ['00:00:00.01', '00:01:00.02', '00:02+00.03']
-        self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-        strings = ['00:00:00.01', '00:01:00.02', '00:02:00+03']
-        self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-        self.assertEqual(sec_from_iso('12.5'), 43200 + 1800)
-
-        # bytes, colons
-        self.assertEqual(sec_from_iso(b'01:00:00'),     3600)
-        self.assertEqual(sec_from_iso(b'23:59:60'),    86400)
-        self.assertEqual(sec_from_iso(b'23:59:69'),    86409)
-        self.assertEqual(sec_from_iso(b'23:59:69Z'),   86409)
-        self.assertEqual(sec_from_iso(b'23:59:69.10'), 86409.10)
-        self.assertEqual(sec_from_iso(b'23:59:69.5Z'), 86409.5)
-        self.assertEqual(sec_from_iso(b'12:00'),         43200)
-        self.assertEqual(sec_from_iso(b'12:01.5'),       43290)
-
-        strings = [b'00:00:00', b'00:01:00', b'00:02:00']
-        secs    = [         0 ,         60 ,        120 ]
-        self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-        strings = [b' 00:00:00', b' 00:01:00', b' 00:02:00']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b' 00:00:00  ', b' 00:01:00  ', b' 00:02:00  ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00    ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00   x']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True, validate=False) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 00:00:00', b' 00:01:00', b'x00:02:00']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b'00:00:00', b'00:01:00', b'00:02:00']
-        secs    = [         0 ,         60 ,        120 ]
-        self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-        strings = [b' 00:00:00', b' 00:01:00', b' 00:02:00']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b' 00:00:00  ', b' 00:01:00  ', b' 00:02:00  ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00    ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00   x']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True, validate=False) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 00:00:00', b' 00:01:00', b'x00:02:00']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 00:00:00', b' 00:01:00', b' 00:02-00']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 00:00:00', b' 00-01:00', b' 00:02:00']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        # bytes, no colons
-        self.assertEqual(sec_from_iso(b'010000'),     3600)
-        self.assertEqual(sec_from_iso(b'235960'),    86400)
-        self.assertEqual(sec_from_iso(b'235969'),    86409)
-        self.assertEqual(sec_from_iso(b'235969Z'),   86409)
-        self.assertEqual(sec_from_iso(b'235969.10'), 86409.10)
-        self.assertEqual(sec_from_iso(b'235969.5Z'), 86409.5)
-        self.assertEqual(sec_from_iso(b'1200'),         43200)
-        self.assertEqual(sec_from_iso(b'1201.5'),       43290)
-
-        strings = [b'000000', b'000100', b'000200']
-        secs    = [       0 ,       60 ,      120 ]
-        self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-        strings = [b' 000000', b' 000100', b' 000200']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b' 000000  ', b' 000100  ', b' 000200  ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'000000    ', b'000100    ', b'000200    ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'000000    ', b'000100    ', b'000200   x']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True, validate=False) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 000000', b' 000100', b'x000200']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b'000000', b'000100', b'000200']
-        secs    = [       0 ,       60 ,      120 ]
-        self.assertTrue(np.all(sec_from_iso(strings) == secs))
-
-        strings = [b' 000000', b' 000100', b' 000200']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b' 000000  ', b' 000100  ', b' 000200  ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'000000    ', b'000100    ', b'000200    ']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        strings = [b'000000    ', b'000100    ', b'000200   x']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True, validate=False) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        strings = [b' 000000', b' 000100', b'x000200']
-        self.assertRaises(JPE, sec_from_iso, strings, strip=True, syntax=True)
-
-        # bytes, no colons, with nulls
-        self.assertEqual(sec_from_iso(b'010000\0'),     3600)
-        self.assertEqual(sec_from_iso(b'235960\0'),    86400)
-        self.assertEqual(sec_from_iso(b'235969\0'),    86409)
-        self.assertEqual(sec_from_iso(b'235969Z\0'),   86409)
-        self.assertEqual(sec_from_iso(b'235969.10\0'), 86409.10)
-        self.assertEqual(sec_from_iso(b'235969.5Z\0'), 86409.5)
-        self.assertEqual(sec_from_iso(b'1200\0'),      43200)
-        self.assertEqual(sec_from_iso(b'1201.5\0'),    43290)
-
-        strings = [b'000000\0', b'000100\0', b'000200\0']
-        secs    = [         0 ,         60 ,        120 ]
-        self.assertTrue(np.all(sec_from_iso(strings, syntax=False) == secs))
-        self.assertTrue(np.all(sec_from_iso(strings, syntax=True) == secs))
-
-        strings = [b'000000\0', b'000100\0', b'000200q']
-        secs    = [         0 ,         60 ,       120 ]
-        self.assertTrue(np.all(sec_from_iso(strings, syntax=False) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, syntax=True)
-
-        strings = [b' 000000\0', b' 000100\0', b' 000200\0']
-        self.assertTrue(np.all(sec_from_iso(strings, strip=True) == secs))
-        self.assertRaises(JPE, sec_from_iso, strings, strip=False)
-
-        # Errors
-        self.assertRaises(JPE, sec_from_iso, '12:34:56:78')
-        self.assertRaises(JPE, sec_from_iso, '12:34.:56.78')
-        self.assertRaises(JPE, sec_from_iso, '12:34.:56')
-        self.assertRaises(JPE, sec_from_iso, '12:34:5.6')
-        self.assertRaises(JPE, sec_from_iso, '12345.6')
-        self.assertRaises(JPE, sec_from_iso, '12:3.:56')
-        self.assertRaises(JPE, sec_from_iso, ['12:34:56:78 ', '12:34:56:78'])
-        self.assertRaises(JPE, sec_from_iso, ['12:34.:56.78', '12:34.:56.78'])
-        self.assertRaises(JPE, sec_from_iso, ['12:34.:56'   , '12:34.:56'])
-        self.assertRaises(JPE, sec_from_iso, ['12:34:5.6'   , '12:34:5.6'])
-        self.assertRaises(JPE, sec_from_iso, ['12:34:56'    , '12:34:5a'])
-
-    def test_day_sec_from_iso(self):
-
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
-
-        self.assertEqual(day_sec_from_iso('2001-01-01'), (366, 0))
-        self.assertEqual(day_sec_from_iso('2001-01-01  ', strip=True), (366, 0))
-        self.assertEqual(day_sec_from_iso(' 2001-01-01 ', strip=True), (366, 0))
-        self.assertEqual(day_sec_from_iso('2001-01-01 01:00:00'), (366, 3600))
-        self.assertEqual(day_sec_from_iso('2001-01-01T01:00:00'), (366, 3600))
-        self.assertEqual(day_sec_from_iso('1998-12-31 23:59:60'), (-366, 86400))
-        self.assertEqual(day_sec_from_iso('  1998-12-31 23:59:60 ', strip=True),
-                         (-366, 86400))
-        self.assertEqual(day_sec_from_iso('2001-01-01.5'), (366.5, 0))
-
-        self.assertIs(type(day_sec_from_iso('2001-01-01')[0]), int)
-        self.assertIs(type(day_sec_from_iso('2001-01-01')[1]), int)
-        self.assertIs(type(day_sec_from_iso('2001-01-01 01:00:00')[0]), int)
-        self.assertIs(type(day_sec_from_iso('2001-01-01 01:00:00')[1]), int)
-        self.assertIs(type(day_sec_from_iso('2001-01-01 01:00:00.')[0]), int)
-        self.assertIs(type(day_sec_from_iso('2001-01-01 01:00:00.')[1]), float)
-        self.assertIs(type(day_sec_from_iso('2001-01-01.5')[0]), float)
-        self.assertIs(type(day_sec_from_iso('2001-01-01.5')[1]), int)
-
-        self.assertRaises(JVF, day_sec_from_iso, '2000-01-01 23:59:60')
-        self.assertRaises(JVF, day_sec_from_iso, '1999-12-31 23:59:61')
-
-        for p in (False, True):
-          for s in (False, True):
-            for v in (False, True):
-                strings = ['1999-01-01', '2000-01-01', '2001-01-01']
-                days    = [       -365 ,           0 ,         366 ]
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[0] == days))
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[1] == 0))
-
-                strings = [['2000-001', '2000-002'], ['2000-003', '2000-004']]
-                days    = [[        0 ,         1 ], [        2 ,         3 ]]
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[0] == days))
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[1] == 0))
-
-                strings = ['1998-12-31 23:59:60', '2001-01-01 01:00:01']
-                days    = [       -366          ,         366          ]
-                secs    = [               86400 ,                 3601 ]
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[0] == days))
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[1] == secs))
-
-                strings = ['1998-12-31T23:59:60', '2001-01-01T01:00:01']
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[0] == days))
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=s,
-                                                        proleptic=p)[1] == secs))
-
-                strings = ['1998-12-31 23:59:60Z', '2001-01-01x01:00:01Z']
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=False,
-                                                        proleptic=p)[0] == days))
-                self.assertTrue(np.all(day_sec_from_iso(strings, validate=v, syntax=False,
-                                                        proleptic=p)[1] == secs))
-                self.assertRaises(JPE, day_sec_from_iso, strings, validate=v, syntax=True,
-                                                         proleptic=p)
-
-                strings = ['1998-12-31 23:59:60Z', '1998-12-31 23:59:61Z']
-                self.assertRaises(JVF, day_sec_from_iso, strings, validate=True, syntax=s,
-                                                         proleptic=p)
-
-                self.assertEqual(day_sec_from_iso('1500-01-01T12:00:00', validate=True,
-                                                  syntax=s, proleptic=True),
-                                 (-182621, 43200))
-                self.assertEqual(day_sec_from_iso('1500-01-01T12:00:00', validate=True,
-                                                  syntax=s, proleptic=False),
-                                 (-182612, 43200))
-
-        self.assertEqual(tai_from_iso( '2001-01-01 01:00:00'),
-                         tai_from_day_sec(366, 3600))
-
-    def test_time_from_iso(self):
-
-        self.assertEqual(tai_from_iso( '2001-01-01 01:00:00'),
-                         tai_from_day_sec(366, 3600))
-        self.assertEqual(tai_from_iso( '2001-01-01T01:00:00'),
-                         tai_from_day_sec(366, 3600))
-        self.assertEqual(tai_from_iso('1998-12-31 23:59:60'),
-                         tai_from_day_sec(-366, 86400))
-        self.assertEqual(tai_from_iso('  1998-12-31 23:59:60 ', strip=True),
-                         tai_from_day_sec(-366, 86400))
-
-        pro_tai = tai_from_iso('1500-12-31 00:00:00', proleptic=True)
-        jul_tai = tai_from_iso('1500-12-31 00:00:00', proleptic=False)
-        self.assertEqual(pro_tai, -15747047990)
-        self.assertEqual(jul_tai, -15746183990)
-
-        self.assertEqual(tdb_from_iso( '2001-01-01 01:00:00'),
-                         tdb_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(tdb_from_iso( '2001-01-01T01:00:00'),
-                         tdb_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(tdb_from_iso('1998-12-31 23:59:60'),
-                         tdb_from_tai(tai_from_day_sec(-366, 86400)))
-        self.assertEqual(tdb_from_iso('  1998-12-31 23:59:60 ', strip=True),
-                         tdb_from_tai(tai_from_day_sec(-366, 86400)))
-
-        self.assertEqual(time_from_iso( '2001-01-01 01:00:00'),
-                         tai_from_day_sec(366, 3600))
-        self.assertEqual(time_from_iso( '2001-01-01T01:00:00'),
-                         tai_from_day_sec(366, 3600))
-        self.assertEqual(time_from_iso('1998-12-31 23:59:60'),
-                         tai_from_day_sec(-366, 86400))
-        self.assertEqual(time_from_iso('  1998-12-31 23:59:60 ', strip=True),
-                         tai_from_day_sec(-366, 86400))
-
-        self.assertEqual(time_from_iso( '2001-01-01 01:00:00', timesys='TDB'),
-                         tdb_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(time_from_iso( '2001-01-01T01:00:00', timesys='TDB'),
-                         tdb_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(time_from_iso('1998-12-31 23:59:60', timesys='TDB'),
-                         tdb_from_tai(tai_from_day_sec(-366, 86400)))
-        self.assertEqual(time_from_iso(' 1998-12-31 23:59:60', strip=True, timesys='TDB'),
-                         tdb_from_tai(tai_from_day_sec(-366, 86400)))
-
-        self.assertEqual(time_from_iso( '2001-01-01 01:00:00', timesys='TT'),
-                         tt_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(time_from_iso( '2001-01-01T01:00:00', timesys='TT'),
-                         tt_from_tai(tai_from_day_sec(366, 3600)))
-        self.assertEqual(time_from_iso('1998-12-31 23:59:60', timesys='TT'),
-                         tt_from_tai(tai_from_day_sec(-366, 86400)))
-        self.assertEqual(time_from_iso(' 1998-12-31 23:59:60', strip=True, timesys='TT'),
-                         tt_from_tai(tai_from_day_sec(-366, 86400)))
+def test_day_from_iso():
+
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+
+    # YYYY-MM-DD
+    for x in ('-', ''):
+        assert day_from_iso(f'2001{x}01{x}01') == 366
+        assert day_from_iso(f'2001{x}01{x}01.') == 366.
+        assert day_from_iso(f'2001{x}01{x}01.5') == 366.5
+        assert day_from_iso(f'  2001{x}01{x}01', strip=True) == 366
+        assert day_from_iso(f'  2001{x}01{x}01.5', strip=True) == 366.5
+        with pytest.raises(JPE):
+            day_from_iso('  2001{x}01{x}01')
+
+        assert type(day_from_iso(f'2001{x}01{x}01')) is int
+        assert type(day_from_iso(f'2001{x}01{x}01.')) is float
+        assert type(day_from_iso(f'2001{x}01{x}01.0')) is float
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}01']
+        days    = [            -365 ,                0 ,              366 ]
+        assert np.all(day_from_iso(strings) == days)
+
+        strings = [f'  1999{x}01{x}01', f'  2000{x}01{x}01', f'  2001{x}01{x}01']
+        assert np.all(day_from_iso(strings, strip=True) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01  ', f'2000{x}01{x}01  ', f'2001{x}01{x}01  ']
+        assert np.all(day_from_iso(strings, strip=True) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01  ', f'  2000{x}01{x}01', f' 2001{x}01{x}01 ']
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=False)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}aa']
+        with pytest.raises(JPE):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}aa', f'2000{x}01{x}01', f'2001{x}01{x}01']
+        with pytest.raises(JPE):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x} 1']
+        with pytest.raises(JPE):
+            day_from_iso(strings, syntax=True)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}01{x}00']
+        with pytest.raises(JVF):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}00{x}01']
+        with pytest.raises(JVF):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}13{x}01']
+        with pytest.raises(JVF):
+            day_from_iso(strings)
+
+        strings = [f'1999{x}01{x}01', f'2000{x}01{x}01', f'2001{x}02{x}29']
+        with pytest.raises(JVF):
+            day_from_iso(strings)
+
+        strings = [[f' 2000{x}01{x}01', f' 2000{x}01{x}02'],
+                   [f' 2000{x}01{x}03', f'x2000{x}01{x}04']]
+        days    = [[                0 ,                 1 ],
+                   [                2 ,                 3 ]]
+        assert np.all(day_from_iso(strings, strip=True, syntax=False) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=True, syntax=True)
+
+        strings = [[f'2000{x}01{x}01 ', f'2000{x}01{x}02 '],
+                   [f'2000{x}01{x}03 ', f'2000{x}01{x}04x']]
+        assert np.all(day_from_iso(strings, strip=True, syntax=False) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=True, syntax=True)
+
+        with pytest.raises(JVF):
+            day_from_iso(f'2000{x}02{x}30', validate=True)
+        with pytest.raises(JVF):
+            day_from_iso(f'2001{x}02{x}29', validate=True)
+
+    strings = ['1999-01-01', '2000-01-01', '2001-01+01']
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    strings = ['1999-01-01', '2000+01-01', '2001-01-01']
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    strings = ['1999-01-01', '2000-01-01', '2001-01 01']
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    strings = ['1999-01-01', '2000-01-01', '2001-01--1']
+    with pytest.raises(JVF):
+        day_from_iso(strings, validate=True)
+
+    strings = [b'2000-01-01\0', b'2001-01-01\0']
+    assert np.all(day_from_iso(strings, syntax=True) == [0, 366])
+
+    strings = [b'2000-01-01\0', b'2001-01-01x']
+    assert np.all(day_from_iso(strings, syntax=False) == [0, 366])
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    strings = [b'20000101\0', b'20010101\0']
+    assert np.all(day_from_iso(strings, syntax=True) == [0, 366])
+
+    strings = [b'20000101\0', b'20010101x']
+    assert np.all(day_from_iso(strings, syntax=False) == [0, 366])
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    # YYYY-DDD
+    for x in ('-', ''):
+        strings = [[f'2000{x}001', f'2000{x}002'], [f'2000{x}003', f'2000{x}004']]
+        days    = [[           0 ,            1 ], [           2 ,            3 ]]
+        assert np.all(day_from_iso(strings) == days)
+
+        strings = [[f' 2000{x}001', f' 2000{x}002'], [f' 2000{x}003', f' 2000{x}004']]
+        assert np.all(day_from_iso(strings, strip=True) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=False)
+
+        strings = [[f'2000{x}001 ', f'2000{x}002 '],
+                   [f'2000{x}003 ', f'2000{x}004 ']]
+        assert np.all(day_from_iso(strings, strip=True) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=False)
+
+        strings = [[f' 2000{x}001 ', f' 2000{x}002 '],
+                   [f' 2000{x}003 ', f' 2000{x}004 ']]
+        assert np.all(day_from_iso(strings, strip=True) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=False)
+
+        strings = [[f' 2000{x}001', f' 2000{x}002'],
+                   [f' 2000{x}003', f'x2000{x}004']]
+        assert np.all(day_from_iso(strings, strip=True, syntax=False) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=True, syntax=True)
+
+        strings = [[f'2000{x}001 ', f'2000{x}002 '],
+                   [f'2000{x}003 ', f'2000{x}004x']]
+        assert np.all(day_from_iso(strings, strip=True, syntax=False) == days)
+        with pytest.raises(JPE):
+            day_from_iso(strings, strip=True, syntax=True)
+
+        with pytest.raises(JVF):
+            day_from_iso(f'2000{x}000', validate=True)
+        with pytest.raises(JVF):
+            day_from_iso(f'2000{x}367', validate=True)
+
+    with pytest.raises(JPE):
+        day_from_iso('2000+001', syntax=True)
+
+    strings = [b'2000-001\0', b'2001-001\0']
+    assert np.all(day_from_iso(strings, syntax=True) == [0, 366])
+
+    strings = [b'2000-001\0', b'2001-001x']
+    assert np.all(day_from_iso(strings, syntax=False) == [0, 366])
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    strings = [b'2000001\0', b'2001001\0']
+    assert np.all(day_from_iso(strings, syntax=True) == [0, 366])
+
+    strings = [b'2000001\0', b'2001001x']
+    assert np.all(day_from_iso(strings, syntax=False) == [0, 366])
+    with pytest.raises(JPE):
+        day_from_iso(strings, syntax=True)
+
+    with pytest.raises(JPE):
+        day_from_iso(['2010-01-01', '2010-01- 1'], syntax=True)
+    with pytest.raises(JPE):
+        day_from_iso(['20100201', '201002-1'], syntax=True)
+    with pytest.raises(JPE):
+        day_from_iso('2020-01-01-01')
+
+    assert day_from_iso('1500-01-01', proleptic=True) == -182621
+    assert day_from_iso('1500-01-01', proleptic=False) == -182612
+
+    # Fractional day
+    assert day_from_iso('2000-01-31.25') == 30.25
+    assert type(day_from_iso('2000-01-31.25')) is float
+
+    assert (list(day_from_iso(['2000-01-31.25', '2000-01-31.75']))
+            == [30.25, 30.75])
+
+def test_sec_from_iso():
+
+    for c in (':', ''):
+        assert sec_from_iso(f'01{c}00{c}00') == 3600
+        assert sec_from_iso(f'23{c}59{c}60') == 86400
+        assert sec_from_iso(f'23{c}59{c}69') == 86409
+        assert sec_from_iso(f'23{c}59{c}69Z') == 86409
+        assert sec_from_iso(f'23{c}59{c}69.10') == 86409.10
+        assert sec_from_iso(f'23{c}59{c}69.5Z') == 86409.5
+        assert sec_from_iso(f'12{c}00') == 43200
+        assert sec_from_iso(f'12{c}01.5') == 43290
+        assert type(sec_from_iso(f'01{c}00{c}00')) is int
+        assert type(sec_from_iso(f'01{c}00{c}00.')) is float
+        assert type(sec_from_iso(f'01{c}00{c}00.0')) is float
+
+        strings = [f'00{c}00{c}00', f'00{c}01{c}00', f'00{c}02{c}00']
+        secs    = [             0 ,             60 ,            120 ]
+        assert np.all(sec_from_iso(strings) == secs)
+
+        strings = [f' 00{c}00{c}00', f' 00{c}01{c}00', f' 00{c}02{c}00']
+        assert np.all(sec_from_iso(strings, strip=True) == secs)
+        with pytest.raises(JPE):
+            sec_from_iso(strings, strip=False)
+
+        strings = [f' 00{c}00{c}00  ', f' 00{c}01{c}00  ', f' 00{c}02{c}00  ']
+        assert np.all(sec_from_iso(strings, strip=True) == secs)
+        with pytest.raises(JPE):
+            sec_from_iso(strings, strip=False)
+
+        strings = [f'00{c}00{c}00    ', f'00{c}01{c}00    ', f'00{c}02{c}00    ']
+        assert np.all(sec_from_iso(strings, strip=True) == secs)
+        with pytest.raises(JPE):
+            sec_from_iso(strings, strip=False)
+
+        strings = [f'00{c}00{c}00    ', f'00{c}01{c}00    ', f'00{c}02{c}00   x']
+        assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
+        with pytest.raises(JPE):
+            sec_from_iso(strings, strip=True, syntax=True)
+
+        strings = [f' 00{c}00{c}00', f' 00{c}01{c}00', f'x00{c}02{c}00']
+        with pytest.raises(JPE):
+            sec_from_iso(strings, strip=True, syntax=True)
+
+        strings = [[f'00{c}02{c}00Z', f'00{c}04{c}00Z'],
+                   [f'00{c}06{c}00Z', f'00{c}08{c}01Z']]
+        secs    = [[           120  ,            240  ],
+                   [            360 ,             481 ]]
+        assert np.all(sec_from_iso(strings) == secs)
+
+        strings = [[f'00{c}02{c}00Z', f'00{c}04{c}00Z'],
+                  [f'00{c}06{c}00Z', f'00{c}08{c}01 ']]
+        secs    = [[           120  ,            240  ],
+                  [            360 ,             481 ]]
+        assert np.all(sec_from_iso(strings, validate=False) == secs)
+        with pytest.raises(JPE):
+            sec_from_iso(strings, syntax=True)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'23{c}59{c}69.03']
+        secs    = [             0.01 ,             60.02 ,          86409.03 ]
+        assert np.all(sec_from_iso(strings) == secs)
+
+        assert sec_from_iso(f'00{c}00{c}69', validate=False) == 69
+        with pytest.raises(JVF):
+            sec_from_iso(f'00{c}00{c}69', validate=True)
+        with pytest.raises(JVF):
+            sec_from_iso(f'24{c}00{c}00', validate=True)
+        with pytest.raises(JVF):
+            sec_from_iso(f'00{c}60{c}00', validate=True)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}02{c} 0.03']
+        with pytest.raises(JPE):
+            sec_from_iso(strings, syntax=True)
+
+        strings = [f'00{c}02{c}00.1Z', f'00{c}04{c}00.2Z', f'00{c}06{c}00.3z']
+        with pytest.raises(JPE):
+            sec_from_iso(strings, syntax=True)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'-0{c}02{c}00.03']
+        with pytest.raises(JPE):
+            sec_from_iso(strings, syntax=True)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'24{c}02{c}00.03']
+        with pytest.raises(JVF):
+            sec_from_iso(strings)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}60{c}00.03']
+        with pytest.raises(JVF):
+            sec_from_iso(strings)
+
+        strings = [f'00{c}00{c}00', f'00{c}01{c}00', f'00{c}00{c}70']
+        with pytest.raises(JVF):
+            sec_from_iso(strings)
+
+        strings = [f'00{c}00{c}00.01', f'00{c}01{c}00.02', f'00{c}00{c}69.00']
+        with pytest.raises(JVF):
+            sec_from_iso(strings)
+
+    strings = ['00:00:00.01', '00:01:00.02', '00:02+00.03']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, syntax=True)
+
+    strings = ['00:00:00.01', '00:01:00.02', '00:02:00+03']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, syntax=True)
+
+    assert sec_from_iso('12.5') == 43200 + 1800
+
+    # bytes, colons
+    assert sec_from_iso(b'01:00:00') == 3600
+    assert sec_from_iso(b'23:59:60') == 86400
+    assert sec_from_iso(b'23:59:69') == 86409
+    assert sec_from_iso(b'23:59:69Z') == 86409
+    assert sec_from_iso(b'23:59:69.10') == 86409.10
+    assert sec_from_iso(b'23:59:69.5Z') == 86409.5
+    assert sec_from_iso(b'12:00') == 43200
+    assert sec_from_iso(b'12:01.5') == 43290
+
+    strings = [b'00:00:00', b'00:01:00', b'00:02:00']
+    secs    = [         0 ,         60 ,        120 ]
+    assert np.all(sec_from_iso(strings) == secs)
+
+    strings = [b' 00:00:00', b' 00:01:00', b' 00:02:00']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b' 00:00:00  ', b' 00:01:00  ', b' 00:02:00  ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00    ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00   x']
+    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 00:00:00', b' 00:01:00', b'x00:02:00']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b'00:00:00', b'00:01:00', b'00:02:00']
+    secs    = [         0 ,         60 ,        120 ]
+    assert np.all(sec_from_iso(strings) == secs)
+
+    strings = [b' 00:00:00', b' 00:01:00', b' 00:02:00']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b' 00:00:00  ', b' 00:01:00  ', b' 00:02:00  ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00    ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00   x']
+    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 00:00:00', b' 00:01:00', b'x00:02:00']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 00:00:00', b' 00:01:00', b' 00:02-00']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 00:00:00', b' 00-01:00', b' 00:02:00']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    # bytes, no colons
+    assert sec_from_iso(b'010000') == 3600
+    assert sec_from_iso(b'235960') == 86400
+    assert sec_from_iso(b'235969') == 86409
+    assert sec_from_iso(b'235969Z') == 86409
+    assert sec_from_iso(b'235969.10') == 86409.10
+    assert sec_from_iso(b'235969.5Z') == 86409.5
+    assert sec_from_iso(b'1200') == 43200
+    assert sec_from_iso(b'1201.5') == 43290
+
+    strings = [b'000000', b'000100', b'000200']
+    secs    = [       0 ,       60 ,      120 ]
+    assert np.all(sec_from_iso(strings) == secs)
+
+    strings = [b' 000000', b' 000100', b' 000200']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b' 000000  ', b' 000100  ', b' 000200  ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'000000    ', b'000100    ', b'000200    ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'000000    ', b'000100    ', b'000200   x']
+    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 000000', b' 000100', b'x000200']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b'000000', b'000100', b'000200']
+    secs    = [       0 ,       60 ,      120 ]
+    assert np.all(sec_from_iso(strings) == secs)
+
+    strings = [b' 000000', b' 000100', b' 000200']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b' 000000  ', b' 000100  ', b' 000200  ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'000000    ', b'000100    ', b'000200    ']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    strings = [b'000000    ', b'000100    ', b'000200   x']
+    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    strings = [b' 000000', b' 000100', b'x000200']
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=True, syntax=True)
+
+    # bytes, no colons, with nulls
+    assert sec_from_iso(b'010000\0') == 3600
+    assert sec_from_iso(b'235960\0') == 86400
+    assert sec_from_iso(b'235969\0') == 86409
+    assert sec_from_iso(b'235969Z\0') == 86409
+    assert sec_from_iso(b'235969.10\0') == 86409.10
+    assert sec_from_iso(b'235969.5Z\0') == 86409.5
+    assert sec_from_iso(b'1200\0') == 43200
+    assert sec_from_iso(b'1201.5\0') == 43290
+
+    strings = [b'000000\0', b'000100\0', b'000200\0']
+    secs    = [         0 ,         60 ,        120 ]
+    assert np.all(sec_from_iso(strings, syntax=False) == secs)
+    assert np.all(sec_from_iso(strings, syntax=True) == secs)
+
+    strings = [b'000000\0', b'000100\0', b'000200q']
+    secs    = [         0 ,         60 ,       120 ]
+    assert np.all(sec_from_iso(strings, syntax=False) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, syntax=True)
+
+    strings = [b' 000000\0', b' 000100\0', b' 000200\0']
+    assert np.all(sec_from_iso(strings, strip=True) == secs)
+    with pytest.raises(JPE):
+        sec_from_iso(strings, strip=False)
+
+    # Errors
+    with pytest.raises(JPE):
+        sec_from_iso('12:34:56:78')
+    with pytest.raises(JPE):
+        sec_from_iso('12:34.:56.78')
+    with pytest.raises(JPE):
+        sec_from_iso('12:34.:56')
+    with pytest.raises(JPE):
+        sec_from_iso('12:34:5.6')
+    with pytest.raises(JPE):
+        sec_from_iso('12345.6')
+    with pytest.raises(JPE):
+        sec_from_iso('12:3.:56')
+    with pytest.raises(JPE):
+        sec_from_iso(['12:34:56:78 ', '12:34:56:78'])
+    with pytest.raises(JPE):
+        sec_from_iso(['12:34.:56.78', '12:34.:56.78'])
+    with pytest.raises(JPE):
+        sec_from_iso(['12:34.:56'   , '12:34.:56'])
+    with pytest.raises(JPE):
+        sec_from_iso(['12:34:5.6'   , '12:34:5.6'])
+    with pytest.raises(JPE):
+        sec_from_iso(['12:34:56'    , '12:34:5a'])
+
+def test_day_sec_from_iso():
+
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+
+    assert day_sec_from_iso('2001-01-01') == (366, 0)
+    assert day_sec_from_iso('2001-01-01  ', strip=True) == (366, 0)
+    assert day_sec_from_iso(' 2001-01-01 ', strip=True) == (366, 0)
+    assert day_sec_from_iso('2001-01-01 01:00:00') == (366, 3600)
+    assert day_sec_from_iso('2001-01-01T01:00:00') == (366, 3600)
+    assert day_sec_from_iso('1998-12-31 23:59:60') == (-366, 86400)
+    assert (day_sec_from_iso('  1998-12-31 23:59:60 ', strip=True)
+            == (-366, 86400))
+    assert day_sec_from_iso('2001-01-01.5') == (366.5, 0)
+
+    assert type(day_sec_from_iso('2001-01-01')[0]) is int
+    assert type(day_sec_from_iso('2001-01-01')[1]) is int
+    assert type(day_sec_from_iso('2001-01-01 01:00:00')[0]) is int
+    assert type(day_sec_from_iso('2001-01-01 01:00:00')[1]) is int
+    assert type(day_sec_from_iso('2001-01-01 01:00:00.')[0]) is int
+    assert type(day_sec_from_iso('2001-01-01 01:00:00.')[1]) is float
+    assert type(day_sec_from_iso('2001-01-01.5')[0]) is float
+    assert type(day_sec_from_iso('2001-01-01.5')[1]) is int
+
+    with pytest.raises(JVF):
+        day_sec_from_iso('2000-01-01 23:59:60')
+    with pytest.raises(JVF):
+        day_sec_from_iso('1999-12-31 23:59:61')
+
+    for p in (False, True):
+      for s in (False, True):
+        for v in (False, True):
+            strings = ['1999-01-01', '2000-01-01', '2001-01-01']
+            days    = [       -365 ,           0 ,         366 ]
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[0] == days)
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[1] == 0)
+
+            strings = [['2000-001', '2000-002'], ['2000-003', '2000-004']]
+            days    = [[        0 ,         1 ], [        2 ,         3 ]]
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[0] == days)
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[1] == 0)
+
+            strings = ['1998-12-31 23:59:60', '2001-01-01 01:00:01']
+            days    = [       -366          ,         366          ]
+            secs    = [               86400 ,                 3601 ]
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[0] == days)
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[1] == secs)
+
+            strings = ['1998-12-31T23:59:60', '2001-01-01T01:00:01']
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[0] == days)
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=s,
+                                                    proleptic=p)[1] == secs)
+
+            strings = ['1998-12-31 23:59:60Z', '2001-01-01x01:00:01Z']
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=False,
+                                                    proleptic=p)[0] == days)
+            assert np.all(day_sec_from_iso(strings, validate=v, syntax=False,
+                                                    proleptic=p)[1] == secs)
+            with pytest.raises(JPE):
+                day_sec_from_iso(strings, validate=v, syntax=True, proleptic=p)
+
+            strings = ['1998-12-31 23:59:60Z', '1998-12-31 23:59:61Z']
+            with pytest.raises(JVF):
+                day_sec_from_iso(strings, validate=True, syntax=s, proleptic=p)
+
+            assert (day_sec_from_iso('1500-01-01T12:00:00', validate=True,
+                                      syntax=s, proleptic=True)
+                    == (-182621, 43200))
+            assert (day_sec_from_iso('1500-01-01T12:00:00', validate=True,
+                                      syntax=s, proleptic=False)
+                    == (-182612, 43200))
+
+    assert (tai_from_iso( '2001-01-01 01:00:00')
+            == tai_from_day_sec(366, 3600))
+
+def test_time_from_iso():
+
+    assert (tai_from_iso( '2001-01-01 01:00:00')
+            == tai_from_day_sec(366, 3600))
+    assert (tai_from_iso( '2001-01-01T01:00:00')
+            == tai_from_day_sec(366, 3600))
+    assert (tai_from_iso('1998-12-31 23:59:60')
+            == tai_from_day_sec(-366, 86400))
+    assert (tai_from_iso('  1998-12-31 23:59:60 ', strip=True)
+            == tai_from_day_sec(-366, 86400))
+
+    pro_tai = tai_from_iso('1500-12-31 00:00:00', proleptic=True)
+    jul_tai = tai_from_iso('1500-12-31 00:00:00', proleptic=False)
+    assert pro_tai == -15747047990
+    assert jul_tai == -15746183990
+
+    assert (tdb_from_iso( '2001-01-01 01:00:00')
+            == tdb_from_tai(tai_from_day_sec(366, 3600)))
+    assert (tdb_from_iso( '2001-01-01T01:00:00')
+            == tdb_from_tai(tai_from_day_sec(366, 3600)))
+    assert (tdb_from_iso('1998-12-31 23:59:60')
+            == tdb_from_tai(tai_from_day_sec(-366, 86400)))
+    assert (tdb_from_iso('  1998-12-31 23:59:60 ', strip=True)
+            == tdb_from_tai(tai_from_day_sec(-366, 86400)))
+
+    assert (time_from_iso( '2001-01-01 01:00:00')
+            == tai_from_day_sec(366, 3600))
+    assert (time_from_iso( '2001-01-01T01:00:00')
+            == tai_from_day_sec(366, 3600))
+    assert (time_from_iso('1998-12-31 23:59:60')
+            == tai_from_day_sec(-366, 86400))
+    assert (time_from_iso('  1998-12-31 23:59:60 ', strip=True)
+            == tai_from_day_sec(-366, 86400))
+
+    assert (time_from_iso( '2001-01-01 01:00:00', timesys='TDB')
+            == tdb_from_tai(tai_from_day_sec(366, 3600)))
+    assert (time_from_iso( '2001-01-01T01:00:00', timesys='TDB')
+            == tdb_from_tai(tai_from_day_sec(366, 3600)))
+    assert (time_from_iso('1998-12-31 23:59:60', timesys='TDB')
+            == tdb_from_tai(tai_from_day_sec(-366, 86400)))
+    assert (time_from_iso(' 1998-12-31 23:59:60', strip=True, timesys='TDB')
+            == tdb_from_tai(tai_from_day_sec(-366, 86400)))
+
+    assert (time_from_iso( '2001-01-01 01:00:00', timesys='TT')
+            == tt_from_tai(tai_from_day_sec(366, 3600)))
+    assert (time_from_iso( '2001-01-01T01:00:00', timesys='TT')
+            == tt_from_tai(tai_from_day_sec(366, 3600)))
+    assert (time_from_iso('1998-12-31 23:59:60', timesys='TT')
+            == tt_from_tai(tai_from_day_sec(-366, 86400)))
+    assert (time_from_iso(' 1998-12-31 23:59:60', strip=True, timesys='TT')
+            == tt_from_tai(tai_from_day_sec(-366, 86400)))
 
 ##########################################################################################

--- a/tests/test_iso_parsers.py
+++ b/tests/test_iso_parsers.py
@@ -33,7 +33,7 @@ def test_day_from_iso():
         assert day_from_iso(f'  2001{x}01{x}01', strip=True) == 366
         assert day_from_iso(f'  2001{x}01{x}01.5', strip=True) == 366.5
         with pytest.raises(JPE):
-            day_from_iso('  2001{x}01{x}01')
+            day_from_iso(f'  2001{x}01{x}01')
 
         assert type(day_from_iso(f'2001{x}01{x}01')) is int
         assert type(day_from_iso(f'2001{x}01{x}01.')) is float
@@ -357,34 +357,6 @@ def test_sec_from_iso():
     with pytest.raises(JPE):
         sec_from_iso(strings, strip=True, syntax=True)
 
-    strings = [b'00:00:00', b'00:01:00', b'00:02:00']
-    secs    = [         0 ,         60 ,        120 ]
-    assert np.all(sec_from_iso(strings) == secs)
-
-    strings = [b' 00:00:00', b' 00:01:00', b' 00:02:00']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b' 00:00:00  ', b' 00:01:00  ', b' 00:02:00  ']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00    ']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b'00:00:00    ', b'00:01:00    ', b'00:02:00   x']
-    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=True, syntax=True)
-
-    strings = [b' 00:00:00', b' 00:01:00', b'x00:02:00']
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=True, syntax=True)
-
     strings = [b' 00:00:00', b' 00:01:00', b' 00:02-00']
     with pytest.raises(JPE):
         sec_from_iso(strings, strip=True, syntax=True)
@@ -402,34 +374,6 @@ def test_sec_from_iso():
     assert sec_from_iso(b'235969.5Z') == 86409.5
     assert sec_from_iso(b'1200') == 43200
     assert sec_from_iso(b'1201.5') == 43290
-
-    strings = [b'000000', b'000100', b'000200']
-    secs    = [       0 ,       60 ,      120 ]
-    assert np.all(sec_from_iso(strings) == secs)
-
-    strings = [b' 000000', b' 000100', b' 000200']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b' 000000  ', b' 000100  ', b' 000200  ']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b'000000    ', b'000100    ', b'000200    ']
-    assert np.all(sec_from_iso(strings, strip=True) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=False)
-
-    strings = [b'000000    ', b'000100    ', b'000200   x']
-    assert np.all(sec_from_iso(strings, strip=True, validate=False) == secs)
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=True, syntax=True)
-
-    strings = [b' 000000', b' 000100', b'x000200']
-    with pytest.raises(JPE):
-        sec_from_iso(strings, strip=True, syntax=True)
 
     strings = [b'000000', b'000100', b'000200']
     secs    = [       0 ,       60 ,      120 ]

--- a/tests/test_leap_seconds.py
+++ b/tests/test_leap_seconds.py
@@ -222,12 +222,15 @@ def test_negative_leap_seconds():
         tai = tai_from_iso('2030-01-01T00:00:00')
         assert tai_from_iso('2029-12-31T23:59:58', validate=True) == tai-1
         assert tai_from_iso('2029-12-31T23:59:59', validate=False) == tai
-        with pytest.raises(JVF): tai_from_iso('2029-12-31T23:59:59', validate=True)
+        with pytest.raises(JVF):
+            tai_from_iso('2029-12-31T23:59:59', validate=True)
 
         tai = tai_from_iso('2031-01-01T00:00:00')
         assert tai_from_iso('2030-12-31T23:59:57', validate=True) == tai-1
-        with pytest.raises(JVF): tai_from_iso('2030-12-31T23:59:58', validate=True)
-        with pytest.raises(JVF): tai_from_iso('2030-12-31T23:59:59', validate=True)
+        with pytest.raises(JVF):
+            tai_from_iso('2030-12-31T23:59:58', validate=True)
+        with pytest.raises(JVF):
+            tai_from_iso('2030-12-31T23:59:59', validate=True)
 
         load_lsk()
 

--- a/tests/test_leap_seconds.py
+++ b/tests/test_leap_seconds.py
@@ -4,7 +4,7 @@
 
 import numbers
 import numpy as np
-import unittest
+import pytest
 
 from julian             import leap_seconds
 from julian.calendar    import day_from_ymd
@@ -25,226 +25,212 @@ from julian.leap_seconds import (
     _delta_t_neg1999_3000,
 )
 
-class Test_leap_seconds(unittest.TestCase):
+def test_leap_seconds():
 
-    def test_leap_seconds(self):
+    set_ut_model('SPICE')
+    assert seconds_on_day(day_from_ymd(1971,12,31), timesys='UTC') == 86401
+    assert seconds_on_day(day_from_ymd(1971,12,31), timesys='TAI') == 86401
+    assert leapsecs_from_ym(1958, 1) == 9
+    assert leapsecs_from_ym(1964, 1) == 9
+    assert leapsecs_from_ym(1971,12) == 9
+    assert leapsecs_from_ym(1972, 1) == 10
+    assert leapsecs_from_ym(2022, 1) == 37
+    assert type(leapsecs_from_ym(1958, 1)) is int
+    assert type(leapsecs_from_ym(1964, 1)) is int
+    assert type(leapsecs_from_ym(1971,12)) is int
+    assert type(leapsecs_from_ym(1972, 1)) is int
+    assert type(leapsecs_from_ym(2022, 1)) is int
+    assert np.all(leapsecs_from_ym([1971, 1964, 1958], 1) == 9)
+    assert leapsecs_from_ym([1971, 1964, 1958], 1).dtype == np.int64
 
-        set_ut_model('SPICE')
-        self.assertEqual(seconds_on_day(day_from_ymd(1971,12,31), timesys='UTC'), 86401)
-        self.assertEqual(seconds_on_day(day_from_ymd(1971,12,31), timesys='TAI'), 86401)
-        self.assertEqual(leapsecs_from_ym(1958, 1), 9)
-        self.assertEqual(leapsecs_from_ym(1964, 1), 9)
-        self.assertEqual(leapsecs_from_ym(1971,12), 9)
-        self.assertEqual(leapsecs_from_ym(1972, 1), 10)
-        self.assertEqual(leapsecs_from_ym(2022, 1), 37)
-        self.assertIs(type(leapsecs_from_ym(1958, 1)), int)
-        self.assertIs(type(leapsecs_from_ym(1964, 1)), int)
-        self.assertIs(type(leapsecs_from_ym(1971,12)), int)
-        self.assertIs(type(leapsecs_from_ym(1972, 1)), int)
-        self.assertIs(type(leapsecs_from_ym(2022, 1)), int)
-        self.assertTrue(np.all(leapsecs_from_ym([1971, 1964, 1958], 1) == 9))
-        self.assertEqual(leapsecs_from_ym([1971, 1964, 1958], 1).dtype, np.int64)
+    assert delta_t_from_ymd(1958, 1) == 9
+    assert delta_t_from_ymd(1964, 1) == 9
+    assert delta_t_from_ymd(1971,12) == 9
+    assert delta_t_from_ymd(1972, 1) == 10
+    assert delta_t_from_ymd(2022, 1) == 37
+    assert np.all(delta_t_from_ymd([1971, 1964, 1958], 1) == 9)
 
-        self.assertEqual(delta_t_from_ymd(1958, 1), 9)
-        self.assertEqual(delta_t_from_ymd(1964, 1), 9)
-        self.assertEqual(delta_t_from_ymd(1971,12), 9)
-        self.assertEqual(delta_t_from_ymd(1972, 1), 10)
-        self.assertEqual(delta_t_from_ymd(2022, 1), 37)
-        self.assertTrue(np.all(delta_t_from_ymd([1971, 1964, 1958], 1) == 9))
+    assert leapsecs_from_day(day_from_ymd(1972, 1, 1)) == 10
+    assert leapsecs_on_day(day_from_ymd(1972, 1, 1)) == 10
+    assert delta_t_from_day(day_from_ymd(1972, 1, 1)) == 10
 
-        self.assertEqual(leapsecs_from_day(day_from_ymd(1972, 1, 1)), 10)
-        self.assertEqual(leapsecs_on_day(day_from_ymd(1972, 1, 1)), 10)
-        self.assertEqual(delta_t_from_day(day_from_ymd(1972, 1, 1)), 10)
+    assert np.all(leapsecs_from_day(
+                            day_from_ymd([1971, 1964, 1958], 1, 1)) == 9)
+    assert np.all(delta_t_from_day(
+                            day_from_ymd([1971, 1964, 1958], 1, 1)) == 9)
 
-        self.assertTrue(np.all(leapsecs_from_day(
-                                day_from_ymd([1971, 1964, 1958], 1, 1)) == 9))
-        self.assertTrue(np.all(delta_t_from_day(
-                                day_from_ymd([1971, 1964, 1958], 1, 1)) == 9))
+    set_ut_model('LEAPS')
+    assert seconds_on_day(day_from_ymd(1971,12,31), timesys='UTC') == 86400
+    assert seconds_on_day(day_from_ymd(1971,12,31), timesys='TAI') == 86400
+    assert leapsecs_from_ymd(1958, 1) == 10
+    assert leapsecs_from_ymd(1964, 1) == 10
+    assert leapsecs_from_ymd(1971,12) == 10
+    assert leapsecs_from_ymd(1972, 1) == 10
+    assert leapsecs_from_ymd(2022, 1) == 37
+    assert np.all(leapsecs_from_ymd([1972, 1971, 1964, 1958], 1) == 10)
 
-        set_ut_model('LEAPS')
-        self.assertEqual(seconds_on_day(day_from_ymd(1971,12,31), timesys='UTC'), 86400)
-        self.assertEqual(seconds_on_day(day_from_ymd(1971,12,31), timesys='TAI'), 86400)
-        self.assertEqual(leapsecs_from_ymd(1958, 1), 10)
-        self.assertEqual(leapsecs_from_ymd(1964, 1), 10)
-        self.assertEqual(leapsecs_from_ymd(1971,12), 10)
-        self.assertEqual(leapsecs_from_ymd(1972, 1), 10)
-        self.assertEqual(leapsecs_from_ymd(2022, 1), 37)
-        self.assertTrue(np.all(leapsecs_from_ymd([1972, 1971, 1964, 1958], 1) == 10))
+    assert delta_t_from_ymd(1958, 1) == 10
+    assert delta_t_from_ymd(1964, 1) == 10
+    assert delta_t_from_ymd(1971,12) == 10
+    assert delta_t_from_ymd(1972, 1) == 10
+    assert delta_t_from_ymd(2022, 1) == 37
+    assert np.all(delta_t_from_ymd([1972, 1971, 1964, 1958], 1) == 10)
 
-        self.assertEqual(delta_t_from_ymd(1958, 1), 10)
-        self.assertEqual(delta_t_from_ymd(1964, 1), 10)
-        self.assertEqual(delta_t_from_ymd(1971,12), 10)
-        self.assertEqual(delta_t_from_ymd(1972, 1), 10)
-        self.assertEqual(delta_t_from_ymd(2022, 1), 37)
-        self.assertTrue(np.all(delta_t_from_ymd([1972, 1971, 1964, 1958], 1) == 10))
+    assert leapsecs_from_day(day_from_ymd(1972, 1, 1)) == 10
+    assert delta_t_from_day(day_from_ymd(1972, 1, 1)) == 10
 
-        self.assertEqual(leapsecs_from_day(day_from_ymd(1972, 1, 1)), 10)
-        self.assertEqual(delta_t_from_day(day_from_ymd(1972, 1, 1)), 10)
+    assert np.all(leapsecs_from_day(
+                            day_from_ymd([1972, 1971, 1964, 1958], 1, 1)) == 10)
+    assert np.all(delta_t_from_day(
+                            day_from_ymd([1972, 1971, 1964, 1958], 1, 1)) == 10)
 
-        self.assertTrue(np.all(leapsecs_from_day(
-                                day_from_ymd([1972, 1971, 1964, 1958], 1, 1)) == 10))
-        self.assertTrue(np.all(delta_t_from_day(
-                                day_from_ymd([1972, 1971, 1964, 1958], 1, 1)) == 10))
+    set_ut_model('PRE-1972')
+    assert leapsecs_from_ym(1956, 1) == 10
+    assert leapsecs_from_ym(1960,12,31) == 10
+    assert leapsecs_from_ym(1972,1,1) == 10
+    assert leapsecs_from_ym(2022, 1) == 37
+    assert np.all(leapsecs_from_ym([1972, 1960], 1) == [10,10])
+    assert isinstance(leapsecs_from_ym(1965,5,1), numbers.Integral)
 
-        set_ut_model('PRE-1972')
-        self.assertEqual(leapsecs_from_ym(1956, 1), 10)
-        self.assertEqual(leapsecs_from_ym(1960,12,31), 10)
-        self.assertEqual(leapsecs_from_ym(1972,1,1), 10)
-        self.assertEqual(leapsecs_from_ym(2022, 1), 37)
-        self.assertTrue(np.all(leapsecs_from_ym([1972, 1960], 1) == [10,10]))
-        self.assertIsInstance(leapsecs_from_ym(1965,5,1), numbers.Integral)
+    assert delta_t_from_ymd(1956, 1) == 0
+    assert delta_t_from_ymd(1960,12,31) == 0
+    assert delta_t_from_ymd(1972,1,1) == 10
+    assert delta_t_from_ymd(2022, 1) == 37
+    assert np.all(delta_t_from_ymd([1972, 1960], 1) == [10,0])
+    assert not isinstance(delta_t_from_ymd(1965,5,1), numbers.Integral)
 
-        self.assertEqual(delta_t_from_ymd(1956, 1), 0)
-        self.assertEqual(delta_t_from_ymd(1960,12,31), 0)
-        self.assertEqual(delta_t_from_ymd(1972,1,1), 10)
-        self.assertEqual(delta_t_from_ymd(2022, 1), 37)
-        self.assertTrue(np.all(delta_t_from_ymd([1972, 1960], 1) == [10,0]))
-        self.assertNotIsInstance(delta_t_from_ymd(1965,5,1), numbers.Integral)
+    set_ut_model('CANON')
+    assert leapsecs_from_ym(1956, 1) == 10
+    assert leapsecs_from_ym(1960,12,31) == 10
+    assert leapsecs_from_ym(1972,1,1) == 10
+    assert leapsecs_from_ymd(2022, 1) == 37
+    assert leapsecs_from_ymd(9999, 1) == 37
+    assert np.all(leapsecs_from_ym([1972, 1960], 1) == [10,10])
+    assert isinstance(leapsecs_from_ym(1965,5,1), numbers.Integral)
 
-        set_ut_model('CANON')
-        self.assertEqual(leapsecs_from_ym(1956, 1), 10)
-        self.assertEqual(leapsecs_from_ym(1960,12,31), 10)
-        self.assertEqual(leapsecs_from_ym(1972,1,1), 10)
-        self.assertEqual(leapsecs_from_ymd(2022, 1), 37)
-        self.assertEqual(leapsecs_from_ymd(9999, 1), 37)
-        self.assertTrue(np.all(leapsecs_from_ym([1972, 1960], 1) == [10,10]))
-        self.assertIsInstance(leapsecs_from_ym(1965,5,1), numbers.Integral)
+    assert delta_t_from_ymd(1600, 1, 1) == pytest.approx(86.1862447, abs=1e-7)
+    assert delta_t_from_ymd(1960,12,31) == 0
+    assert delta_t_from_ymd(1972,1,1) == 10
+    assert delta_t_from_ymd(2022, 1) == 37
+    assert delta_t_from_ymd(9999, 1) == 37
+    assert np.all(delta_t_from_ymd([1972, 1960], 1) == [10,0])
+    assert not isinstance(delta_t_from_ymd(1965,5,1), numbers.Integral)
 
-        self.assertAlmostEqual(delta_t_from_ymd(1600, 1, 1), 86.1862447)
-        self.assertEqual(delta_t_from_ymd(1960,12,31), 0)
-        self.assertEqual(delta_t_from_ymd(1972,1,1), 10)
-        self.assertEqual(delta_t_from_ymd(2022, 1), 37)
-        self.assertEqual(delta_t_from_ymd(9999, 1), 37)
-        self.assertTrue(np.all(delta_t_from_ymd([1972, 1960], 1) == [10,0]))
-        self.assertNotIsInstance(delta_t_from_ymd(1965,5,1), numbers.Integral)
+    set_ut_model('CANON', future=2030)
+    year = np.arange(-600, 2300, 10)
+    delta_t = delta_t_from_ymd(year,1,1)
+    canon_dt = _delta_t_neg1999_3000(year,1,1)
+    mask = (year < 1958) | (year >= 2030)
 
-        set_ut_model('CANON', future=2030)
-        year = np.arange(-600, 2300, 10)
-        delta_t = delta_t_from_ymd(year,1,1)
-        canon_dt = _delta_t_neg1999_3000(year,1,1)
-        mask = (year < 1958) | (year >= 2030)
+    assert np.all(delta_t[mask] == canon_dt[mask])
 
-        self.assertTrue(np.all(delta_t[mask] == canon_dt[mask]))
+    set_ut_model('PRE-1972')
+    year = year[~mask]
+    pre1972_dt = delta_t_from_ymd(year,1,1)
+    assert np.all(delta_t[~mask] == pre1972_dt)
 
-        set_ut_model('PRE-1972')
-        year = year[~mask]
-        pre1972_dt = delta_t_from_ymd(year,1,1)
-        self.assertTrue(np.all(delta_t[~mask] == pre1972_dt))
+    year = np.arange(1960, 2020)
+    answers = [0, 1.422818, 1.845858, 2.255826, 2.765794, 3.54013 ,
+                  4.31317 , 5.25925 , 6.20533 , 7.054002, 8.000082, 8.946162,
+               10, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 22, 23, 23,
+               24, 24, 25, 26, 26, 27, 28, 29, 30, 30, 31, 32, 32, 32, 32, 32,
+               32, 32, 33, 33, 33, 34, 34, 34, 34, 35, 35, 35, 36, 37, 37, 37]
 
-        year = np.arange(1960, 2020)
-        answers = [0, 1.422818, 1.845858, 2.255826, 2.765794, 3.54013 ,
-                      4.31317 , 5.25925 , 6.20533 , 7.054002, 8.000082, 8.946162,
-                   10, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 22, 23, 23,
-                   24, 24, 25, 26, 26, 27, 28, 29, 30, 30, 31, 32, 32, 32, 32, 32,
-                   32, 32, 33, 33, 33, 34, 34, 34, 34, 35, 35, 35, 36, 37, 37, 37]
+    assert np.abs(delta_t_from_ymd(year,1,1) - answers).max() < 1.e-14
 
-        self.assertLess(np.abs(delta_t_from_ymd(year,1,1) - answers).max(), 1.e-14)
+    set_ut_model('SPICE')
+    answers = 12*[9] + answers[12:]
+    assert np.all(delta_t_from_ymd(year,1,1) == answers)
 
-        set_ut_model('SPICE')
-        answers = 12*[9] + answers[12:]
-        self.assertTrue(np.all(delta_t_from_ymd(year,1,1) == answers))
+    set_ut_model('LEAPS')
 
-        set_ut_model('LEAPS')
+    count = leapsecs_from_ym(2021,1)
+    insert_leap_second(2020,7)
+    assert leapsecs_from_ym(2021,1) == count + 1
 
-        # insert_leap_second()
-        count = leapsecs_from_ym(2021,1)
-        insert_leap_second(2020,7)
-        self.assertEqual(leapsecs_from_ym(2021,1), count + 1)
+    insert_leap_second(2020,9,3)
+    assert leapsecs_from_ym(2021,1) == count + 4
 
-        insert_leap_second(2020,9,3)
-        self.assertEqual(leapsecs_from_ym(2021,1), count + 4)
+    insert_leap_second(2020,11,-4)
+    assert leapsecs_from_ym(2021,1) == count
 
-        insert_leap_second(2020,11,-4)
-        self.assertEqual(leapsecs_from_ym(2021,1), count)
+    load_lsk()
+    assert leapsecs_from_ym(2021,1) == count
+    assert leap_seconds._SELECTED_UT_MODEL == 'LEAPS'
+    assert leap_seconds._SELECTED_DELTA_T is leap_seconds._DELTA_T_DICT['LEAPS']
 
-        # Restore without added leap seconds
+    daylist = range(-40001, 40000, 83)
+
+    for name in ('LEAPS', 'SPICE', 'PRE-1972', 'CANON'):
+        set_ut_model(name)
+
+        assert np.all(seconds_on_day(daylist) >= 86400)
+        assert np.all(seconds_on_day(daylist) <= 86401)
+
+        assert seconds_on_day(day_from_ymd(1998,12,31)) == 86401
+        assert seconds_on_day(day_from_ymd(1972, 6,30)) == 86401
+
+        assert np.all(seconds_on_day(daylist, leapsecs=False) == 86400)
+        assert seconds_on_day(day_from_ymd(1998,12,31), leapsecs=False) == 86400
+
+        for secs, y, mon, d in leap_seconds._DELTET_DELTA_AT[1:]:
+            day = day_from_ymd(int(y), 1 if mon == 'JAN' else 7, int(d))
+            assert leapsecs_from_day(day) == int(secs)
+            assert leapsecs_from_day(day-1) == int(secs)-1
+
+        assert leapsecs_from_day(day + 10000) == int(secs)
+
+    set_ut_model('LEAPS')
+
+    load_lsk()
+
+def test_delta_t_neg1999_3000():
+
+    for year in [-500, 500, 1600, 1700, 1800, 1860, 1900, 1920, 1941, 1961, 1986,
+                 2005, 2050, 2150]:
+
+        delta_t = _delta_t_neg1999_3000(year,1,1)
+
+        dt1 = _delta_t_neg1999_3000(year-1, 12, 31.8)
+        dt2 = _delta_t_neg1999_3000(year-1, 12, 31.9)
+        extrap = 2 * dt2 - dt1
+
+        assert abs(extrap - delta_t) < 0.26
+
+def test_negative_leap_seconds():
+
+    load_lsk()
+    for name in ('LEAPS', 'SPICE', 'PRE-1972', 'CANON'):
+        set_ut_model(name)
+
+        insert_leap_second(2030, 1, -1)
+        insert_leap_second(2031, 1, -2)
+        insert_leap_second(2040, 1, 1)
+
+        assert seconds_on_day(day_from_ymd(2030,1,1)  ) == 86400
+        assert seconds_on_day(day_from_ymd(2030,1,1)-1) == 86399
+
+        assert seconds_on_day(day_from_ymd(2031,1,1)  ) == 86400
+        assert seconds_on_day(day_from_ymd(2031,1,1)-1) == 86398
+
+        assert seconds_on_day(day_from_ymd(2040,1,1)  ) == 86400
+        assert seconds_on_day(day_from_ymd(2040,1,1)-1) == 86401
+
+        assert np.all(seconds_on_day(day_from_ymd([2030,2031,2040],1,1)-1)
+                               == [86399, 86398, 86401])
+
+        tai = tai_from_iso('2030-01-01T00:00:00')
+        assert tai_from_iso('2029-12-31T23:59:58', validate=True) == tai-1
+        assert tai_from_iso('2029-12-31T23:59:59', validate=False) == tai
+        with pytest.raises(JVF): tai_from_iso('2029-12-31T23:59:59', validate=True)
+
+        tai = tai_from_iso('2031-01-01T00:00:00')
+        assert tai_from_iso('2030-12-31T23:59:57', validate=True) == tai-1
+        with pytest.raises(JVF): tai_from_iso('2030-12-31T23:59:58', validate=True)
+        with pytest.raises(JVF): tai_from_iso('2030-12-31T23:59:59', validate=True)
+
         load_lsk()
-        self.assertEqual(leapsecs_from_ym(2021,1), count)
-        self.assertEqual(leap_seconds._SELECTED_UT_MODEL, 'LEAPS')
-        self.assertIs(leap_seconds._SELECTED_DELTA_T, leap_seconds._DELTA_T_DICT['LEAPS'])
 
-        # A large number of dates, spanning > 200 years
-        daylist = range(-40001, 40000, 83)
-
-        for name in ('LEAPS', 'SPICE', 'PRE-1972', 'CANON'):
-            set_ut_model(name)
-
-            # Check all seconds are within the range
-            self.assertTrue(np.all(seconds_on_day(daylist) >= 86400))
-            self.assertTrue(np.all(seconds_on_day(daylist) <= 86401))
-
-            self.assertEqual(seconds_on_day(day_from_ymd(1998,12,31)), 86401)
-            self.assertEqual(seconds_on_day(day_from_ymd(1972, 6,30)), 86401)
-
-            # Check cases where leap seconds are ignored
-            self.assertTrue(np.all(seconds_on_day(daylist, leapsecs=False) == 86400))
-            self.assertEqual(seconds_on_day(day_from_ymd(1998,12,31), leapsecs=False),
-                                            86400)
-
-            for secs, y, mon, d in leap_seconds._DELTET_DELTA_AT[1:]:
-                day = day_from_ymd(int(y), 1 if mon == 'JAN' else 7, int(d))
-                self.assertEqual(leapsecs_from_day(day), int(secs))
-                self.assertEqual(leapsecs_from_day(day-1), int(secs)-1)
-
-            self.assertEqual(leapsecs_from_day(day + 10000), int(secs))
-
-        # Go back to the default
-        set_ut_model('LEAPS')
-
-        # Restore without added leap seconds
-        load_lsk()
-
-    # Test for continuity of the "CANON" model
-    def test_delta_t_neg1999_3000(self):
-
-        for year in [-500, 500, 1600, 1700, 1800, 1860, 1900, 1920, 1941, 1961, 1986,
-                     2005, 2050, 2150]:
-
-            delta_t = _delta_t_neg1999_3000(year,1,1)
-
-            # Extrapolate value from before the jump in formula
-            dt1 = _delta_t_neg1999_3000(year-1, 12, 31.8)
-            dt2 = _delta_t_neg1999_3000(year-1, 12, 31.9)
-            extrap = 2 * dt2 - dt1
-
-            self.assertLess(abs(extrap - delta_t), 0.26)
-
-    # Negative leap seconds...
-    def test_negative_leap_seconds(self):
-
-        load_lsk()
-        for name in ('LEAPS', 'SPICE', 'PRE-1972', 'CANON'):
-            set_ut_model(name)
-
-            insert_leap_second(2030, 1, -1)
-            insert_leap_second(2031, 1, -2)
-            insert_leap_second(2040, 1, 1)
-
-            self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)  ), 86400)
-            self.assertEqual(seconds_on_day(day_from_ymd(2030,1,1)-1), 86399)
-
-            self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)  ), 86400)
-            self.assertEqual(seconds_on_day(day_from_ymd(2031,1,1)-1), 86398)
-
-            self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)  ), 86400)
-            self.assertEqual(seconds_on_day(day_from_ymd(2040,1,1)-1), 86401)
-
-            self.assertTrue(np.all(seconds_on_day(day_from_ymd([2030,2031,2040],1,1)-1)
-                                   == [86399, 86398, 86401]))
-
-            tai = tai_from_iso('2030-01-01T00:00:00')
-            self.assertEqual(tai_from_iso('2029-12-31T23:59:58', validate=True), tai-1)
-            self.assertEqual(tai_from_iso('2029-12-31T23:59:59', validate=False), tai)
-            self.assertRaises(JVF, tai_from_iso, '2029-12-31T23:59:59', validate=True)
-
-            tai = tai_from_iso('2031-01-01T00:00:00')
-            self.assertEqual(tai_from_iso('2030-12-31T23:59:57', validate=True), tai-1)
-            self.assertRaises(JVF, tai_from_iso, '2030-12-31T23:59:58', validate=True)
-            self.assertRaises(JVF, tai_from_iso, '2030-12-31T23:59:59', validate=True)
-
-            load_lsk()
-
-        # Go back to the default
-        set_ut_model('LEAPS')
+    set_ut_model('LEAPS')
 
 ##########################################################################################

--- a/tests/test_mjd_jd.py
+++ b/tests/test_mjd_jd.py
@@ -43,117 +43,121 @@ def test_mjd_jd():
     from julian._warnings import JulianDeprecationWarning
     warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-    # Test integer conversions...
-    assert mjd_from_day(0) == 51544
-    assert isinstance(mjd_from_day(0), numbers.Integral)
-    assert not isinstance(mjd_from_day(0.), numbers.Integral)
+    try:
+        # Test integer conversions...
+        assert mjd_from_day(0) == 51544
+        assert isinstance(mjd_from_day(0), numbers.Integral)
+        assert not isinstance(mjd_from_day(0.), numbers.Integral)
 
-    assert np.all(mjd_from_day([0,1]) == [51544, 51545])
-    assert mjd_from_day([0,1]).dtype.kind == 'i'
-    assert mjd_from_day([0,1.]).dtype.kind == 'f'
+        assert np.all(mjd_from_day([0,1]) == [51544, 51545])
+        assert mjd_from_day([0,1]).dtype.kind == 'i'
+        assert mjd_from_day([0,1.]).dtype.kind == 'f'
 
-    assert day_from_mjd(51545) == 1
-    assert isinstance(day_from_mjd(51545), numbers.Integral)
-    assert not isinstance(day_from_mjd(51545.), numbers.Integral)
+        assert day_from_mjd(51545) == 1
+        assert isinstance(day_from_mjd(51545), numbers.Integral)
+        assert not isinstance(day_from_mjd(51545.), numbers.Integral)
 
-    assert day_from_mjd([0,1]).dtype.kind == 'i'
-    assert day_from_mjd([0,1.]).dtype.kind == 'f'
+        assert day_from_mjd([0,1]).dtype.kind == 'i'
+        assert day_from_mjd([0,1.]).dtype.kind == 'f'
 
-    assert np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544)
-    assert np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544)
+        assert np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544)
+        assert np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544)
 
-    # Test integer conversions...
-    assert mjd_from_day_sec(0) == mjd_from_day(0)
-    assert np.all(mjd_from_day_sec([0,1],[0,43200]) == mjd_from_day([0,1.5]))
+        # Test integer conversions...
+        assert mjd_from_day_sec(0) == mjd_from_day(0)
+        assert np.all(mjd_from_day_sec([0,1],[0,43200]) == mjd_from_day([0,1.5]))
 
-    # Test MJD floating-point conversions spanning 1000 years
-    span = 1000. * 365.25
-    mjdlist = np.arange(-span, span, 5*np.pi) + _MJD_OF_JAN_1_2000
+        # Test MJD floating-point conversions spanning 1000 years
+        span = 1000. * 365.25
+        mjdlist = np.arange(-span, span, 5*np.pi) + _MJD_OF_JAN_1_2000
 
-    for origin in ('MIDNIGHT', 'NOON'):
-        set_tai_origin(origin)
-        for mjdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
-            for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                time = time_from_mjd(mjdlist, mjdsys=mjdsys, timesys=timesys)
-                test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
-                assert np.abs(test - mjdlist).max() < span * 1.e-15
-
-                for mjd in mjdlist[:100]:
-                    time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
+        for origin in ('MIDNIGHT', 'NOON'):
+            set_tai_origin(origin)
+            for mjdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                    time = time_from_mjd(mjdlist, mjdsys=mjdsys, timesys=timesys)
                     test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
-                    assert abs(test - mjd) < span * 1.e-15
+                    assert np.abs(test - mjdlist).max() < span * 1.e-15
 
-    (day, sec) = day_sec_from_mjd(mjdlist)
-    test = mjd_from_day_sec(day, sec)
-    assert np.abs(test - mjdlist).max() < span * 1.e-15
+                    for mjd in mjdlist[:100]:
+                        time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
+                        test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
+                        assert abs(test - mjd) < span * 1.e-15
 
-    for mjd in mjdlist[:100]:
-        (day, sec) = day_sec_from_mjd(mjd)
+        (day, sec) = day_sec_from_mjd(mjdlist)
         test = mjd_from_day_sec(day, sec)
-        assert abs(test - mjd) < span * 1.e-15
+        assert np.abs(test - mjdlist).max() < span * 1.e-15
 
-    # Test JD floating-point conversions spanning 100 years
-    span = 100. * 365.25
-    jdlist = np.arange(-span, span, np.pi) + _JD_OF_JAN_1_2000
+        for mjd in mjdlist[:100]:
+            (day, sec) = day_sec_from_mjd(mjd)
+            test = mjd_from_day_sec(day, sec)
+            assert abs(test - mjd) < span * 1.e-15
 
-    for origin in ('MIDNIGHT', 'NOON'):
-        set_tai_origin(origin)
-        for jdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
-            for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                time = time_from_jd(jdlist, jdsys=jdsys, timesys=timesys)
-                test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
-                assert np.abs(test - jdlist).max() < span * 1.e-15
+        # Test JD floating-point conversions spanning 100 years
+        span = 100. * 365.25
+        jdlist = np.arange(-span, span, np.pi) + _JD_OF_JAN_1_2000
 
-                for jd in jdlist[:100]:
-                    time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
+        for origin in ('MIDNIGHT', 'NOON'):
+            set_tai_origin(origin)
+            for jdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                    time = time_from_jd(jdlist, jdsys=jdsys, timesys=timesys)
                     test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
-                    assert abs(test - jd) < span * 1.e-15
+                    assert np.abs(test - jdlist).max() < span * 1.e-15
 
-    (day, sec) = day_sec_from_jd(jdlist)
-    test = jd_from_day_sec(day, sec)
-    assert np.abs(test - jdlist).max() < span * 1.e-15
+                    for jd in jdlist[:100]:
+                        time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
+                        test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
+                        assert abs(test - jd) < span * 1.e-15
 
-    for jd in jdlist[:100]:
-        (day, sec) = day_sec_from_jd(jd)
+        (day, sec) = day_sec_from_jd(jdlist)
         test = jd_from_day_sec(day, sec)
-        assert abs(test - jd) < span * 1.e-15
+        assert np.abs(test - jdlist).max() < span * 1.e-15
 
-    MJD_TIME_CASES = [
-        ('TAI', 'UTC', mjd_from_tai , mjd_from_time),
-        ('TAI', 'TDB', mjed_from_tai, mjd_from_time),
-        ('TDB', 'TDB', mjed_from_tdb, mjd_from_time),
-        ('TAI', 'UTC', tai_from_mjd , time_from_mjd),
-        ('TAI', 'TDB', tai_from_mjed, time_from_mjd),
-        ('TDB', 'TDB', tdb_from_mjed, time_from_mjd),
-    ]
+        for jd in jdlist[:100]:
+            (day, sec) = day_sec_from_jd(jd)
+            test = jd_from_day_sec(day, sec)
+            assert abs(test - jd) < span * 1.e-15
 
-    for (timesys, mjdsys, oldfunc, newfunc) in MJD_TIME_CASES:
-        assert oldfunc(100) == newfunc(100, timesys=timesys, mjdsys=mjdsys)
+        MJD_TIME_CASES = [
+            ('TAI', 'UTC', mjd_from_tai , mjd_from_time),
+            ('TAI', 'TDB', mjed_from_tai, mjd_from_time),
+            ('TDB', 'TDB', mjed_from_tdb, mjd_from_time),
+            ('TAI', 'UTC', tai_from_mjd , time_from_mjd),
+            ('TAI', 'TDB', tai_from_mjed, time_from_mjd),
+            ('TDB', 'TDB', tdb_from_mjed, time_from_mjd),
+        ]
 
-    JD_TIME_CASES = [
-        ('TAI', 'UTC', jd_from_tai , jd_from_time),
-        ('TAI', 'TDB', jed_from_tai, jd_from_time),
-        ('TDB', 'TDB', jed_from_tdb, jd_from_time),
-        ('TAI', 'UTC', tai_from_jd , time_from_jd),
-        ('TAI', 'TDB', tai_from_jed, time_from_jd),
-        ('TDB', 'TDB', tdb_from_jed, time_from_jd),
-    ]
+        for (timesys, mjdsys, oldfunc, newfunc) in MJD_TIME_CASES:
+            assert oldfunc(100) == newfunc(100, timesys=timesys, mjdsys=mjdsys)
 
-    for (timesys, jdsys, oldfunc, newfunc) in JD_TIME_CASES:
-        assert oldfunc(100) == newfunc(100, timesys=timesys, jdsys=jdsys)
+        JD_TIME_CASES = [
+            ('TAI', 'UTC', jd_from_tai , jd_from_time),
+            ('TAI', 'TDB', jed_from_tai, jd_from_time),
+            ('TDB', 'TDB', jed_from_tdb, jd_from_time),
+            ('TAI', 'UTC', tai_from_jd , time_from_jd),
+            ('TAI', 'TDB', tai_from_jed, time_from_jd),
+            ('TDB', 'TDB', tdb_from_jed, time_from_jd),
+        ]
 
-    for origin in ('MIDNIGHT', 'NOON'):
-        set_tai_origin(origin)
-        assert mjd_from_time(0., timesys='TAI') == \
-                         (51544.5 if origin == 'NOON' else 51544.0)
-        assert mjd_from_time(0., timesys='UTC') == \
-                         (51544.5 if origin == 'NOON' else 51544.0)
-        assert mjd_from_day_sec(0, 0) == 51544.0
+        for (timesys, jdsys, oldfunc, newfunc) in JD_TIME_CASES:
+            assert oldfunc(100) == newfunc(100, timesys=timesys, jdsys=jdsys)
 
-        assert time_from_mjd(51544.5 if origin == 'NOON' else 51544.0,
-                         timesys='TAI') == 0.
-        assert time_from_mjd(51544.0, timesys='UTC') == \
-                         (0. if origin == 'MIDNIGHT' else -43200)
-        assert day_sec_from_mjd(51544.0) == (0,0)
+        for origin in ('MIDNIGHT', 'NOON'):
+            set_tai_origin(origin)
+            assert mjd_from_time(0., timesys='TAI') == \
+                             (51544.5 if origin == 'NOON' else 51544.0)
+            assert mjd_from_time(0., timesys='UTC') == \
+                             (51544.5 if origin == 'NOON' else 51544.0)
+            assert mjd_from_day_sec(0, 0) == 51544.0
+
+            assert time_from_mjd(51544.5 if origin == 'NOON' else 51544.0,
+                             timesys='TAI') == 0.
+            assert time_from_mjd(51544.0, timesys='UTC') == \
+                             (0. if origin == 'MIDNIGHT' else -43200)
+            assert day_sec_from_mjd(51544.0) == (0,0)
+
+    finally:
+        set_tai_origin('MIDNIGHT')
 
 ##########################################################################################

--- a/tests/test_mjd_jd.py
+++ b/tests/test_mjd_jd.py
@@ -48,7 +48,7 @@ def test_mjd_jd():
     assert isinstance(mjd_from_day(0), numbers.Integral)
     assert not isinstance(mjd_from_day(0.), numbers.Integral)
 
-    assert np.all(mjd_from_day([0,1] == [51544, 51545]))
+    assert np.all(mjd_from_day([0,1]) == [51544, 51545])
     assert mjd_from_day([0,1]).dtype.kind == 'i'
     assert mjd_from_day([0,1.]).dtype.kind == 'f'
 
@@ -66,16 +66,6 @@ def test_mjd_jd():
     assert mjd_from_day_sec(0) == mjd_from_day(0)
     assert np.all(mjd_from_day_sec([0,1],[0,43200]) == mjd_from_day([0,1.5]))
 
-    assert day_from_mjd(51545) == 1
-    assert isinstance(day_from_mjd(51545), numbers.Integral)
-    assert not isinstance(day_from_mjd(51545.), numbers.Integral)
-
-    assert day_from_mjd([0,1]).dtype.kind == 'i'
-    assert day_from_mjd([0,1.]).dtype.kind == 'f'
-
-    assert np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544)
-    assert np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544)
-
     # Test MJD floating-point conversions spanning 1000 years
     span = 1000. * 365.25
     mjdlist = np.arange(-span, span, 5*np.pi) + _MJD_OF_JAN_1_2000
@@ -88,10 +78,10 @@ def test_mjd_jd():
                 test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
                 assert np.abs(test - mjdlist).max() < span * 1.e-15
 
-        for mjd in mjdlist[:100]:
-            time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
-            test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
-            assert abs(test - mjd) < span * 1.e-15
+                for mjd in mjdlist[:100]:
+                    time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
+                    test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
+                    assert abs(test - mjd) < span * 1.e-15
 
     (day, sec) = day_sec_from_mjd(mjdlist)
     test = mjd_from_day_sec(day, sec)
@@ -114,10 +104,10 @@ def test_mjd_jd():
                 test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
                 assert np.abs(test - jdlist).max() < span * 1.e-15
 
-        for jd in jdlist[:100]:
-            time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
-            test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
-            assert abs(test - jd) < span * 1.e-15
+                for jd in jdlist[:100]:
+                    time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
+                    test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
+                    assert abs(test - jd) < span * 1.e-15
 
     (day, sec) = day_sec_from_jd(jdlist)
     test = jd_from_day_sec(day, sec)

--- a/tests/test_mjd_jd.py
+++ b/tests/test_mjd_jd.py
@@ -4,7 +4,6 @@
 
 import numbers
 import numpy as np
-import unittest
 
 from julian.utc_tai_tdb_tt import set_tai_origin
 
@@ -38,135 +37,133 @@ from julian._DEPRECATED import (
     tdb_from_mjed,
 )
 
-class Test_mjd_jd(unittest.TestCase):
+def test_mjd_jd():
 
-    def runTest(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    # Test integer conversions...
+    assert mjd_from_day(0) == 51544
+    assert isinstance(mjd_from_day(0), numbers.Integral)
+    assert not isinstance(mjd_from_day(0.), numbers.Integral)
 
-        # Test integer conversions...
-        self.assertEqual(mjd_from_day(0), 51544)
-        self.assertTrue(isinstance(mjd_from_day(0), numbers.Integral))
-        self.assertFalse(isinstance(mjd_from_day(0.), numbers.Integral))
+    assert np.all(mjd_from_day([0,1] == [51544, 51545]))
+    assert mjd_from_day([0,1]).dtype.kind == 'i'
+    assert mjd_from_day([0,1.]).dtype.kind == 'f'
 
-        self.assertTrue(np.all(mjd_from_day([0,1] == [51544, 51545])))
-        self.assertEqual(mjd_from_day([0,1]).dtype.kind, 'i')
-        self.assertEqual(mjd_from_day([0,1.]).dtype.kind, 'f')
+    assert day_from_mjd(51545) == 1
+    assert isinstance(day_from_mjd(51545), numbers.Integral)
+    assert not isinstance(day_from_mjd(51545.), numbers.Integral)
 
-        self.assertEqual(day_from_mjd(51545), 1)
-        self.assertTrue(isinstance(day_from_mjd(51545), numbers.Integral))
-        self.assertFalse(isinstance(day_from_mjd(51545.), numbers.Integral))
+    assert day_from_mjd([0,1]).dtype.kind == 'i'
+    assert day_from_mjd([0,1.]).dtype.kind == 'f'
 
-        self.assertEqual(day_from_mjd([0,1]).dtype.kind, 'i')
-        self.assertEqual(day_from_mjd([0,1.]).dtype.kind, 'f')
+    assert np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544)
+    assert np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544)
 
-        self.assertTrue(np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544))
-        self.assertTrue(np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544))
+    # Test integer conversions...
+    assert mjd_from_day_sec(0) == mjd_from_day(0)
+    assert np.all(mjd_from_day_sec([0,1],[0,43200]) == mjd_from_day([0,1.5]))
 
-        # Test integer conversions...
-        self.assertEqual(mjd_from_day_sec(0), mjd_from_day(0))
-        self.assertTrue(np.all(mjd_from_day_sec([0,1],[0,43200]) == mjd_from_day([0,1.5])))
+    assert day_from_mjd(51545) == 1
+    assert isinstance(day_from_mjd(51545), numbers.Integral)
+    assert not isinstance(day_from_mjd(51545.), numbers.Integral)
 
-        self.assertEqual(day_from_mjd(51545), 1)
-        self.assertTrue(isinstance(day_from_mjd(51545), numbers.Integral))
-        self.assertFalse(isinstance(day_from_mjd(51545.), numbers.Integral))
+    assert day_from_mjd([0,1]).dtype.kind == 'i'
+    assert day_from_mjd([0,1.]).dtype.kind == 'f'
 
-        self.assertEqual(day_from_mjd([0,1]).dtype.kind, 'i')
-        self.assertEqual(day_from_mjd([0,1.]).dtype.kind, 'f')
+    assert np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544)
+    assert np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544)
 
-        self.assertTrue(np.all(mjd_from_day(np.arange(10)) == np.arange(10) + 51544))
-        self.assertTrue(np.all(day_from_mjd(np.arange(10)) == np.arange(10) - 51544))
+    # Test MJD floating-point conversions spanning 1000 years
+    span = 1000. * 365.25
+    mjdlist = np.arange(-span, span, 5*np.pi) + _MJD_OF_JAN_1_2000
 
-        # Test MJD floating-point conversions spanning 1000 years
-        span = 1000. * 365.25
-        mjdlist = np.arange(-span, span, 5*np.pi) + _MJD_OF_JAN_1_2000
-
-        for origin in ('MIDNIGHT', 'NOON'):
-            set_tai_origin(origin)
-            for mjdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                    time = time_from_mjd(mjdlist, mjdsys=mjdsys, timesys=timesys)
-                    test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
-                    self.assertLess(np.abs(test - mjdlist).max(), span * 1.e-15)
-
-            for mjd in mjdlist[:100]:
-                time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
+    for origin in ('MIDNIGHT', 'NOON'):
+        set_tai_origin(origin)
+        for mjdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
+            for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                time = time_from_mjd(mjdlist, mjdsys=mjdsys, timesys=timesys)
                 test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
-                self.assertLess(abs(test - mjd), span * 1.e-15)
-
-        (day, sec) = day_sec_from_mjd(mjdlist)
-        test = mjd_from_day_sec(day, sec)
-        self.assertLess(np.abs(test - mjdlist).max(), span * 1.e-15)
+                assert np.abs(test - mjdlist).max() < span * 1.e-15
 
         for mjd in mjdlist[:100]:
-            (day, sec) = day_sec_from_mjd(mjd)
-            test = mjd_from_day_sec(day, sec)
-            self.assertLess(abs(test - mjd), span * 1.e-15)
+            time = time_from_mjd(mjd, mjdsys=mjdsys, timesys=timesys)
+            test = mjd_from_time(time, timesys=timesys, mjdsys=mjdsys)
+            assert abs(test - mjd) < span * 1.e-15
 
-        # Test JD floating-point conversions spanning 100 years
-        span = 100. * 365.25
-        jdlist = np.arange(-span, span, np.pi) + _JD_OF_JAN_1_2000
+    (day, sec) = day_sec_from_mjd(mjdlist)
+    test = mjd_from_day_sec(day, sec)
+    assert np.abs(test - mjdlist).max() < span * 1.e-15
 
-        for origin in ('MIDNIGHT', 'NOON'):
-            set_tai_origin(origin)
-            for jdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
-                    time = time_from_jd(jdlist, jdsys=jdsys, timesys=timesys)
-                    test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
-                    self.assertLess(np.abs(test - jdlist).max(), span * 1.e-15)
+    for mjd in mjdlist[:100]:
+        (day, sec) = day_sec_from_mjd(mjd)
+        test = mjd_from_day_sec(day, sec)
+        assert abs(test - mjd) < span * 1.e-15
 
-            for jd in jdlist[:100]:
-                time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
+    # Test JD floating-point conversions spanning 100 years
+    span = 100. * 365.25
+    jdlist = np.arange(-span, span, np.pi) + _JD_OF_JAN_1_2000
+
+    for origin in ('MIDNIGHT', 'NOON'):
+        set_tai_origin(origin)
+        for jdsys in ('UTC', 'TAI', 'TDB', 'TDT'):
+            for timesys in ('UTC', 'TAI', 'TDB', 'TDT'):
+                time = time_from_jd(jdlist, jdsys=jdsys, timesys=timesys)
                 test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
-                self.assertLess(abs(test - jd), span * 1.e-15)
-
-        (day, sec) = day_sec_from_jd(jdlist)
-        test = jd_from_day_sec(day, sec)
-        self.assertLess(np.abs(test - jdlist).max(), span * 1.e-15)
+                assert np.abs(test - jdlist).max() < span * 1.e-15
 
         for jd in jdlist[:100]:
-            (day, sec) = day_sec_from_jd(jd)
-            test = jd_from_day_sec(day, sec)
-            self.assertLess(abs(test - jd), span * 1.e-15)
+            time = time_from_jd(jd, jdsys=jdsys, timesys=timesys)
+            test = jd_from_time(time, timesys=timesys, jdsys=jdsys)
+            assert abs(test - jd) < span * 1.e-15
 
-        MJD_TIME_CASES = [
-            ('TAI', 'UTC', mjd_from_tai , mjd_from_time),
-            ('TAI', 'TDB', mjed_from_tai, mjd_from_time),
-            ('TDB', 'TDB', mjed_from_tdb, mjd_from_time),
-            ('TAI', 'UTC', tai_from_mjd , time_from_mjd),
-            ('TAI', 'TDB', tai_from_mjed, time_from_mjd),
-            ('TDB', 'TDB', tdb_from_mjed, time_from_mjd),
-        ]
+    (day, sec) = day_sec_from_jd(jdlist)
+    test = jd_from_day_sec(day, sec)
+    assert np.abs(test - jdlist).max() < span * 1.e-15
 
-        for (timesys, mjdsys, oldfunc, newfunc) in MJD_TIME_CASES:
-            self.assertEqual(oldfunc(100), newfunc(100, timesys=timesys, mjdsys=mjdsys))
+    for jd in jdlist[:100]:
+        (day, sec) = day_sec_from_jd(jd)
+        test = jd_from_day_sec(day, sec)
+        assert abs(test - jd) < span * 1.e-15
 
-        JD_TIME_CASES = [
-            ('TAI', 'UTC', jd_from_tai , jd_from_time),
-            ('TAI', 'TDB', jed_from_tai, jd_from_time),
-            ('TDB', 'TDB', jed_from_tdb, jd_from_time),
-            ('TAI', 'UTC', tai_from_jd , time_from_jd),
-            ('TAI', 'TDB', tai_from_jed, time_from_jd),
-            ('TDB', 'TDB', tdb_from_jed, time_from_jd),
-        ]
+    MJD_TIME_CASES = [
+        ('TAI', 'UTC', mjd_from_tai , mjd_from_time),
+        ('TAI', 'TDB', mjed_from_tai, mjd_from_time),
+        ('TDB', 'TDB', mjed_from_tdb, mjd_from_time),
+        ('TAI', 'UTC', tai_from_mjd , time_from_mjd),
+        ('TAI', 'TDB', tai_from_mjed, time_from_mjd),
+        ('TDB', 'TDB', tdb_from_mjed, time_from_mjd),
+    ]
 
-        for (timesys, jdsys, oldfunc, newfunc) in JD_TIME_CASES:
-            self.assertEqual(oldfunc(100), newfunc(100, timesys=timesys, jdsys=jdsys))
+    for (timesys, mjdsys, oldfunc, newfunc) in MJD_TIME_CASES:
+        assert oldfunc(100) == newfunc(100, timesys=timesys, mjdsys=mjdsys)
 
-        for origin in ('MIDNIGHT', 'NOON'):
-            set_tai_origin(origin)
-            self.assertEqual(mjd_from_time(0., timesys='TAI'),
-                             51544.5 if origin == 'NOON' else 51544.0)
-            self.assertEqual(mjd_from_time(0., timesys='UTC'),
-                             51544.5 if origin == 'NOON' else 51544.0)
-            self.assertEqual(mjd_from_day_sec(0, 0), 51544.0)
+    JD_TIME_CASES = [
+        ('TAI', 'UTC', jd_from_tai , jd_from_time),
+        ('TAI', 'TDB', jed_from_tai, jd_from_time),
+        ('TDB', 'TDB', jed_from_tdb, jd_from_time),
+        ('TAI', 'UTC', tai_from_jd , time_from_jd),
+        ('TAI', 'TDB', tai_from_jed, time_from_jd),
+        ('TDB', 'TDB', tdb_from_jed, time_from_jd),
+    ]
 
-            self.assertEqual(time_from_mjd(51544.5 if origin == 'NOON' else 51544.0,
-                             timesys='TAI'), 0.)
-            self.assertEqual(time_from_mjd(51544.0, timesys='UTC'),
-                             0. if origin == 'MIDNIGHT' else -43200)
-            self.assertEqual(day_sec_from_mjd(51544.0), (0,0))
+    for (timesys, jdsys, oldfunc, newfunc) in JD_TIME_CASES:
+        assert oldfunc(100) == newfunc(100, timesys=timesys, jdsys=jdsys)
+
+    for origin in ('MIDNIGHT', 'NOON'):
+        set_tai_origin(origin)
+        assert mjd_from_time(0., timesys='TAI') == \
+                         (51544.5 if origin == 'NOON' else 51544.0)
+        assert mjd_from_time(0., timesys='UTC') == \
+                         (51544.5 if origin == 'NOON' else 51544.0)
+        assert mjd_from_day_sec(0, 0) == 51544.0
+
+        assert time_from_mjd(51544.5 if origin == 'NOON' else 51544.0,
+                         timesys='TAI') == 0.
+        assert time_from_mjd(51544.0, timesys='UTC') == \
+                         (0. if origin == 'MIDNIGHT' else -43200)
+        assert day_sec_from_mjd(51544.0) == (0,0)
 
 ##########################################################################################

--- a/tests/test_mjd_pyparser.py
+++ b/tests/test_mjd_pyparser.py
@@ -1,5 +1,5 @@
 ##########################################################################################
-# julian/test_mjd_pyparser.py
+# tests/test_mjd_pyparser.py
 ##########################################################################################
 
 from tests._helpers import confirm_failure, confirm_success
@@ -39,15 +39,15 @@ def mjd_tester(parser, floating, timesys, padding=False, embedded=False):
 
     count = 0
     for fstat, fmt, yval, sval in FMTS:
-      for nstat, nword, nval in NUMBERS:
-        test = before + fmt % nword + after
-        status = fstat + nstat
-        expect_failure = status > 0
+        for nstat, nword, nval in NUMBERS:
+            test = before + fmt % nword + after
+            status = fstat + nstat
+            expect_failure = status > 0
 
-        count += 1
-        msg = (f'**** MJD PYPARSER test {count} expected %s: "{test}"; '
-               f'floating={floating}, timesys={timesys}, '
-               f'padding={padding}, embedded={embedded}')
+            count += 1
+            msg = (f'**** MJD PYPARSER test {count} expected %s: "{test}"; '
+                   f'floating={floating}, timesys={timesys}, '
+                   f'padding={padding}, embedded={embedded}')
 
         if expect_failure:
             confirm_failure(parser, test, msg=msg % 'FAILURE')

--- a/tests/test_mjd_pyparser.py
+++ b/tests/test_mjd_pyparser.py
@@ -2,78 +2,72 @@
 # julian/test_mjd_pyparser.py
 ##########################################################################################
 
-import unittest
+from tests._helpers import confirm_failure, confirm_success
 
 
-class Test_mjd_pyparser(unittest.TestCase):
+def mjd_tester(parser, floating, timesys, padding=False, embedded=False):
 
-    def runTest(self):
+    NUMBERS = []
+    for n in ['12345', '-12345', '1']:
+        NUMBERS.append((0, n, int(n)))
+    for n in ['1234.5', '-1.5']:
+        NUMBERS.append((0 if floating else 9, n, float(n)))
+    NUMBERS.append((9, '1.2.5', 0))
 
-        from julian.mjd_pyparser import mjd_pyparser
+    FMTS = []
+    for f in ['MJD %s', '%s  mjd', '%s (MJD)']:
+        FMTS.append((0, f, 'MJD', ''))
+    if floating:
+        for f in ['JD %s', '%s  jd', '%s (JD)']:
+            FMTS.append((0, f, 'JD', ''))
+    if timesys:
+        for j,t in [('MJED', 'TDB'), ('JTD', 'TT')]:
+            FMTS.append((0, f'{j.lower()} %s', j[:-2] + j[-1], t))
+            FMTS.append((0, f'%s {j}',         j[:-2] + j[-1], t))
+            FMTS.append((0, f'%s ({j})',       j[:-2] + j[-1], t))
+    FMTS.append((9, 'JXD %s', '', ''))
 
-        for padding in (False, True):
-          for embedded in (False, True):
-            for floating, timesys in ((False, False), (True, False), (True, True)):
-                parser = mjd_pyparser(floating=floating, timesys=timesys,
-                                      padding=padding, embedded=embedded)
-                self.my_mjd_tester(parser, floating=floating, timesys=timesys,
-                                   padding=padding, embedded=embedded)
+    if padding:
+        before = '  '
+        after = '  '
+    else:
+        before = ''
+        after = ''
 
-    def my_mjd_tester(self, parser, floating, timesys, padding=False, embedded=False):
+    if embedded:
+        after = ' xxx'
 
-        from tests.test_date_pyparser import Test_date_pyparser
+    count = 0
+    for fstat, fmt, yval, sval in FMTS:
+      for nstat, nword, nval in NUMBERS:
+        test = before + fmt % nword + after
+        status = fstat + nstat
+        expect_failure = status > 0
 
-        NUMBERS = []
-        for n in ['12345', '-12345', '1']:
-            NUMBERS.append((0, n, int(n)))
-        for n in ['1234.5', '-1.5']:
-            NUMBERS.append((0 if floating else 9, n, float(n)))
-        NUMBERS.append((9, '1.2.5', 0))
+        count += 1
+        msg = (f'**** MJD PYPARSER test {count} expected %s: "{test}"; '
+               f'floating={floating}, timesys={timesys}, '
+               f'padding={padding}, embedded={embedded}')
 
-        FMTS = []
-        for f in ['MJD %s', '%s  mjd', '%s (MJD)']:
-            FMTS.append((0, f, 'MJD', ''))
-        if floating:
-            for f in ['JD %s', '%s  jd', '%s (JD)']:
-                FMTS.append((0, f, 'JD', ''))
-        if timesys:
-            for j,t in [('MJED', 'TDB'), ('JTD', 'TT')]:
-                FMTS.append((0, f'{j.lower()} %s', j[:-2] + j[-1], t))
-                FMTS.append((0, f'%s {j}',         j[:-2] + j[-1], t))
-                FMTS.append((0, f'%s ({j})',       j[:-2] + j[-1], t))
-        FMTS.append((9, 'JXD %s', '', ''))
-
-        if padding:
-            before = '  '
-            after = '  '
+        if expect_failure:
+            confirm_failure(parser, test, msg=msg % 'FAILURE')
         else:
-            before = ''
-            after = ''
+            success_msg = msg % 'SUCCESS'
+            parse_dict = confirm_success(parser, test, msg=success_msg,
+                                         values=[('YEAR', yval), ('DAY', nval)])
+            assert parse_dict.get('TIMESYS', '') == sval, success_msg
 
-        if embedded:
-            after = ' xxx'
 
-        count = 0
-        for fstat, fmt, yval, sval in FMTS:
-          for nstat, nword, nval in NUMBERS:
-            test = before + fmt % nword + after
-            status = fstat + nstat
-            expect_failure = status > 0
+def test_mjd_pyparser():
 
-            count += 1
-            msg = (f'**** MJD PYPARSER test {count} expected %s: "{test}"; '
-                   f'floating={floating}, timesys={timesys}, '
-                   f'padding={padding}, embedded={embedded}')
+    from julian.mjd_pyparser import mjd_pyparser
 
-            if expect_failure:
-                Test_date_pyparser._confirm_failure(self, parser, test,
-                                                    msg=msg % 'FAILURE')
-            else:
-                success_msg = msg % 'SUCCESS'
-                parse_dict = Test_date_pyparser._confirm_success(self,
-                                                        parser, test, msg=success_msg,
-                                                        values=[('YEAR', yval),
-                                                                ('DAY', nval)])
-                self.assertEqual(parse_dict.get('TIMESYS', ''), sval, msg=success_msg)
+    for padding in (False, True):
+      for embedded in (False, True):
+        for floating, timesys in ((False, False), (True, False), (True, True)):
+            parser = mjd_pyparser(floating=floating, timesys=timesys,
+                                  padding=padding, embedded=embedded)
+            mjd_tester(parser, floating=floating, timesys=timesys,
+                       padding=padding, embedded=embedded)
 
 ##########################################################################################

--- a/tests/test_time_of_day.py
+++ b/tests/test_time_of_day.py
@@ -32,9 +32,12 @@ def test_time_of_day():
     assert hms_from_sec(86400) == (23, 59, 60)
     small = 2.**-20
     assert hms_from_sec(86410 - small) == (23, 59, 70 - small)
-    with pytest.raises(JVF): hms_from_sec(86410, validate=True, leapsecs=True)
-    with pytest.raises(JVF): hms_from_sec(86400, validate=True, leapsecs=False)
-    with pytest.raises(JVF): hms_from_sec(-1.e-30, validate=True)
+    with pytest.raises(JVF):
+        hms_from_sec(86410, validate=True, leapsecs=True)
+    with pytest.raises(JVF):
+        hms_from_sec(86400, validate=True, leapsecs=False)
+    with pytest.raises(JVF):
+        hms_from_sec(-1.e-30, validate=True)
 
     assert hms_from_sec(43200, validate=True,  leapsecs=True ) == (12, 0, 0)
     assert hms_from_sec(43200, validate=True,  leapsecs=False) == (12, 0, 0)
@@ -86,22 +89,36 @@ def test_time_of_day():
     assert sec_from_hms(0, 0, [10.,10]).dtype.kind == 'f'
 
     # Check errors
-    with pytest.raises(JVF): sec_from_hms(-1,  0,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms(24,  0,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1, -1,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1, 60,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1,  1, -1, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1,  1, 60, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(-1,  0,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(24,  0,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1, -1,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1, 60,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1,  1, -1, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1,  1, 60, validate=True)
 
-    with pytest.raises(JVF): sec_from_hms(-0.001,  0,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms(24.000,  0,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1, -0.001,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1, 60.000,  0, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1,  1, -0.001, validate=True)
-    with pytest.raises(JVF): sec_from_hms( 1,  1, 60.000, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(-0.001,  0,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(24.000,  0,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1, -0.001,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1, 60.000,  0, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1,  1, -0.001, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms( 1,  1, 60.000, validate=True)
 
-    with pytest.raises(JVF): sec_from_hms(23, 59, 70, validate=True, leapsecs=True)
-    with pytest.raises(JVF): sec_from_hms(23, 59, 60, validate=True, leapsecs=False)
+    with pytest.raises(JVF):
+        sec_from_hms(23, 59, 70, validate=True, leapsecs=True)
+    with pytest.raises(JVF):
+        sec_from_hms(23, 59, 60, validate=True, leapsecs=False)
 
     # ...but these should be fine
     _ = sec_from_hms(23, 59, 59, validate=True, leapsecs=True)
@@ -133,14 +150,19 @@ def test_time_of_day():
     assert hms_microsec_from_sec(1.2345678) == (0, 0, 1, 234568)
     assert hms_microsec_from_sec(86409.9999995) == (23, 59, 69, 999999)
     assert hms_microsec_from_sec(-0.0000004999) == (0, 0, 0, 0)
-    with pytest.raises(JVF): hms_microsec_from_sec(86410, validate=True, leapsecs=True)
-    with pytest.raises(JVF): hms_microsec_from_sec(86409.99999950001, validate=True,
-                      leapsecs=True)
-    with pytest.raises(JVF): hms_microsec_from_sec(86400, validate=True,
-                      leapsecs=False)
-    with pytest.raises(JVF): hms_microsec_from_sec(86399.99999950001, validate=True,
-                      leapsecs=False)
-    with pytest.raises(JVF): hms_microsec_from_sec(-0.0000005, validate=True)
+    with pytest.raises(JVF):
+        hms_microsec_from_sec(86410, validate=True, leapsecs=True)
+    with pytest.raises(JVF):
+        hms_microsec_from_sec(86409.99999950001, validate=True,
+                              leapsecs=True)
+    with pytest.raises(JVF):
+        hms_microsec_from_sec(86400, validate=True,
+                              leapsecs=False)
+    with pytest.raises(JVF):
+        hms_microsec_from_sec(86399.99999950001, validate=True,
+                              leapsecs=False)
+    with pytest.raises(JVF):
+        hms_microsec_from_sec(-0.0000005, validate=True)
 
     # float arrays
     # This makes about 3300 non-uniformly spaced transcendental numbers
@@ -171,7 +193,9 @@ def test_time_of_day():
     assert np.all(microsec / 1.e6 == sec)
     assert sec.shape == microsec.shape
 
-    with pytest.raises(JVF): sec_from_hms(0,  0,  0, -1, validate=True)
-    with pytest.raises(JVF): sec_from_hms(0,  0,  0, 1000000, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(0,  0,  0, -1, validate=True)
+    with pytest.raises(JVF):
+        sec_from_hms(0,  0,  0, 1000000, validate=True)
 
 ##########################################################################################

--- a/tests/test_time_of_day.py
+++ b/tests/test_time_of_day.py
@@ -4,7 +4,7 @@
 
 import numbers
 import numpy as np
-import unittest
+import pytest
 
 from julian.time_of_day import (
     hms_from_sec,
@@ -14,166 +14,164 @@ from julian.time_of_day import (
 
 from julian._exceptions import JulianValidateFailure as JVF
 
-class Test_time_of_day(unittest.TestCase):
+def test_time_of_day():
 
-    def runTest(self):
+    np.random.seed(1753)
 
-        np.random.seed(1753)
+    # Check hms_from_sec
+    assert hms_from_sec(0) == (0, 0, 0)
+    assert type(hms_from_sec(0)[0]) is int
+    assert type(hms_from_sec(0)[1]) is int
+    assert type(hms_from_sec(0)[2]) is int
 
-        # Check hms_from_sec
-        self.assertEqual(hms_from_sec(0), (0, 0, 0))
-        self.assertIs(type(hms_from_sec(0)[0]), int)
-        self.assertIs(type(hms_from_sec(0)[1]), int)
-        self.assertIs(type(hms_from_sec(0)[2]), int)
+    assert hms_from_sec(0.) == (0, 0, 0)
+    assert type(hms_from_sec(0.)[0]) is int
+    assert type(hms_from_sec(0.)[1]) is int
+    assert type(hms_from_sec(0.)[2]) is float
 
-        self.assertEqual(hms_from_sec(0.), (0, 0, 0))
-        self.assertIs(type(hms_from_sec(0.)[0]), int)
-        self.assertIs(type(hms_from_sec(0.)[1]), int)
-        self.assertIs(type(hms_from_sec(0.)[2]), float)
+    assert hms_from_sec(86400) == (23, 59, 60)
+    small = 2.**-20
+    assert hms_from_sec(86410 - small) == (23, 59, 70 - small)
+    with pytest.raises(JVF): hms_from_sec(86410, validate=True, leapsecs=True)
+    with pytest.raises(JVF): hms_from_sec(86400, validate=True, leapsecs=False)
+    with pytest.raises(JVF): hms_from_sec(-1.e-30, validate=True)
 
-        self.assertEqual(hms_from_sec(86400), (23, 59, 60))
-        small = 2.**-20
-        self.assertEqual(hms_from_sec(86410 - small), (23, 59, 70 - small))
-        self.assertRaises(JVF, hms_from_sec, 86410, validate=True, leapsecs=True)
-        self.assertRaises(JVF, hms_from_sec, 86400, validate=True, leapsecs=False)
-        self.assertRaises(JVF, hms_from_sec, -1.e-30, validate=True)
+    assert hms_from_sec(43200, validate=True,  leapsecs=True ) == (12, 0, 0)
+    assert hms_from_sec(43200, validate=True,  leapsecs=False) == (12, 0, 0)
+    assert hms_from_sec(43200, validate=False, leapsecs=True ) == (12, 0, 0)
+    assert hms_from_sec(43200, validate=False, leapsecs=False) == (12, 0, 0)
 
-        self.assertEqual(hms_from_sec(43200, validate=True,  leapsecs=True ), (12, 0, 0))
-        self.assertEqual(hms_from_sec(43200, validate=True,  leapsecs=False), (12, 0, 0))
-        self.assertEqual(hms_from_sec(43200, validate=False, leapsecs=True ), (12, 0, 0))
-        self.assertEqual(hms_from_sec(43200, validate=False, leapsecs=False), (12, 0, 0))
+    # Check sec_from_hms
+    assert sec_from_hms(0, 0, 0) == 0
+    assert type(sec_from_hms(0, 0, 0)) is int
+    assert type(sec_from_hms(0, 0, 0.)) is float
+    assert type(sec_from_hms(0, 0., 0)) is float
+    assert type(sec_from_hms(0., 0, 0)) is float
 
-        # Check sec_from_hms
-        self.assertEqual(sec_from_hms(0, 0, 0), 0)
-        self.assertIs(type(sec_from_hms(0, 0, 0)), int)
-        self.assertIs(type(sec_from_hms(0, 0, 0.)), float)
-        self.assertIs(type(sec_from_hms(0, 0., 0)), float)
-        self.assertIs(type(sec_from_hms(0., 0, 0)), float)
+    assert sec_from_hms(23, 59, 60) == 86400
+    assert type(sec_from_hms(23, 59, 60)) is int
+    assert type(sec_from_hms(23, 59, 60.)) is float
+    assert type(sec_from_hms(23, 59., 60)) is float
+    assert type(sec_from_hms(23., 59, 60)) is float
 
-        self.assertEqual(sec_from_hms(23, 59, 60), 86400)
-        self.assertIs(type(sec_from_hms(23, 59, 60)), int)
-        self.assertIs(type(sec_from_hms(23, 59, 60.)), float)
-        self.assertIs(type(sec_from_hms(23, 59., 60)), float)
-        self.assertIs(type(sec_from_hms(23., 59, 60)), float)
+    # Array tests
+    # This makes about 333,000 non-uniformly spaced transcendental numbers
+    secs = 86410. * np.sqrt(np.arange(0., 1., 3.e-6))
 
-        # Array tests
-        # This makes about 333,000 non-uniformly spaced transcendental numbers
-        secs = 86410. * np.sqrt(np.arange(0., 1., 3.e-6))
+    # Because HMS times carry extra precision, inversions should be exact
+    (h,m,s) = hms_from_sec(secs)
+    errors = (sec_from_hms(h,m,s) - secs)
+    assert np.all(errors == 0.)
 
-        # Because HMS times carry extra precision, inversions should be exact
-        (h,m,s) = hms_from_sec(secs)
-        errors = (sec_from_hms(h,m,s) - secs)
-        self.assertTrue(np.all(errors == 0.))
+    # Test all seconds
+    seclist = np.arange(0,86410)
 
-        # Test all seconds
-        seclist = np.arange(0,86410)
+    # Convert to hms and back
+    (h, m, t) = hms_from_sec(seclist)
+    test_seclist = sec_from_hms(h, m, t)
 
-        # Convert to hms and back
-        (h, m, t) = hms_from_sec(seclist)
-        test_seclist = sec_from_hms(h, m, t)
+    assert np.all(test_seclist == seclist)
 
-        self.assertTrue(np.all(test_seclist == seclist))
+    # Check types
+    assert isinstance(hms_from_sec(10)[-1], numbers.Integral)
+    assert not isinstance(hms_from_sec(10.)[-1], numbers.Integral)
 
-        # Check types
-        self.assertTrue(isinstance(hms_from_sec(10)[-1], numbers.Integral))
-        self.assertFalse(isinstance(hms_from_sec(10.)[-1], numbers.Integral))
+    assert hms_from_sec([10,10])[-1].dtype.kind == 'i'
+    assert hms_from_sec([10.,10])[-1].dtype.kind == 'f'
 
-        self.assertEqual(hms_from_sec([10,10])[-1].dtype.kind, 'i')
-        self.assertEqual(hms_from_sec([10.,10])[-1].dtype.kind, 'f')
+    assert isinstance(sec_from_hms(0, 0, 10), numbers.Integral)
+    assert not isinstance(sec_from_hms(0, 0, 10.), numbers.Integral)
 
-        self.assertTrue(isinstance(sec_from_hms(0, 0, 10), numbers.Integral))
-        self.assertFalse(isinstance(sec_from_hms(0, 0, 10.), numbers.Integral))
+    assert sec_from_hms(0, 0, [10,10]).dtype.kind == 'i'
+    assert sec_from_hms(0, 0, [10.,10]).dtype.kind == 'f'
 
-        self.assertEqual(sec_from_hms(0, 0, [10,10]).dtype.kind, 'i')
-        self.assertEqual(sec_from_hms(0, 0, [10.,10]).dtype.kind, 'f')
+    # Check errors
+    with pytest.raises(JVF): sec_from_hms(-1,  0,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms(24,  0,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1, -1,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1, 60,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1,  1, -1, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1,  1, 60, validate=True)
 
-        # Check errors
-        self.assertRaises(JVF, sec_from_hms, -1,  0,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms, 24,  0,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1, -1,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1, 60,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1,  1, -1, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1,  1, 60, validate=True)
+    with pytest.raises(JVF): sec_from_hms(-0.001,  0,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms(24.000,  0,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1, -0.001,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1, 60.000,  0, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1,  1, -0.001, validate=True)
+    with pytest.raises(JVF): sec_from_hms( 1,  1, 60.000, validate=True)
 
-        self.assertRaises(JVF, sec_from_hms, -0.001,  0,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms, 24.000,  0,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1, -0.001,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1, 60.000,  0, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1,  1, -0.001, validate=True)
-        self.assertRaises(JVF, sec_from_hms,  1,  1, 60.000, validate=True)
+    with pytest.raises(JVF): sec_from_hms(23, 59, 70, validate=True, leapsecs=True)
+    with pytest.raises(JVF): sec_from_hms(23, 59, 60, validate=True, leapsecs=False)
 
-        self.assertRaises(JVF, sec_from_hms, 23, 59, 70, validate=True, leapsecs=True)
-        self.assertRaises(JVF, sec_from_hms, 23, 59, 60, validate=True, leapsecs=False)
+    # ...but these should be fine
+    _ = sec_from_hms(23, 59, 59, validate=True, leapsecs=True)
+    _ = sec_from_hms(23, 59, 59, validate=True, leapsecs=False)
 
-        # ...but these should be fine
-        _ = sec_from_hms(23, 59, 59, validate=True, leapsecs=True)
-        _ = sec_from_hms(23, 59, 59, validate=True, leapsecs=False)
+    # Check hms_microsec_from_sec
+    assert hms_microsec_from_sec(0) == (0, 0, 0, 0)
+    assert type(hms_microsec_from_sec(0)[0]) is int
+    assert type(hms_microsec_from_sec(0)[1]) is int
+    assert type(hms_microsec_from_sec(0)[2]) is int
+    assert type(hms_microsec_from_sec(0)[3]) is int
 
-        # Check hms_microsec_from_sec
-        self.assertEqual(hms_microsec_from_sec(0), (0, 0, 0, 0))
-        self.assertIs(type(hms_microsec_from_sec(0)[0]), int)
-        self.assertIs(type(hms_microsec_from_sec(0)[1]), int)
-        self.assertIs(type(hms_microsec_from_sec(0)[2]), int)
-        self.assertIs(type(hms_microsec_from_sec(0)[3]), int)
+    assert hms_microsec_from_sec(0.) == (0, 0, 0, 0)
+    assert type(hms_microsec_from_sec(0.)[0]) is int
+    assert type(hms_microsec_from_sec(0.)[1]) is int
+    assert type(hms_microsec_from_sec(0.)[2]) is int
+    assert type(hms_microsec_from_sec(0.)[3]) is int      # always integral
 
-        self.assertEqual(hms_microsec_from_sec(0.), (0, 0, 0, 0))
-        self.assertIs(type(hms_microsec_from_sec(0.)[0]), int)
-        self.assertIs(type(hms_microsec_from_sec(0.)[1]), int)
-        self.assertIs(type(hms_microsec_from_sec(0.)[2]), int)
-        self.assertIs(type(hms_microsec_from_sec(0.)[3]), int)      # always integral
+    # int array
+    seconds = np.arange(86410)
+    test = hms_microsec_from_sec(seconds)
+    assert test[0].dtype == np.int64
+    assert test[1].dtype == np.int64
+    assert test[2].dtype == np.int64
+    assert test[3].dtype == np.int64
+    assert np.all(test[3] == 0)
 
-        # int array
-        seconds = np.arange(86410)
-        test = hms_microsec_from_sec(seconds)
-        self.assertEqual(test[0].dtype, np.int64)
-        self.assertEqual(test[1].dtype, np.int64)
-        self.assertEqual(test[2].dtype, np.int64)
-        self.assertEqual(test[3].dtype, np.int64)
-        self.assertTrue(np.all(test[3] == 0))
+    # floats
+    assert hms_microsec_from_sec(1.2345678) == (0, 0, 1, 234568)
+    assert hms_microsec_from_sec(86409.9999995) == (23, 59, 69, 999999)
+    assert hms_microsec_from_sec(-0.0000004999) == (0, 0, 0, 0)
+    with pytest.raises(JVF): hms_microsec_from_sec(86410, validate=True, leapsecs=True)
+    with pytest.raises(JVF): hms_microsec_from_sec(86409.99999950001, validate=True,
+                      leapsecs=True)
+    with pytest.raises(JVF): hms_microsec_from_sec(86400, validate=True,
+                      leapsecs=False)
+    with pytest.raises(JVF): hms_microsec_from_sec(86399.99999950001, validate=True,
+                      leapsecs=False)
+    with pytest.raises(JVF): hms_microsec_from_sec(-0.0000005, validate=True)
 
-        # floats
-        self.assertEqual(hms_microsec_from_sec(1.2345678), (0, 0, 1, 234568))
-        self.assertEqual(hms_microsec_from_sec(86409.9999995), (23, 59, 69, 999999))
-        self.assertEqual(hms_microsec_from_sec(-0.0000004999), (0, 0, 0, 0))
-        self.assertRaises(JVF, hms_microsec_from_sec, 86410, validate=True, leapsecs=True)
-        self.assertRaises(JVF, hms_microsec_from_sec, 86409.99999950001, validate=True,
-                          leapsecs=True)
-        self.assertRaises(JVF, hms_microsec_from_sec, 86400, validate=True,
-                          leapsecs=False)
-        self.assertRaises(JVF, hms_microsec_from_sec, 86399.99999950001, validate=True,
-                          leapsecs=False)
-        self.assertRaises(JVF, hms_microsec_from_sec, -0.0000005, validate=True)
+    # float arrays
+    # This makes about 3300 non-uniformly spaced transcendental numbers
+    seconds = 86410. * np.sqrt(np.arange(0., 1., 3.e-4))
+    test = hms_microsec_from_sec(seconds)
+    assert test[0].dtype == np.int64
+    assert test[1].dtype == np.int64
+    assert test[2].dtype == np.int64
+    assert test[3].dtype == np.int64
 
-        # float arrays
-        # This makes about 3300 non-uniformly spaced transcendental numbers
-        seconds = 86410. * np.sqrt(np.arange(0., 1., 3.e-4))
-        test = hms_microsec_from_sec(seconds)
-        self.assertEqual(test[0].dtype, np.int64)
-        self.assertEqual(test[1].dtype, np.int64)
-        self.assertEqual(test[2].dtype, np.int64)
-        self.assertEqual(test[3].dtype, np.int64)
+    seconds = np.arange(86410) + 0.0000005
+    assert np.all(hms_microsec_from_sec(seconds)[3]) == 0
 
-        seconds = np.arange(86410) + 0.0000005
-        self.assertTrue(np.all(hms_microsec_from_sec(seconds)[3]) == 0)
+    seconds = 86410. * np.random.rand(100,100)
+    diff = hms_microsec_from_sec(seconds)[3] - np.floor(1.e6 * (seconds%1.) + 0.5)
+    assert np.all(diff == 0)
 
-        seconds = 86410. * np.random.rand(100,100)
-        diff = hms_microsec_from_sec(seconds)[3] - np.floor(1.e6 * (seconds%1.) + 0.5)
-        self.assertTrue(np.all(diff == 0))
+    # Check sec_from_hms() with microseconds
+    assert sec_from_hms(0, 0, 0, 0) == 0
+    assert type(sec_from_hms(0, 0, 0, 0)) is int
+    assert type(sec_from_hms(0, 0, 0, 0.)) is float
+    assert type(sec_from_hms(0, 0, 0., 0)) is float
+    assert type(sec_from_hms(0, 0., 0, 0)) is float
+    assert type(sec_from_hms(0., 0, 0, 0)) is float
 
-        # Check sec_from_hms() with microseconds
-        self.assertEqual(sec_from_hms(0, 0, 0, 0), 0)
-        self.assertIs(type(sec_from_hms(0, 0, 0, 0)), int)
-        self.assertIs(type(sec_from_hms(0, 0, 0, 0.)), float)
-        self.assertIs(type(sec_from_hms(0, 0, 0., 0)), float)
-        self.assertIs(type(sec_from_hms(0, 0., 0, 0)), float)
-        self.assertIs(type(sec_from_hms(0., 0, 0, 0)), float)
+    microsec = np.arange(0, 1000000, 10).reshape(25, 4, -1)
+    sec = sec_from_hms(0, 0, 0, microsec)
+    assert np.all(microsec / 1.e6 == sec)
+    assert sec.shape == microsec.shape
 
-        microsec = np.arange(0, 1000000, 10).reshape(25, 4, -1)
-        sec = sec_from_hms(0, 0, 0, microsec)
-        self.assertTrue(np.all(microsec / 1.e6 == sec))
-        self.assertEqual(sec.shape, microsec.shape)
-
-        self.assertRaises(JVF, sec_from_hms, 0,  0,  0, -1, validate=True)
-        self.assertRaises(JVF, sec_from_hms, 0,  0,  0, 1000000, validate=True)
+    with pytest.raises(JVF): sec_from_hms(0,  0,  0, -1, validate=True)
+    with pytest.raises(JVF): sec_from_hms(0,  0,  0, 1000000, validate=True)
 
 ##########################################################################################

--- a/tests/test_time_of_day.py
+++ b/tests/test_time_of_day.py
@@ -152,7 +152,7 @@ def test_time_of_day():
     assert test[3].dtype == np.int64
 
     seconds = np.arange(86410) + 0.0000005
-    assert np.all(hms_microsec_from_sec(seconds)[3]) == 0
+    assert np.all(hms_microsec_from_sec(seconds)[3] == 0)
 
     seconds = 86410. * np.random.rand(100,100)
     diff = hms_microsec_from_sec(seconds)[3] - np.floor(1.e6 * (seconds%1.) + 0.5)

--- a/tests/test_time_parsers.py
+++ b/tests/test_time_parsers.py
@@ -40,8 +40,10 @@ def test_time_parsers():
     # sec_from_string, leapsecs
     assert sec_from_string('23:59:60.000') == 86400.0
     assert sec_from_string('23:59:69.000') == 86409.0
-    with pytest.raises(JPE): sec_from_string('23:59:70.000')
-    with pytest.raises(JPE): sec_from_string('23:59:60', leapsecs=False)
+    with pytest.raises(JPE):
+        sec_from_string('23:59:70.000')
+    with pytest.raises(JPE):
+        sec_from_string('23:59:60', leapsecs=False)
 
     # sec_from_string, am/pm
     assert sec_from_string('12:00:00 am', ampm=True) == 0
@@ -51,8 +53,10 @@ def test_time_parsers():
     assert sec_from_string(' 1:00:00 pm', ampm=True) == 43200 + 3600
     assert sec_from_string('11:59:59 pm', ampm=True) == 86399
     assert sec_from_string('11:59:60 pm', ampm=True, leapsecs=True) == 86400
-    with pytest.raises(JPE): sec_from_string('11:59:60 pm', ampm=True, leapsecs=False)
-    with pytest.raises(JPE): sec_from_string('23:00:00 am', ampm=True)
+    with pytest.raises(JPE):
+        sec_from_string('11:59:60 pm', ampm=True, leapsecs=False)
+    with pytest.raises(JPE):
+        sec_from_string('23:00:00 am', ampm=True)
 
     # sec_from_string, floating
     assert sec_from_string('12h',    floating=True) == 43200
@@ -62,7 +66,8 @@ def test_time_parsers():
     assert sec_from_string('1:10.5', floating=True) == 70.5 * 60
     assert sec_from_string('60 M',   floating=True) == 60 * 60
 
-    with pytest.raises(JPE): sec_from_string('86400s', floating=True, leapsecs=False)
+    with pytest.raises(JPE):
+        sec_from_string('86400s', floating=True, leapsecs=False)
 
     # sec_from_string, timezones, am/pm, leapsecs
     assert sec_from_string('00:00 gmt',   timezones=True) == (0, 0)
@@ -75,13 +80,17 @@ def test_time_parsers():
     assert sec_from_string('1:00 am bst', timezones=True) == (0, 0)
     assert sec_from_string('6:59:60 pm est', timezones=True, leapsecs=True) == (86400, 0)
 
-    with pytest.raises(JPE): sec_from_string('10:59:59 pm', ampm=False)
-    with pytest.raises(JPE): sec_from_string('7:59:59 pm est', ampm=True,
-                      timezones=False)
-    with pytest.raises(JPE): sec_from_string('6:59:60 pm est', ampm=True,
-                      timezones=True, leapsecs=False)
-    with pytest.raises(JVF): sec_from_string('7:59:60 pm est', ampm=True,
-                      timezones=True, leapsecs=True)
+    with pytest.raises(JPE):
+        sec_from_string('10:59:59 pm', ampm=False)
+    with pytest.raises(JPE):
+        sec_from_string('7:59:59 pm est', ampm=True,
+                        timezones=False)
+    with pytest.raises(JPE):
+        sec_from_string('6:59:60 pm est', ampm=True,
+                        timezones=True, leapsecs=False)
+    with pytest.raises(JVF):
+        sec_from_string('7:59:60 pm est', ampm=True,
+                        timezones=True, leapsecs=True)
 
     # secs_in_strings
     assert secs_in_strings('t=00:00:00.000', first=True) == 0.0

--- a/tests/test_time_parsers.py
+++ b/tests/test_time_parsers.py
@@ -2,7 +2,7 @@
 # julian/test_time_parsers.py
 ##########################################################################################
 
-import unittest
+import pytest
 
 from julian.time_parsers import (
     sec_from_string,
@@ -18,109 +18,104 @@ from julian._exceptions import JulianParseException as JPE
 from julian._exceptions import JulianValidateFailure as JVF
 
 
-class Test_time_parsers(unittest.TestCase):
+def test_time_parsers():
 
-    def runTest(self):
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
 
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+    # Note: test_time_pyparser.py has more extensive unit tests
 
-        # Note: test_time_pyparser.py has more extensive unit tests
+    # sec_from_string
+    assert sec_from_string('00:00:00.000') == 0.0
+    assert sec_from_string('00:00:00') == 0
+    assert sec_from_string('00:00:59.000') == 59.0
+    assert sec_from_string('00:00:59') == 59
 
-        # sec_from_string
-        self.assertEqual(sec_from_string('00:00:00.000'), 0.0)
-        self.assertEqual(sec_from_string('00:00:00'), 0)
-        self.assertEqual(sec_from_string('00:00:59.000'), 59.0)
-        self.assertEqual(sec_from_string('00:00:59'), 59)
+    assert type(sec_from_string('00:00:00.000')) is float
+    assert type(sec_from_string('00:00:00')) is int
+    assert type(sec_from_string('00:00:59.000')) is float
+    assert type(sec_from_string('00:00:59')) is int
 
-        self.assertIs(type(sec_from_string('00:00:00.000')), float)
-        self.assertIs(type(sec_from_string('00:00:00')), int)
-        self.assertIs(type(sec_from_string('00:00:59.000')), float)
-        self.assertIs(type(sec_from_string('00:00:59')), int)
+    # sec_from_string, leapsecs
+    assert sec_from_string('23:59:60.000') == 86400.0
+    assert sec_from_string('23:59:69.000') == 86409.0
+    with pytest.raises(JPE): sec_from_string('23:59:70.000')
+    with pytest.raises(JPE): sec_from_string('23:59:60', leapsecs=False)
 
-        # sec_from_string, leapsecs
-        self.assertEqual(sec_from_string('23:59:60.000'), 86400.0)
-        self.assertEqual(sec_from_string('23:59:69.000'), 86409.0)
-        self.assertRaises(JPE, sec_from_string, '23:59:70.000')
-        self.assertRaises(JPE, sec_from_string, '23:59:60', leapsecs=False)
+    # sec_from_string, am/pm
+    assert sec_from_string('12:00:00 am', ampm=True) == 0
+    assert sec_from_string(' 1:00:00 am', ampm=True) == 3600
+    assert sec_from_string('11:59:59 am', ampm=True) == 43199
+    assert sec_from_string('12:00:00PM ', ampm=True) == 43200
+    assert sec_from_string(' 1:00:00 pm', ampm=True) == 43200 + 3600
+    assert sec_from_string('11:59:59 pm', ampm=True) == 86399
+    assert sec_from_string('11:59:60 pm', ampm=True, leapsecs=True) == 86400
+    with pytest.raises(JPE): sec_from_string('11:59:60 pm', ampm=True, leapsecs=False)
+    with pytest.raises(JPE): sec_from_string('23:00:00 am', ampm=True)
 
-        # sec_from_string, am/pm
-        self.assertEqual(sec_from_string('12:00:00 am', ampm=True),     0)
-        self.assertEqual(sec_from_string(' 1:00:00 am', ampm=True),  3600)
-        self.assertEqual(sec_from_string('11:59:59 am', ampm=True), 43199)
-        self.assertEqual(sec_from_string('12:00:00PM ', ampm=True), 43200)
-        self.assertEqual(sec_from_string(' 1:00:00 pm', ampm=True), 43200 + 3600)
-        self.assertEqual(sec_from_string('11:59:59 pm', ampm=True), 86399)
-        self.assertEqual(sec_from_string('11:59:60 pm', ampm=True, leapsecs=True), 86400)
-        self.assertRaises(JPE, sec_from_string, '11:59:60 pm', ampm=True, leapsecs=False)
-        self.assertRaises(JPE, sec_from_string, '23:00:00 am', ampm=True)
+    # sec_from_string, floating
+    assert sec_from_string('12h',    floating=True) == 43200
+    assert sec_from_string('1.5 h',  floating=True) == 5400
+    assert sec_from_string('86399s', floating=True) == 86399
+    assert sec_from_string('86400s', floating=True, leapsecs=True) == 86400
+    assert sec_from_string('1:10.5', floating=True) == 70.5 * 60
+    assert sec_from_string('60 M',   floating=True) == 60 * 60
 
-        # sec_from_string, floating
-        self.assertEqual(sec_from_string('12h',    floating=True), 43200)
-        self.assertEqual(sec_from_string('1.5 h',  floating=True), 5400)
-        self.assertEqual(sec_from_string('86399s', floating=True), 86399)
-        self.assertEqual(sec_from_string('86400s', floating=True, leapsecs=True), 86400)
-        self.assertEqual(sec_from_string('1:10.5', floating=True), 70.5 * 60)
-        self.assertEqual(sec_from_string('60 M',   floating=True), 60 * 60)
+    with pytest.raises(JPE): sec_from_string('86400s', floating=True, leapsecs=False)
 
-        self.assertRaises(JPE, sec_from_string, '86400s', floating=True, leapsecs=False)
+    # sec_from_string, timezones, am/pm, leapsecs
+    assert sec_from_string('00:00 gmt',   timezones=True) == (0, 0)
+    assert sec_from_string('0:01 Z',      timezones=True) == (60, 0)
+    assert sec_from_string('16:00-08',    timezones=True) == (0, 1)
+    assert sec_from_string('16:00 PST',   timezones=True) == (0, 1)
+    assert sec_from_string('0:00 cet',    timezones=True) == (86400 - 3600, -1)
+    assert sec_from_string('0:00 cest',   timezones=True) == (86400 - 7200, -1)
+    assert sec_from_string('12:00am gmt', timezones=True) == (0, 0)
+    assert sec_from_string('1:00 am bst', timezones=True) == (0, 0)
+    assert sec_from_string('6:59:60 pm est', timezones=True, leapsecs=True) == (86400, 0)
 
-        # sec_from_string, timezones, am/pm, leapsecs
-        self.assertEqual(sec_from_string('00:00 gmt',   timezones=True), (0, 0))
-        self.assertEqual(sec_from_string('0:01 Z',      timezones=True), (60, 0))
-        self.assertEqual(sec_from_string('16:00-08',    timezones=True), (0, 1))
-        self.assertEqual(sec_from_string('16:00 PST',   timezones=True), (0, 1))
-        self.assertEqual(sec_from_string('0:00 cet',    timezones=True), (86400 - 3600, -1))
-        self.assertEqual(sec_from_string('0:00 cest',   timezones=True), (86400 - 7200, -1))
-        self.assertEqual(sec_from_string('12:00am gmt', timezones=True), (0, 0))
-        self.assertEqual(sec_from_string('1:00 am bst', timezones=True), (0, 0))
-        self.assertEqual(sec_from_string('6:59:60 pm est', timezones=True, leapsecs=True),
-                                         (86400, 0))
+    with pytest.raises(JPE): sec_from_string('10:59:59 pm', ampm=False)
+    with pytest.raises(JPE): sec_from_string('7:59:59 pm est', ampm=True,
+                      timezones=False)
+    with pytest.raises(JPE): sec_from_string('6:59:60 pm est', ampm=True,
+                      timezones=True, leapsecs=False)
+    with pytest.raises(JVF): sec_from_string('7:59:60 pm est', ampm=True,
+                      timezones=True, leapsecs=True)
 
-        self.assertRaises(JPE, sec_from_string, '10:59:59 pm', ampm=False)
-        self.assertRaises(JPE, sec_from_string, '7:59:59 pm est', ampm=True,
-                          timezones=False)
-        self.assertRaises(JPE, sec_from_string, '6:59:60 pm est', ampm=True,
-                          timezones=True, leapsecs=False)
-        self.assertRaises(JVF, sec_from_string, '7:59:60 pm est', ampm=True,
-                          timezones=True, leapsecs=True)
+    # secs_in_strings
+    assert secs_in_strings('t=00:00:00.000', first=True) == 0.0
+    assert secs_in_strings(['...', 't=00:00:00.000'], first=True) == 0.0
+    assert secs_in_strings(['...', 't=00:00:00.000']) == [0.]
+    assert secs_in_strings(['25:00', 't=00:00:00.000']) == [0.]
+    assert secs_in_strings('after midnight, 1:00 am bst or later',
+                                     timezones=True) == [(0, 0)]
+    assert secs_in_strings('after midnight, 1:00 am bst or later',
+                                     timezones=True, substrings=True) == [(0, 0, '1:00 am bst')]
 
-        # secs_in_strings
-        self.assertEqual(secs_in_strings('t=00:00:00.000', first=True), 0.0)
-        self.assertEqual(secs_in_strings(['...', 't=00:00:00.000'], first=True), 0.0)
-        self.assertEqual(secs_in_strings(['...', 't=00:00:00.000']), [0.])
-        self.assertEqual(secs_in_strings(['25:00', 't=00:00:00.000']), [0.])
-        self.assertEqual(secs_in_strings('after midnight, 1:00 am bst or later',
-                                         timezones=True),
-                         [(0, 0)])
-        self.assertEqual(secs_in_strings('after midnight, 1:00 am bst or later',
-                                         timezones=True, substrings=True),
-                         [(0, 0, '1:00 am bst')])
+    # DEPRECATED
 
-        # DEPRECATED
+    # Check time_in_string
+    assert time_in_string('This is the time--00:00:00.000') == 0.0
+    assert time_in_string('Is this the time? 00:00:00=now') == 0
+    assert time_in_string('Time:00:00:59.000 is now') == 59.0
+    assert time_in_string('Time (00:00:59)') == 59
+    assert time_in_string('Time (00:00:60)') == 60
+    assert time_in_string('Time (00:00:99)') is None
+    assert time_in_string('whatever') is None
 
-        # Check time_in_string
-        self.assertEqual(time_in_string('This is the time--00:00:00.000'), 0.0)
-        self.assertEqual(time_in_string('Is this the time? 00:00:00=now'), 0)
-        self.assertEqual(time_in_string('Time:00:00:59.000 is now'), 59.0)
-        self.assertEqual(time_in_string('Time (00:00:59)'), 59)
-        self.assertEqual(time_in_string('Time (00:00:60)'), 60)
-        self.assertEqual(time_in_string('Time (00:00:99)'), None)
-        self.assertEqual(time_in_string('whatever'), None)
+    # Check time_in_string with leap seconds
+    assert time_in_string('End time[23:59:60.000]') == 86400.0
+    assert time_in_string('End time is 23:59:69.000 and later') == 86409.0
+    assert time_in_string('Error 23:5z:00.000:0') is None
 
-        # Check time_in_string with leap seconds
-        self.assertEqual(time_in_string('End time[23:59:60.000]'), 86400.0)
-        self.assertEqual(time_in_string('End time is 23:59:69.000 and later'), 86409.0)
-        self.assertEqual(time_in_string('Error 23:5z:00.000:0'), None)
+    assert time_in_string('End time[23:59:60.000]', remainder=True)[1] == ']'
+    assert time_in_string('End time is 23:59:69.000 and later',
+                                    remainder=True)[1] == ' and later'
 
-        self.assertEqual(time_in_string('End time[23:59:60.000]', remainder=True)[1], ']')
-        self.assertEqual(time_in_string('End time is 23:59:69.000 and later',
-                                        remainder=True)[1], ' and later')
-
-        # Check times_in_string with leap seconds
-        self.assertEqual(times_in_string('End time[23:59:60.000]'), [86400.0])
-        self.assertEqual(times_in_string('End time is 23:59:69.000 and later'), [86409.0])
-        self.assertEqual(times_in_string('Error 23:5z:00.000:0'), [])
+    # Check times_in_string with leap seconds
+    assert times_in_string('End time[23:59:60.000]') == [86400.0]
+    assert times_in_string('End time is 23:59:69.000 and later') == [86409.0]
+    assert times_in_string('Error 23:5z:00.000:0') == []
 
 ##########################################################################################

--- a/tests/test_time_pyparser.py
+++ b/tests/test_time_pyparser.py
@@ -2,994 +2,1158 @@
 # julian/test_time_pyparser.py
 ##########################################################################################
 
-import unittest
+import pytest
 
 from pyparsing import ParseException, StringEnd
 
-class Test_time_pyparser(unittest.TestCase):
+from tests._helpers import confirm_failure, confirm_success
 
-    ####################################################################
+####################################################################
+# hour
+####################################################################
+
+def test_hour():
+
+    from julian.time_pyparser import hour, hour_strict, hour_float, \
+                                     hour_float_strict, hour_am, hour_pm \
+
+    ################################
+    # hour_strict
+    ################################
+
+    p = hour_strict + StringEnd()
+
+    # Success
+    assert p.parse_string('00')[0][0] == 'HOUR'
+    for h in range(24):
+        assert p.parse_string('%02d' % h)[0][1] == h
+
+    # Failure
+    for h in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(h))
+    for h in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(h))
+    with pytest.raises(ParseException):
+        p.parse_string('24')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
+
+    ################################
     # hour
-    ####################################################################
+    ################################
 
-    def test_hour(self):
+    p = hour + StringEnd()
 
-        from julian.time_pyparser import hour, hour_strict, hour_float, \
-                                         hour_float_strict, hour_am, hour_pm \
+    # Success
+    assert p.parse_string('00')[0][0] == 'HOUR'
+    for h in range(24):
+        assert p.parse_string('%02d' % h)[0][1] == h
+    for h in range(10):
+        assert p.parse_string(str(h))[0][1] == h
+    for h in range(10):
+        assert p.parse_string(' ' + str(h))[0][1] == h
 
-        ################################
-        # hour_strict
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('24')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = hour_strict + StringEnd()
+    ################################
+    # hour_float_strict
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'HOUR')
-        for h in range(24):
-            self.assertEqual(p.parse_string('%02d' % h)[0][1], h)
+    p = hour_float_strict + StringEnd()
 
-        # Failure
-        for h in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(h))
-        for h in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(h))
-        self.assertRaises(ParseException, p.parse_string, '24')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'HOUR'
+    for h in range(24):
+        assert p.parse_string('%02d.5' % h)[0][1] == h + 0.5
 
-        ################################
-        # hour
-        ################################
+    # Failure
+    for h in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(h) + '.5')
+    for h in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(h) + '.5')
+    with pytest.raises(ParseException):
+        p.parse_string('23')
+    with pytest.raises(ParseException):
+        p.parse_string('24.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0.')
+    with pytest.raises(ParseException):
+        p.parse_string('000.')
 
-        p = hour + StringEnd()
+    ################################
+    # hour_float
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'HOUR')
-        for h in range(24):
-            self.assertEqual(p.parse_string('%02d' % h)[0][1], h)
-        for h in range(10):
-            self.assertEqual(p.parse_string(str(h))[0][1], h)
-        for h in range(10):
-            self.assertEqual(p.parse_string(' ' + str(h))[0][1], h)
+    p = hour_float + StringEnd()
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '24')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'HOUR'
+    for h in range(24):
+        assert p.parse_string('%02d.5' % h)[0][1] == h + 0.5
+    for h in range(10):
+        assert p.parse_string(str(h) + '.5')[0][1] == h + 0.5
+    for h in range(10):
+        assert p.parse_string(' ' + str(h) + '.5')[0][1] == h + 0.5
 
-        ################################
-        # hour_float_strict
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('23')
+    with pytest.raises(ParseException):
+        p.parse_string('24.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000.')
 
-        p = hour_float_strict + StringEnd()
+    ################################
+    # hour_am
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'HOUR')
-        for h in range(24):
-            self.assertEqual(p.parse_string('%02d.5' % h)[0][1], h + 0.5)
+    p = hour_am + StringEnd()
 
-        # Failure
-        for h in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(h) + '.5')
-        for h in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(h) + '.5')
-        self.assertRaises(ParseException, p.parse_string, '23')
-        self.assertRaises(ParseException, p.parse_string, '24.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0.')
-        self.assertRaises(ParseException, p.parse_string, '000.')
+    # Success
+    assert p.parse_string('01')[0][0] == 'HOUR'
+    for h in range(1,12):
+        assert p.parse_string('%02d' % h)[0][1] == h
+    assert p.parse_string('12')[0][1] == 0
+    for h in range(1,10):
+        assert p.parse_string(str(h))[0][1] == h
+    for h in range(1,10):
+        assert p.parse_string(' ' + str(h))[0][1] == h
 
-        ################################
-        # hour_float
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string('13')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = hour_float + StringEnd()
+    ################################
+    # hour_pm
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'HOUR')
-        for h in range(24):
-            self.assertEqual(p.parse_string('%02d.5' % h)[0][1], h + 0.5)
-        for h in range(10):
-            self.assertEqual(p.parse_string(str(h) + '.5')[0][1], h + 0.5)
-        for h in range(10):
-            self.assertEqual(p.parse_string(' ' + str(h) + '.5')[0][1], h + 0.5)
+    p = hour_pm + StringEnd()
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '23')
-        self.assertRaises(ParseException, p.parse_string, '24.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000.')
+    # Success
+    assert p.parse_string('01')[0][0] == 'HOUR'
+    for h in range(1,12):
+        assert p.parse_string('%02d' % h)[0][1] == h+12
+    assert p.parse_string('12')[0][1] == 12
+    for h in range(1,10):
+        assert p.parse_string(str(h))[0][1] == h+12
+    for h in range(1,10):
+        assert p.parse_string(' ' + str(h))[0][1] == h+12
 
-        ################################
-        # hour_am
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('00')
+    with pytest.raises(ParseException):
+        p.parse_string('13')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = hour_am + StringEnd()
+####################################################################
+# minute
+####################################################################
 
-        # Success
-        self.assertEqual(p.parse_string('01')[0][0], 'HOUR')
-        for h in range(1,12):
-            self.assertEqual(p.parse_string('%02d' % h)[0][1], h)
-        self.assertEqual(p.parse_string('12')[0][1], 0)
-        for h in range(1,10):
-            self.assertEqual(p.parse_string(str(h))[0][1], h)
-        for h in range(1,10):
-            self.assertEqual(p.parse_string(' ' + str(h))[0][1], h)
+def test_minute():
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, '13')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    from julian.time_pyparser import minute, minute_strict, minute_float, \
+                                     minute_float_strict, minute1439, \
+                                     minute1439_float
 
-        ################################
-        # hour_pm
-        ################################
+    ################################
+    # minute_strict
+    ################################
 
-        p = hour_pm + StringEnd()
+    p = minute_strict + StringEnd()
 
-        # Success
-        self.assertEqual(p.parse_string('01')[0][0], 'HOUR')
-        for h in range(1,12):
-            self.assertEqual(p.parse_string('%02d' % h)[0][1], h+12)
-        self.assertEqual(p.parse_string('12')[0][1], 12)
-        for h in range(1,10):
-            self.assertEqual(p.parse_string(str(h))[0][1], h+12)
-        for h in range(1,10):
-            self.assertEqual(p.parse_string(' ' + str(h))[0][1], h+12)
+    # Success
+    assert p.parse_string('00')[0][0] == 'MINUTE'
+    for m in range(60):
+        assert p.parse_string('%02d' % m)[0][1] == m
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '00')
-        self.assertRaises(ParseException, p.parse_string, '13')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Failure
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(m))
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(m))
+    with pytest.raises(ParseException):
+        p.parse_string('60')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-    ####################################################################
+    ################################
     # minute
-    ####################################################################
+    ################################
 
-    def test_minute(self):
+    p = minute + StringEnd()
 
-        from julian.time_pyparser import minute, minute_strict, minute_float, \
-                                         minute_float_strict, minute1439, \
-                                         minute1439_float
+    # Success
+    assert p.parse_string('00')[0][0] == 'MINUTE'
+    for m in range(60):
+        assert p.parse_string('%02d' % m)[0][1] == m
+    for m in range(10):
+        assert p.parse_string(' ' + str(m))[0][1] == m
 
-        ################################
-        # minute_strict
-        ################################
+    # Failure
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(m))
+    with pytest.raises(ParseException):
+        p.parse_string('60')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = minute_strict + StringEnd()
+    ################################
+    # minute_float_strict
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'MINUTE')
-        for m in range(60):
-            self.assertEqual(p.parse_string('%02d' % m)[0][1], m)
+    p = minute_float_strict + StringEnd()
 
-        # Failure
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(m))
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(m))
-        self.assertRaises(ParseException, p.parse_string, '60')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'MINUTE'
+    for m in range(60):
+        assert p.parse_string('%02d.5' % m)[0][1] == m + 0.5
 
-        ################################
-        # minute
-        ################################
+    # Failure
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(m))
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(m))
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('60.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0.5')
+    with pytest.raises(ParseException):
+        p.parse_string('000.5')
 
-        p = minute + StringEnd()
+    ################################
+    # minute_float
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'MINUTE')
-        for m in range(60):
-            self.assertEqual(p.parse_string('%02d' % m)[0][1], m)
-        for m in range(10):
-            self.assertEqual(p.parse_string(' ' + str(m))[0][1], m)
+    p = minute_float + StringEnd()
 
-        # Failure
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(m))
-        self.assertRaises(ParseException, p.parse_string, '60')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'MINUTE'
+    for m in range(60):
+        assert p.parse_string('%02d.5' % m)[0][1] == m + 0.5
+    for m in range(10):
+        assert p.parse_string(' ' + str(m) + '.5')[0][1] == m + 0.5
 
-        ################################
-        # minute_float_strict
-        ################################
+    # Failure
+    for m in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(m) + '.5')
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('60.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0.5')
+    with pytest.raises(ParseException):
+        p.parse_string('000.5')
 
-        p = minute_float_strict + StringEnd()
+    ################################
+    # minute1439
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'MINUTE')
-        for m in range(60):
-            self.assertEqual(p.parse_string('%02d.5' % m)[0][1], m + 0.5)
+    p = minute1439 + StringEnd()
 
-        # Failure
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(m))
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(m))
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '60.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0.5')
-        self.assertRaises(ParseException, p.parse_string, '000.5')
+    # Success
+    assert p.parse_string('0')[0][0] == 'MINUTE'
+    for m in range(1440):
+        assert p.parse_string(str(m))[0][1] == m
 
-        ################################
-        # minute_float
-        ################################
+    # Failure
+    for m in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(m))
+    for m in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(m))
 
-        p = minute_float + StringEnd()
+    with pytest.raises(ParseException):
+        p.parse_string('1440')
+    with pytest.raises(ParseException):
+        p.parse_string('1500')
+    with pytest.raises(ParseException):
+        p.parse_string('2000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 1000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 100')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'MINUTE')
-        for m in range(60):
-            self.assertEqual(p.parse_string('%02d.5' % m)[0][1], m + 0.5)
-        for m in range(10):
-            self.assertEqual(p.parse_string(' ' + str(m) + '.5')[0][1], m + 0.5)
+    ################################
+    # minute1439_float
+    ################################
 
-        # Failure
-        for m in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(m) + '.5')
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '60.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0.5')
-        self.assertRaises(ParseException, p.parse_string, '000.5')
+    p = minute1439_float + StringEnd()
 
-        ################################
-        # minute1439
-        ################################
+    # Success
+    assert p.parse_string('0.5')[0][0] == 'MINUTE'
+    for m in range(1440):
+        assert p.parse_string(str(m) + '.5')[0][1] == m + 0.5
 
-        p = minute1439 + StringEnd()
+    # Failure
+    for m in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(m))
+    for m in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(m))
 
-        # Success
-        self.assertEqual(p.parse_string('0')[0][0], 'MINUTE')
-        for m in range(1440):
-            self.assertEqual(p.parse_string(str(m))[0][1], m)
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('1440')
+    with pytest.raises(ParseException):
+        p.parse_string('1500')
+    with pytest.raises(ParseException):
+        p.parse_string('2000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 1000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 100')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Failure
-        for m in range(100):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(m))
-        for m in range(100):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(m))
+####################################################################
+# second
+####################################################################
 
-        self.assertRaises(ParseException, p.parse_string, '1440')
-        self.assertRaises(ParseException, p.parse_string, '1500')
-        self.assertRaises(ParseException, p.parse_string, '2000')
-        self.assertRaises(ParseException, p.parse_string, ' 1000')
-        self.assertRaises(ParseException, p.parse_string, ' 100')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+def test_second():
 
-        ################################
-        # minute1439_float
-        ################################
+    from julian.time_pyparser import second, second_strict, second_float, \
+                                     second_float_strict, second86399, \
+                                     second86399_float
 
-        p = minute1439_float + StringEnd()
+    ################################
+    # second_strict
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('0.5')[0][0], 'MINUTE')
-        for m in range(1440):
-            self.assertEqual(p.parse_string(str(m) + '.5')[0][1], m + 0.5)
+    p = second_strict + StringEnd()
 
-        # Failure
-        for m in range(100):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(m))
-        for m in range(100):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(m))
+    # Success
+    assert p.parse_string('00')[0][0] == 'SECOND'
+    for s in range(60):
+        assert p.parse_string('%02d' % s)[0][1] == s
 
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '1440')
-        self.assertRaises(ParseException, p.parse_string, '1500')
-        self.assertRaises(ParseException, p.parse_string, '2000')
-        self.assertRaises(ParseException, p.parse_string, ' 1000')
-        self.assertRaises(ParseException, p.parse_string, ' 100')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Failure
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(s))
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s))
+    with pytest.raises(ParseException):
+        p.parse_string('60')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-    ####################################################################
+    ################################
     # second
-    ####################################################################
+    ################################
 
-    def test_second(self):
+    p = second + StringEnd()
 
-        from julian.time_pyparser import second, second_strict, second_float, \
-                                         second_float_strict, second86399, \
-                                         second86399_float
+    # Success
+    assert p.parse_string('00')[0][0] == 'SECOND'
+    for s in range(60):
+        assert p.parse_string('%02d' % s)[0][1] == s
+    for s in range(10):
+        assert p.parse_string(' ' + str(s))[0][1] == s
 
-        ################################
-        # second_strict
-        ################################
+    # Failure
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(s))
+    with pytest.raises(ParseException):
+        p.parse_string('60')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = second_strict + StringEnd()
+    ################################
+    # second_float_strict
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'SECOND')
-        for s in range(60):
-            self.assertEqual(p.parse_string('%02d' % s)[0][1], s)
+    p = second_float_strict + StringEnd()
 
-        # Failure
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(s))
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s))
-        self.assertRaises(ParseException, p.parse_string, '60')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'SECOND'
+    for s in range(60):
+        assert p.parse_string('%02d.5' % s)[0][1] == s + 0.5
 
-        ################################
-        # second
-        ################################
+    # Failure
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(s))
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s))
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('60.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000.5')
 
-        p = second + StringEnd()
+    ################################
+    # second_float
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00')[0][0], 'SECOND')
-        for s in range(60):
-            self.assertEqual(p.parse_string('%02d' % s)[0][1], s)
-        for s in range(10):
-            self.assertEqual(p.parse_string(' ' + str(s))[0][1], s)
+    p = second_float + StringEnd()
 
-        # Failure
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(s))
-        self.assertRaises(ParseException, p.parse_string, '60')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('00.')[0][0] == 'SECOND'
+    for s in range(60):
+        assert p.parse_string('%02d.5' % s)[0][1] == s + 0.5
+    for s in range(10):
+        assert p.parse_string(' ' + str(s) + '.5')[0][1] == s + 0.5
 
-        ################################
-        # second_float_strict
-        ################################
+    # Failure
+    for s in range(10):
+        with pytest.raises(ParseException):
+            p.parse_string(str(s) + '.5')
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('60.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0.5')
+    with pytest.raises(ParseException):
+        p.parse_string('000.5')
 
-        p = second_float_strict + StringEnd()
+    ################################
+    # second86399
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'SECOND')
-        for s in range(60):
-            self.assertEqual(p.parse_string('%02d.5' % s)[0][1], s + 0.5)
+    p = second86399 + StringEnd()
 
-        # Failure
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(s))
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s))
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '60.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000.5')
+    # Success
+    assert p.parse_string('0')[0][0] == 'SECOND'
+    for s in (1, 10, 100, 1000, 10000, 80000, 86000, 86300, 86399):
+        assert p.parse_string(str(s))[0][1] == s
 
-        ################################
-        # second_float
-        ################################
+    # Failure
+    for s in (100, 200, 400, 800, 999):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s))
+    for s in (100, 200, 400, 800, 999):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(s))
 
-        p = second_float + StringEnd()
+    with pytest.raises(ParseException):
+        p.parse_string('86400')
+    with pytest.raises(ParseException):
+        p.parse_string('87000')
+    with pytest.raises(ParseException):
+        p.parse_string('90000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 1000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 100')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Success
-        self.assertEqual(p.parse_string('00.')[0][0], 'SECOND')
-        for s in range(60):
-            self.assertEqual(p.parse_string('%02d.5' % s)[0][1], s + 0.5)
-        for s in range(10):
-            self.assertEqual(p.parse_string(' ' + str(s) + '.5')[0][1], s + 0.5)
+    ################################
+    # second86399_float
+    ################################
 
-        # Failure
-        for s in range(10):
-            self.assertRaises(ParseException, p.parse_string, str(s) + '.5')
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '60.')
-        self.assertRaises(ParseException, p.parse_string, ' 10.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0.5')
-        self.assertRaises(ParseException, p.parse_string, '000.5')
+    p = second86399_float + StringEnd()
 
-        ################################
-        # second86399
-        ################################
+    # Success
+    assert p.parse_string('0.5')[0][0] == 'SECOND'
+    for s in range(1440):
+        assert p.parse_string(str(s) + '.5')[0][1] == s + 0.5
 
-        p = second86399 + StringEnd()
+    # Failure
+    for s in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s))
+    for s in range(100):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(s))
 
-        # Success
-        self.assertEqual(p.parse_string('0')[0][0], 'SECOND')
-        for s in (1, 10, 100, 1000, 10000, 80000, 86000, 86300, 86399):
-            self.assertEqual(p.parse_string(str(s))[0][1], s)
+    with pytest.raises(ParseException):
+        p.parse_string('10')
+    with pytest.raises(ParseException):
+        p.parse_string('1440')
+    with pytest.raises(ParseException):
+        p.parse_string('1500')
+    with pytest.raises(ParseException):
+        p.parse_string('2000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 1000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 100')
+    with pytest.raises(ParseException):
+        p.parse_string(' 10')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Failure
-        for s in (100, 200, 400, 800, 999):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s))
-        for s in (100, 200, 400, 800, 999):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(s))
+####################################################################
+# leapsec
+####################################################################
 
-        self.assertRaises(ParseException, p.parse_string, '86400')
-        self.assertRaises(ParseException, p.parse_string, '87000')
-        self.assertRaises(ParseException, p.parse_string, '90000')
-        self.assertRaises(ParseException, p.parse_string, ' 10000')
-        self.assertRaises(ParseException, p.parse_string, ' 1000')
-        self.assertRaises(ParseException, p.parse_string, ' 100')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+def test_leapsec():
 
-        ################################
-        # second86399_float
-        ################################
+    from julian.time_pyparser import leapsec, leapsec_float, \
+                                     leapsec86409, leapsec86409_float
 
-        p = second86399_float + StringEnd()
-
-        # Success
-        self.assertEqual(p.parse_string('0.5')[0][0], 'SECOND')
-        for s in range(1440):
-            self.assertEqual(p.parse_string(str(s) + '.5')[0][1], s + 0.5)
-
-        # Failure
-        for s in range(100):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s))
-        for s in range(100):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(s))
-
-        self.assertRaises(ParseException, p.parse_string, '10')
-        self.assertRaises(ParseException, p.parse_string, '1440')
-        self.assertRaises(ParseException, p.parse_string, '1500')
-        self.assertRaises(ParseException, p.parse_string, '2000')
-        self.assertRaises(ParseException, p.parse_string, ' 1000')
-        self.assertRaises(ParseException, p.parse_string, ' 100')
-        self.assertRaises(ParseException, p.parse_string, ' 10')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
-
-    ####################################################################
+    ################################
     # leapsec
-    ####################################################################
+    ################################
 
-    def test_leapsec(self):
+    p = leapsec + StringEnd()
 
-        from julian.time_pyparser import leapsec, leapsec_float, \
-                                         leapsec86409, leapsec86409_float
+    # Success
+    assert p.parse_string('60')[0][0] == 'SECOND'
+    for s in range(60,70):
+        assert p.parse_string(str(s))[0][1] == s
 
-        ################################
-        # leapsec
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('70')
+    with pytest.raises(ParseException):
+        p.parse_string('90')
+    with pytest.raises(ParseException):
+        p.parse_string(' 60')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('0')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        p = leapsec + StringEnd()
+    ################################
+    # leapsec_float
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('60')[0][0], 'SECOND')
-        for s in range(60,70):
-            self.assertEqual(p.parse_string(str(s))[0][1], s)
+    p = leapsec_float + StringEnd()
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '70')
-        self.assertRaises(ParseException, p.parse_string, '90')
-        self.assertRaises(ParseException, p.parse_string, ' 60')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '0')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('60.')[0][0] == 'SECOND'
+    for s in range(60,70):
+        assert p.parse_string(str(s) + '.5')[0][1] == s + 0.5
 
-        ################################
-        # leapsec_float
-        ################################
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('60')
+    with pytest.raises(ParseException):
+        p.parse_string('70.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 60.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a.')
+    with pytest.raises(ParseException):
+        p.parse_string('0.5')
+    with pytest.raises(ParseException):
+        p.parse_string('060.5')
 
-        p = leapsec_float + StringEnd()
+    ################################
+    # leapsec86409
+    ################################
 
-        # Success
-        self.assertEqual(p.parse_string('60.')[0][0], 'SECOND')
-        for s in range(60,70):
-            self.assertEqual(p.parse_string(str(s) + '.5')[0][1], s + 0.5)
+    p = leapsec86409 + StringEnd()
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '60')
-        self.assertRaises(ParseException, p.parse_string, '70.')
-        self.assertRaises(ParseException, p.parse_string, ' 60.5')
-        self.assertRaises(ParseException, p.parse_string, 'a.')
-        self.assertRaises(ParseException, p.parse_string, '0.5')
-        self.assertRaises(ParseException, p.parse_string, '060.5')
+    # Success
+    assert p.parse_string('86400')[0][0] == 'SECOND'
+    for s in range(86000, 86410):
+        assert p.parse_string(str(s))[0][1] == s
 
-        ################################
-        # leapsec86409
-        ################################
+    # Failure
+    for s in range(86000, 86400):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s))
+    for s in range(86000, 86400):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(s))
 
-        p = leapsec86409 + StringEnd()
+    with pytest.raises(ParseException):
+        p.parse_string('86410')
+    with pytest.raises(ParseException):
+        p.parse_string('87000')
+    with pytest.raises(ParseException):
+        p.parse_string('90000')
+    with pytest.raises(ParseException):
+        p.parse_string(' 86400')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Success
-        self.assertEqual(p.parse_string('86400')[0][0], 'SECOND')
-        for s in range(86000, 86410):
-            self.assertEqual(p.parse_string(str(s))[0][1], s)
+    ################################
+    # leapsec86409_float
+    ################################
 
-        # Failure
-        for s in range(86000, 86400):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s))
-        for s in range(86000, 86400):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(s))
+    p = leapsec86409_float + StringEnd()
 
-        self.assertRaises(ParseException, p.parse_string, '86410')
-        self.assertRaises(ParseException, p.parse_string, '87000')
-        self.assertRaises(ParseException, p.parse_string, '90000')
-        self.assertRaises(ParseException, p.parse_string, ' 86400')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    # Success
+    assert p.parse_string('86400.')[0][0] == 'SECOND'
+    for s in range(86000, 86410):
+        assert p.parse_string(str(s) + '.5')[0][1] == s+ 0.5
 
-        ################################
-        # leapsec86409_float
-        ################################
+    # Failure
+    for s in range(86330, 86400):
+        with pytest.raises(ParseException):
+            p.parse_string(' ' + str(s) + '.')
+    for s in range(86300, 86400):
+        with pytest.raises(ParseException):
+            p.parse_string('0' + str(s) + '.')
 
-        p = leapsec86409_float + StringEnd()
+    with pytest.raises(ParseException):
+        p.parse_string('86400')
+    with pytest.raises(ParseException):
+        p.parse_string('86410.')
+    with pytest.raises(ParseException):
+        p.parse_string('87000.')
+    with pytest.raises(ParseException):
+        p.parse_string('90000.')
+    with pytest.raises(ParseException):
+        p.parse_string(' 86400.5')
+    with pytest.raises(ParseException):
+        p.parse_string('a')
+    with pytest.raises(ParseException):
+        p.parse_string('000')
 
-        # Success
-        self.assertEqual(p.parse_string('86400.')[0][0], 'SECOND')
-        for s in range(86000, 86410):
-            self.assertEqual(p.parse_string(str(s) + '.5')[0][1], s+ 0.5)
+####################################################################
+# timezone
+####################################################################
 
-        # Failure
-        for s in range(86330, 86400):
-            self.assertRaises(ParseException, p.parse_string, ' ' + str(s) + '.')
-        for s in range(86300, 86400):
-            self.assertRaises(ParseException, p.parse_string, '0' + str(s) + '.')
+def test_tz():
 
-        self.assertRaises(ParseException, p.parse_string, '86400')
-        self.assertRaises(ParseException, p.parse_string, '86410.')
-        self.assertRaises(ParseException, p.parse_string, '87000.')
-        self.assertRaises(ParseException, p.parse_string, '90000.')
-        self.assertRaises(ParseException, p.parse_string, ' 86400.5')
-        self.assertRaises(ParseException, p.parse_string, 'a')
-        self.assertRaises(ParseException, p.parse_string, '000')
+    from julian.time_pyparser import hhmm_tz, named_tz, timezone
 
-    ####################################################################
-    # timezone
-    ####################################################################
+    ################################
+    # hhmm_tz
+    ################################
 
-    def test_tz(self):
+    p = hhmm_tz + StringEnd()
 
-        from julian.time_pyparser import hhmm_tz, named_tz, timezone
+    # Success
+    assert p.parse_string('Z')[:2] == [('TZ', 'Z'), ('TZMIN', 0)]
+    assert p.parse_string('+00')[:2] == [('TZ', '+00'), ('TZMIN', 0)]
+    for s in ('-', '+'):
+        for h in range(0,15):
+            test = s + '%02d' % h
+            assert p.parse_string(test)[0][1] == test
+            assert p.parse_string(test)[1][1] == 60 * int(s+'1') * h
+            for m in (0, 15, 30, 45):
+                test1 = test + ':%02d' % m
+                assert p.parse_string(test1)[0][1] == test1
+                assert p.parse_string(test1)[1][1] == int(s+'1') * (60*h + m)
 
-        ################################
-        # hhmm_tz
-        ################################
+                test2 = test + '%02d' % m
+                assert p.parse_string(test2)[0][1] == test2
+                assert p.parse_string(test2)[1][1] == int(s+'1') * (60*h + m)
 
-        p = hhmm_tz + StringEnd()
+    assert p.parse_string(' Z')[0] == ('TZ', 'Z')
+    assert p.parse_string(' z')[0] == ('TZ', 'Z')
 
-        # Success
-        self.assertEqual(p.parse_string('Z')[:2], [('TZ', 'Z'), ('TZMIN', 0)])
-        self.assertEqual(p.parse_string('+00')[:2], [('TZ', '+00'), ('TZMIN', 0)])
-        for s in ('-', '+'):
-            for h in range(0,15):
-                test = s + '%02d' % h
-                self.assertEqual(p.parse_string(test)[0][1], test)
-                self.assertEqual(p.parse_string(test)[1][1], 60 * int(s+'1') * h)
-                for m in (0, 15, 30, 45):
-                    test1 = test + ':%02d' % m
-                    self.assertEqual(p.parse_string(test1)[0][1], test1)
-                    self.assertEqual(p.parse_string(test1)[1][1], int(s+'1') * (60*h + m))
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('+0')
+    with pytest.raises(ParseException):
+        p.parse_string('+ 0')
+    with pytest.raises(ParseException):
+        p.parse_string(' +0')
+    with pytest.raises(ParseException):
+        p.parse_string('+00:14')
 
-                    test2 = test + '%02d' % m
-                    self.assertEqual(p.parse_string(test2)[0][1], test2)
-                    self.assertEqual(p.parse_string(test2)[1][1], int(s+'1') * (60*h + m))
+    ################################
+    # named_tz
+    ################################
 
-        self.assertEqual(p.parse_string(' Z')[0], ('TZ', 'Z'))
-        self.assertEqual(p.parse_string(' z')[0], ('TZ', 'Z'))
+    p = named_tz + StringEnd()
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '+0')
-        self.assertRaises(ParseException, p.parse_string, '+ 0')
-        self.assertRaises(ParseException, p.parse_string, ' +0')
-        self.assertRaises(ParseException, p.parse_string, '+00:14')
-
-        ################################
-        # named_tz
-        ################################
-
-        p = named_tz + StringEnd()
-
-        # Success
-        self.assertEqual(p.parse_string('PST')[:2], [('TZ', 'PST'), ('TZMIN', -8 * 60)])
-        for name, h in [('GMT',0), ('  gmT',0), ('  z',0), ('Z',0),
-                        ('EST',-5), (' pdt',-7)]:
-            for space in ('', ' '):
-                self.assertEqual(p.parse_string(space + name)[0][1], name.lstrip().upper())
-                self.assertEqual(p.parse_string(space + name)[1][1], 60 * h)
-
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, 'ABC')
-
-        ################################
-        # timezone
-        ################################
-
-        p = timezone + StringEnd()
-
-        # Success
-        self.assertEqual(p.parse_string('PsT')[:2], [('TZ', 'PST'), ('TZMIN', -8 * 60)])
-        self.assertEqual(p.parse_string('  z')[:2], [('TZ', 'Z'), ('TZMIN', 0)])
-        self.assertEqual(p.parse_string('+00')[:2], [('TZ', '+00'), ('TZMIN', 0)])
-        for s in ('-', '+'):
-            for h in range(0,15):
-                test = s + '%02d' % h
-                sign = -1 if s == '-' else +1
-                self.assertEqual(p.parse_string(test)[0][1], test)
-                self.assertEqual(p.parse_string(test)[1][1], 60 * sign * h)
-                for m in (0, 15, 30, 45):
-                    test1 = test + ':%02d' % m
-                    self.assertEqual(p.parse_string(test1)[0][1], test1)
-                    self.assertEqual(p.parse_string(test1)[1][1], sign * (60*h + m))
-
-                    test2 = test + '%02d' % m
-                    self.assertEqual(p.parse_string(test2)[0][1], test2)
-                    self.assertEqual(p.parse_string(test2)[1][1], sign * (60*h + m))
-
-        for name, h in [('GMT',0), ('EST',-5), ('PDT',-7)]:
-            for space in ('', ' '):
-                self.assertEqual(p.parse_string(space + name)[0][1], name)
-                self.assertEqual(p.parse_string(space + name)[1][1], 60 * h)
-
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, '+0')
-        self.assertRaises(ParseException, p.parse_string, '+ 0')
-        self.assertRaises(ParseException, p.parse_string, ' +0')
-        self.assertRaises(ParseException, p.parse_string, '+00:14')
-        self.assertRaises(ParseException, p.parse_string, 'ABC')
-
-    ####################################################################
-    # timesys
-    ####################################################################
-
-    def test_timesys(self):
-
-        from julian.time_pyparser import timesys
-
-        p = timesys + StringEnd()
-
-        # Success
+    # Success
+    assert p.parse_string('PST')[:2] == [('TZ', 'PST'), ('TZMIN', -8 * 60)]
+    for name, h in [('GMT',0), ('  gmT',0), ('  z',0), ('Z',0),
+                    ('EST',-5), (' pdt',-7)]:
         for space in ('', ' '):
-            self.assertEqual(p.parse_string(space + 'UTC')[0][1], 'UTC')
-            self.assertEqual(p.parse_string(space + 'utc')[0][1], 'UTC')
-            self.assertEqual(p.parse_string(space + 'UT') [0][1], 'UTC')
-            self.assertEqual(p.parse_string(space + 'UT1')[0][1], 'UTC')
-            self.assertEqual(p.parse_string(space + 'TAI')[0][1], 'TAI')
-            self.assertEqual(p.parse_string(space + 'tai')[0][1], 'TAI')
-            self.assertEqual(p.parse_string(space + 'TDB')[0][1], 'TDB')
-            self.assertEqual(p.parse_string(space + 'ET') [0][1], 'TDB')
-            self.assertEqual(p.parse_string(space + 'TDT')[0][1], 'TT' )
-            self.assertEqual(p.parse_string(space + 'TT') [0][1], 'TT' )
-            self.assertEqual(p.parse_string(space + 'tt') [0][1], 'TT' )
-            self.assertEqual(p.parse_string(space + 'Z')  [0][1], 'UTC')
+            assert p.parse_string(space + name)[0][1] == name.lstrip().upper()
+            assert p.parse_string(space + name)[1][1] == 60 * h
 
-        # Failure
-        self.assertRaises(ParseException, p.parse_string, 'PST')
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('ABC')
 
-    ####################################################################
-    # time_pyparser
-    ####################################################################
+    ################################
+    # timezone
+    ################################
 
-    def my_time_tester(self, parser, *, leapsecs=False, ampm=False, timezones=False,
-                             floating=False, timesys=False, iso_only=False,
-                             padding=False, embedded=False, failure=False):
+    p = timezone + StringEnd()
 
-        from tests.test_date_pyparser import Test_date_pyparser
+    # Success
+    assert p.parse_string('PsT')[:2] == [('TZ', 'PST'), ('TZMIN', -8 * 60)]
+    assert p.parse_string('  z')[:2] == [('TZ', 'Z'), ('TZMIN', 0)]
+    assert p.parse_string('+00')[:2] == [('TZ', '+00'), ('TZMIN', 0)]
+    for s in ('-', '+'):
+        for h in range(0,15):
+            test = s + '%02d' % h
+            sign = -1 if s == '-' else +1
+            assert p.parse_string(test)[0][1] == test
+            assert p.parse_string(test)[1][1] == 60 * sign * h
+            for m in (0, 15, 30, 45):
+                test1 = test + ':%02d' % m
+                assert p.parse_string(test1)[0][1] == test1
+                assert p.parse_string(test1)[1][1] == sign * (60*h + m)
 
-        HOURS = []
-        for h in [0, 1, 9, 23, 24]:
-            HOURS.append((9 if h >= 24 else 0, '%02d' % h, h))
-            if h < 10:
-                HOURS.append((9 if iso_only else 1, str(h), h))
+                test2 = test + '%02d' % m
+                assert p.parse_string(test2)[0][1] == test2
+                assert p.parse_string(test2)[1][1] == sign * (60*h + m)
 
-        MINUTES = []
-        for m in [0, 1, 14, 59, 60]:
-            MINUTES.append((9 if m >= 60 else 0, '%02d' % m, m))
-            if m < 10:
-                MINUTES.append((9 if iso_only else 1, '%2d' % m, m))
+    for name, h in [('GMT',0), ('EST',-5), ('PDT',-7)]:
+        for space in ('', ' '):
+            assert p.parse_string(space + name)[0][1] == name
+            assert p.parse_string(space + name)[1][1] == 60 * h
 
-        SECONDS = []
-        for s in [0, 1, 9, 59, 70]:
-            SECONDS.append((9 if s >= 70 else 0, '%02d' % s, s))
-            if s < 10:
-                SECONDS.append((9 if iso_only else 1, '%2d' % s, s))
-        for s in [60, 69]:
-            SECONDS.append((0 if leapsecs else 9, str(s), s))
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('+0')
+    with pytest.raises(ParseException):
+        p.parse_string('+ 0')
+    with pytest.raises(ParseException):
+        p.parse_string(' +0')
+    with pytest.raises(ParseException):
+        p.parse_string('+00:14')
+    with pytest.raises(ParseException):
+        p.parse_string('ABC')
 
-        TIMEZONES = [(0, '', 0)]
-        if timezones:
-            TIMEZONES += [(0, 'Z', 0), (0, '-01:15', -75), (0, '+14', 14*60)]
-            if not iso_only:
-                TIMEZONES += [(0, ' GMT', 0), (0, 'PST', -8*60)]
+####################################################################
+# timesys
+####################################################################
 
-        TIMESYS = []
-        if timesys:
-            TIMESYS = [(0, 'UT', 'UTC'), (0, ' TDT', 'TT'), (0, 'Z', 'UTC')]
+def test_timesys():
 
-        ALL_TIMESYS = ('TDB', 'TT', 'UTC', 'TAI')
+    from julian.time_pyparser import timesys
 
-        if iso_only:
-            PUNCS = [':', '']
-        else:
-            PUNCS = [':']
+    p = timesys + StringEnd()
 
-        if padding:
-            before = '  '
-            after = '  '
-        else:
-            before = ''
-            after = ''
+    # Success
+    for space in ('', ' '):
+        assert p.parse_string(space + 'UTC')[0][1] == 'UTC'
+        assert p.parse_string(space + 'utc')[0][1] == 'UTC'
+        assert p.parse_string(space + 'UT') [0][1] == 'UTC'
+        assert p.parse_string(space + 'UT1')[0][1] == 'UTC'
+        assert p.parse_string(space + 'TAI')[0][1] == 'TAI'
+        assert p.parse_string(space + 'tai')[0][1] == 'TAI'
+        assert p.parse_string(space + 'TDB')[0][1] == 'TDB'
+        assert p.parse_string(space + 'ET') [0][1] == 'TDB'
+        assert p.parse_string(space + 'TDT')[0][1] == 'TT'
+        assert p.parse_string(space + 'TT') [0][1] == 'TT'
+        assert p.parse_string(space + 'tt') [0][1] == 'TT'
+        assert p.parse_string(space + 'Z')  [0][1] == 'UTC'
 
-        if embedded:
-            after = ' xxx'
+    # Failure
+    with pytest.raises(ParseException):
+        p.parse_string('PST')
 
-        if floating:
-            SECONDS += [(stat, word + '.5', val + 0.5) for (stat, word, val) in SECONDS]
+####################################################################
+# time_pyparser
+####################################################################
 
-        msgfmt = ('**** TIME PYPARSER test %d expected %s: "%s"; '
-                  f'leapsecs={leapsecs}, ampm={ampm}, timezones={timezones}, '
-                  f'floating={floating}, timesys={timesys}, iso_only={iso_only}, '
-                  f'padding={padding}, embedded={embedded}')
+def time_tester(parser, *, leapsecs=False, ampm=False, timezones=False,
+                floating=False, timesys=False, iso_only=False,
+                padding=False, embedded=False, failure=False):
 
-        STATUS = {
-            True : 'FAILURE',
-            False: 'SUCCESS',
-        }
+    HOURS = []
+    for h in [0, 1, 9, 23, 24]:
+        HOURS.append((9 if h >= 24 else 0, '%02d' % h, h))
+        if h < 10:
+            HOURS.append((9 if iso_only else 1, str(h), h))
 
-        count = 0
-        for hstat, hword, hval in HOURS:
-          for mstat, mword, mval in MINUTES:
-            for sstat, sword, sval in SECONDS:
-              for zstat, zword, zval in TIMEZONES + TIMESYS:
-                for punc in PUNCS:
-                    test = before + hword + punc + mword + punc + sword + zword + after
-                    status = hstat + mstat + sstat + zstat
-                    expect_failure = status > 3 or failure
-                    count += 1
-                    msg = msgfmt % (count, STATUS[expect_failure], test)
+    MINUTES = []
+    for m in [0, 1, 14, 59, 60]:
+        MINUTES.append((9 if m >= 60 else 0, '%02d' % m, m))
+        if m < 10:
+            MINUTES.append((9 if iso_only else 1, '%2d' % m, m))
 
-                    if expect_failure:
-                        Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                    else:
-                        parse_dict = Test_date_pyparser._confirm_success(self,
-                                            parser, test, msg=msg,
-                                            values=[('HOUR', hval), ('MINUTE', mval),
-                                                    ('SECOND', sval)])
-                        if zval in ALL_TIMESYS:
-                            self.assertIn('TIMESYS', parse_dict, msg)
-                            self.assertEqual(parse_dict['TIMESYS'], zval)
-                        elif zword:
-                            self.assertIn('TZ', parse_dict, msg)
-                            self.assertIn('TZMIN', parse_dict, msg)
-                            self.assertEqual(parse_dict['TZ'], zword.strip())
-                            self.assertEqual(parse_dict['TZMIN'], zval)
+    SECONDS = []
+    for s in [0, 1, 9, 59, 70]:
+        SECONDS.append((9 if s >= 70 else 0, '%02d' % s, s))
+        if s < 10:
+            SECONDS.append((9 if iso_only else 1, '%2d' % s, s))
+    for s in [60, 69]:
+        SECONDS.append((0 if leapsecs else 9, str(s), s))
 
-        if floating:
-            MINUTES += [(stat, word + '.5', val + 0.5) for (stat, word, val) in MINUTES]
+    TIMEZONES = [(0, '', 0)]
+    if timezones:
+        TIMEZONES += [(0, 'Z', 0), (0, '-01:15', -75), (0, '+14', 14*60)]
+        if not iso_only:
+            TIMEZONES += [(0, ' GMT', 0), (0, 'PST', -8*60)]
 
-        for hstat, hword, hval in HOURS:
-          for mstat, mword, mval in MINUTES:
-            for zstat, zword, zval in TIMEZONES + TIMESYS:
-              for punc in PUNCS:
-                test = before + hword + punc + mword + zword + after
-                status = hstat + mstat + zstat
+    TIMESYS = []
+    if timesys:
+        TIMESYS = [(0, 'UT', 'UTC'), (0, ' TDT', 'TT'), (0, 'Z', 'UTC')]
+
+    ALL_TIMESYS = ('TDB', 'TT', 'UTC', 'TAI')
+
+    if iso_only:
+        PUNCS = [':', '']
+    else:
+        PUNCS = [':']
+
+    if padding:
+        before = '  '
+        after = '  '
+    else:
+        before = ''
+        after = ''
+
+    if embedded:
+        after = ' xxx'
+
+    if floating:
+        SECONDS += [(stat, word + '.5', val + 0.5) for (stat, word, val) in SECONDS]
+
+    msgfmt = ('**** TIME PYPARSER test %d expected %s: "%s"; '
+              f'leapsecs={leapsecs}, ampm={ampm}, timezones={timezones}, '
+              f'floating={floating}, timesys={timesys}, iso_only={iso_only}, '
+              f'padding={padding}, embedded={embedded}')
+
+    STATUS = {
+        True : 'FAILURE',
+        False: 'SUCCESS',
+    }
+
+    count = 0
+    for hstat, hword, hval in HOURS:
+      for mstat, mword, mval in MINUTES:
+        for sstat, sword, sval in SECONDS:
+          for zstat, zword, zval in TIMEZONES + TIMESYS:
+            for punc in PUNCS:
+                test = before + hword + punc + mword + punc + sword + zword + after
+                status = hstat + mstat + sstat + zstat
                 expect_failure = status > 3 or failure
                 count += 1
                 msg = msgfmt % (count, STATUS[expect_failure], test)
 
                 if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
+                    confirm_failure(parser, test, msg=msg)
                 else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg,
-                                        values=[('HOUR', hval), ('MINUTE', mval)])
-                    if zval in ALL_TIMESYS:
-                        self.assertIn('TIMESYS', parse_dict, msg)
-                        self.assertEqual(parse_dict['TIMESYS'], zval)
-                    elif zword:
-                        self.assertIn('TZ', parse_dict, msg)
-                        self.assertIn('TZMIN', parse_dict, msg)
-                        self.assertEqual(parse_dict['TZ'], zword.strip())
-                        self.assertEqual(parse_dict['TZMIN'], zval)
-
-        if floating:
-            SECONDS = []
-            for s in [0, 1, 9, 10, 99, 100, 999, 1000, 9999, 10000, 80000,
-                      86000, 86300, 86399, 86400, 86409, 86410, 87000, 9000]:
-                if leapsecs:
-                    stat = 9 * int(s >= 86410)
-                else:
-                    stat = 9 * int(s >= 86400)
-
-                SECONDS.append((stat, str(s), s))
-                SECONDS.append((stat, str(s) + '.5', s + 0.5))
-
-            for sstat, sword, sval in SECONDS:
-                test = before + sword + 's' + after
-                expect_failure = sstat > 1 or failure or iso_only
-                count += 1
-                msg = msgfmt % (count, STATUS[expect_failure], test)
-
-                if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg, values=[('SECOND', sval)])
-
-            MINUTES = []
-            for m in [0, 1, 9, 10, 99, 100, 999, 1000, 1400, 1430, 1439, 1440]:
-                MINUTES.append((9 if m >= 1440 else 0, str(m), m))
-                MINUTES.append((9 if m >= 1440 else 0, str(m) + '.5', m + 0.5))
-
-            for mstat, mword, mval in MINUTES:
-                test = before + mword + 'm' + after
-                expect_failure = mstat > 1 or failure or iso_only
-                count += 1
-                msg = msgfmt % (count, STATUS[expect_failure], test)
-
-                if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg, values=[('MINUTE', mval)])
-
-            HOURS = []
-            for h in [0, 1, 9, 10, 23, 24]:
-                HOURS.append((9 if h >= 24 else 0, str(h), h))
-                HOURS.append((9 if h >= 24 else 0, str(h) + '.5', h + 0.5))
-
-            for hstat, hword, hval in HOURS:
-                test = before + hword + ' h' + after
-                expect_failure = hstat > 1 or failure or iso_only
-                count += 1
-                msg = msgfmt % (count, STATUS[expect_failure], test)
-                if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg, values=[('HOUR', hval)])
-
-        if not ampm:
-            return
-
-        HOURS = []
-        for a in (0,1):
-          for h in [0, 1, 9, 11, 12, 13]:
-            hval = 12 * a + h - (12 if h == 12 else 0)
-            stat = 9 if (h == 0 or h > 12) else 0
-            suffix = 'am' if a == 0 else ' pm'
-            HOURS.append((stat, '%02d' % h, suffix, hval))
-            if h < 10:
-                HOURS.append((stat, str(h), suffix, hval))
-
-        MINUTES = []
-        for m in [0, 1, 59, 60]:
-            MINUTES.append((9 if m >= 60 else 0, '%02d' % m, m))
-            if m < 10:
-                MINUTES.append((9 if iso_only else 1, '%2d' % m, m))
-
-        SECONDS = []
-        for s in [0, 1, 59, 70]:
-            SECONDS.append((9 if s >= 70 else 0, '%02d' % s, s))
-            if s < 10:
-                SECONDS.append((1, '%2d' % s, s))
-        for s in [60, 61, 69]:
-            SECONDS.append((0 if leapsecs else 9, str(s), s))
-
-        for hstat, hword, suffix, hval in HOURS:
-          for mstat, mword, mval in MINUTES:
-            for sstat, sword, sval in SECONDS:
-                test = before + hword + ':' + mword + ':' + sword + suffix + after
-                status = hstat + mstat + sstat
-
-                expect_failure = status > 3 or failure
-                count += 1
-                msg = msgfmt % (count, STATUS[expect_failure], test)
-
-                if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg,
+                    parse_dict = confirm_success(parser, test, msg=msg,
                                         values=[('HOUR', hval), ('MINUTE', mval),
                                                 ('SECOND', sval)])
+                    if zval in ALL_TIMESYS:
+                        assert 'TIMESYS' in parse_dict, msg
+                        assert parse_dict['TIMESYS'] == zval
+                    elif zword:
+                        assert 'TZ' in parse_dict, msg
+                        assert 'TZMIN' in parse_dict, msg
+                        assert parse_dict['TZ'] == zword.strip()
+                        assert parse_dict['TZMIN'] == zval
 
-        for hstat, hword, suffix, hval in HOURS:
-            for mstat, mword, mval in MINUTES:
-                test = before + hword + ':' + mword + suffix + after
-                status = hstat + mstat
-                expect_failure = status > 3 or failure
-                count += 1
-                msg = msgfmt % (count, STATUS[expect_failure], test)
+    if floating:
+        MINUTES += [(stat, word + '.5', val + 0.5) for (stat, word, val) in MINUTES]
 
-                if expect_failure:
-                    Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
-                else:
-                    parse_dict = Test_date_pyparser._confirm_success(self,
-                                        parser, test, msg=msg,
-                                        values=[('HOUR', hval), ('MINUTE', mval)])
-
-        for hstat, hword, suffix, hval in HOURS:
-            test = before + hword + suffix + after
-            status = hstat
+    for hstat, hword, hval in HOURS:
+      for mstat, mword, mval in MINUTES:
+        for zstat, zword, zval in TIMEZONES + TIMESYS:
+          for punc in PUNCS:
+            test = before + hword + punc + mword + zword + after
+            status = hstat + mstat + zstat
             expect_failure = status > 3 or failure
             count += 1
             msg = msgfmt % (count, STATUS[expect_failure], test)
 
             if expect_failure:
-                Test_date_pyparser._confirm_failure(self, parser, test, msg=msg)
+                confirm_failure(parser, test, msg=msg)
             else:
-                parse_dict = Test_date_pyparser._confirm_success(self,
-                                    parser, test, msg=msg, values=[('HOUR', hval)])
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('HOUR', hval), ('MINUTE', mval)])
+                if zval in ALL_TIMESYS:
+                    assert 'TIMESYS' in parse_dict, msg
+                    assert parse_dict['TIMESYS'] == zval
+                elif zword:
+                    assert 'TZ' in parse_dict, msg
+                    assert 'TZMIN' in parse_dict, msg
+                    assert parse_dict['TZ'] == zword.strip()
+                    assert parse_dict['TZMIN'] == zval
 
-    ####################################################################
-    # time_pyparser
-    ####################################################################
+    if floating:
+        SECONDS = []
+        for s in [0, 1, 9, 10, 99, 100, 999, 1000, 9999, 10000, 80000,
+                  86000, 86300, 86399, 86400, 86409, 86410, 87000, 9000]:
+            if leapsecs:
+                stat = 9 * int(s >= 86410)
+            else:
+                stat = 9 * int(s >= 86400)
 
-    def test_time_pyparser(self):
+            SECONDS.append((stat, str(s), s))
+            SECONDS.append((stat, str(s) + '.5', s + 0.5))
 
-        from julian.time_pyparser import time_pyparser
+        for sstat, sword, sval in SECONDS:
+            test = before + sword + 's' + after
+            expect_failure = sstat > 1 or failure or iso_only
+            count += 1
+            msg = msgfmt % (count, STATUS[expect_failure], test)
 
-        # leapsecs, floating, timezones, timesys, ampm
-        options = [(False, False, False, False, False),
-                   (True,  True,  True,  True,  True ),
-                   (True,  False, False, False, False),
-                   (False, True,  False, False, False),
-                   (False, False, True,  False, False),
-                   (False, False, False, True,  False),
-                   (False, False, False, False, True )]
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg)
+            else:
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('SECOND', sval)])
 
-        padding = True
-        embedded = True
-        for leapsecs, floating, timezones, timesys, ampm in options:
-            parser = time_pyparser(leapsecs=leapsecs, ampm=ampm,
-                                   timezones=timezones, floating=floating,
-                                   timesys=timesys, iso_only=False,
-                                   padding=padding, embedded=embedded)
+        MINUTES = []
+        for m in [0, 1, 9, 10, 99, 100, 999, 1000, 1400, 1430, 1439, 1440]:
+            MINUTES.append((9 if m >= 1440 else 0, str(m), m))
+            MINUTES.append((9 if m >= 1440 else 0, str(m) + '.5', m + 0.5))
 
-            self.my_time_tester(parser, leapsecs=leapsecs, ampm=ampm,
-                                timezones=timezones, floating=floating,
-                                timesys=timesys, iso_only=False,
-                                padding=padding, embedded=embedded)
+        for mstat, mword, mval in MINUTES:
+            test = before + mword + 'm' + after
+            expect_failure = mstat > 1 or failure or iso_only
+            count += 1
+            msg = msgfmt % (count, STATUS[expect_failure], test)
 
-        # iso_only = True
-        for leapsecs in (True, False):
-            for floating in (False, True):
-                parser = time_pyparser(leapsecs=leapsecs, ampm=False,
-                                       timezones=timezones, floating=floating,
-                                       timesys=False, iso_only=True,
-                                       padding=padding, embedded=embedded)
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg)
+            else:
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('MINUTE', mval)])
 
-                self.my_time_tester(parser, leapsecs=leapsecs, ampm=False,
-                                    timezones=timezones, floating=floating,
-                                    timesys=False, iso_only=True,
-                                    padding=padding, embedded=embedded)
+        HOURS = []
+        for h in [0, 1, 9, 10, 23, 24]:
+            HOURS.append((9 if h >= 24 else 0, str(h), h))
+            HOURS.append((9 if h >= 24 else 0, str(h) + '.5', h + 0.5))
 
-        # Quicker tests without both padding and embedded
-        for padding in (True, False):
-          for embedded in (True, False):
-            if padding and embedded:
-                continue
+        for hstat, hword, hval in HOURS:
+            test = before + hword + ' h' + after
+            expect_failure = hstat > 1 or failure or iso_only
+            count += 1
+            msg = msgfmt % (count, STATUS[expect_failure], test)
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg)
+            else:
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('HOUR', hval)])
 
-            parser = time_pyparser(leapsecs=False, ampm=False,
-                                   timezones=False, floating=False,
-                                   timesys=False, iso_only=False,
-                                   padding=padding, embedded=embedded)
-            self.my_time_tester(parser, leapsecs=False, ampm=False,
-                                timezones=False, floating=False,
-                                timesys=False, iso_only=False,
-                                padding=padding, embedded=embedded)
+    if not ampm:
+        return
+
+    HOURS = []
+    for a in (0,1):
+      for h in [0, 1, 9, 11, 12, 13]:
+        hval = 12 * a + h - (12 if h == 12 else 0)
+        stat = 9 if (h == 0 or h > 12) else 0
+        suffix = 'am' if a == 0 else ' pm'
+        HOURS.append((stat, '%02d' % h, suffix, hval))
+        if h < 10:
+            HOURS.append((stat, str(h), suffix, hval))
+
+    MINUTES = []
+    for m in [0, 1, 59, 60]:
+        MINUTES.append((9 if m >= 60 else 0, '%02d' % m, m))
+        if m < 10:
+            MINUTES.append((9 if iso_only else 1, '%2d' % m, m))
+
+    SECONDS = []
+    for s in [0, 1, 59, 70]:
+        SECONDS.append((9 if s >= 70 else 0, '%02d' % s, s))
+        if s < 10:
+            SECONDS.append((1, '%2d' % s, s))
+    for s in [60, 61, 69]:
+        SECONDS.append((0 if leapsecs else 9, str(s), s))
+
+    for hstat, hword, suffix, hval in HOURS:
+      for mstat, mword, mval in MINUTES:
+        for sstat, sword, sval in SECONDS:
+            test = before + hword + ':' + mword + ':' + sword + suffix + after
+            status = hstat + mstat + sstat
+
+            expect_failure = status > 3 or failure
+            count += 1
+            msg = msgfmt % (count, STATUS[expect_failure], test)
+
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg)
+            else:
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('HOUR', hval), ('MINUTE', mval),
+                                            ('SECOND', sval)])
+
+    for hstat, hword, suffix, hval in HOURS:
+        for mstat, mword, mval in MINUTES:
+            test = before + hword + ':' + mword + suffix + after
+            status = hstat + mstat
+            expect_failure = status > 3 or failure
+            count += 1
+            msg = msgfmt % (count, STATUS[expect_failure], test)
+
+            if expect_failure:
+                confirm_failure(parser, test, msg=msg)
+            else:
+                parse_dict = confirm_success(parser, test, msg=msg,
+                                    values=[('HOUR', hval), ('MINUTE', mval)])
+
+    for hstat, hword, suffix, hval in HOURS:
+        test = before + hword + suffix + after
+        status = hstat
+        expect_failure = status > 3 or failure
+        count += 1
+        msg = msgfmt % (count, STATUS[expect_failure], test)
+
+        if expect_failure:
+            confirm_failure(parser, test, msg=msg)
+        else:
+            parse_dict = confirm_success(parser, test, msg=msg,
+                                values=[('HOUR', hval)])
+
+
+_MAIN_OPTIONS = [
+    (False, False, False, False, False),
+    (True,  True,  True,  True,  True),
+    (True,  False, False, False, False),
+    (False, True,  False, False, False),
+    (False, False, True,  False, False),
+    (False, False, False, True,  False),
+    (False, False, False, False, True),
+]
+
+@pytest.mark.parametrize('leapsecs,floating,timezones,timesys,ampm', _MAIN_OPTIONS)
+def test_time_pyparser(leapsecs, floating, timezones, timesys, ampm):
+    from julian.time_pyparser import time_pyparser
+    parser = time_pyparser(leapsecs=leapsecs, ampm=ampm,
+                           timezones=timezones, floating=floating,
+                           timesys=timesys, iso_only=False,
+                           padding=True, embedded=True)
+    time_tester(parser, leapsecs=leapsecs, ampm=ampm,
+                timezones=timezones, floating=floating,
+                timesys=timesys, iso_only=False,
+                padding=True, embedded=True)
+
+
+@pytest.mark.parametrize('leapsecs,floating', [
+    (True, False), (True, True), (False, False), (False, True),
+])
+def test_time_pyparser_iso_only(leapsecs, floating):
+    from julian.time_pyparser import time_pyparser
+    parser = time_pyparser(leapsecs=leapsecs, ampm=False,
+                           timezones=True, floating=floating,
+                           timesys=False, iso_only=True,
+                           padding=True, embedded=True)
+    time_tester(parser, leapsecs=leapsecs, ampm=False,
+                timezones=True, floating=floating,
+                timesys=False, iso_only=True,
+                padding=True, embedded=True)
+
+
+@pytest.mark.parametrize('padding,embedded', [
+    (True, False), (False, True), (False, False),
+])
+def test_time_pyparser_quick(padding, embedded):
+    from julian.time_pyparser import time_pyparser
+    parser = time_pyparser(leapsecs=False, ampm=False,
+                           timezones=False, floating=False,
+                           timesys=False, iso_only=False,
+                           padding=padding, embedded=embedded)
+    time_tester(parser, leapsecs=False, ampm=False,
+                timezones=False, floating=False,
+                timesys=False, iso_only=False,
+                padding=padding, embedded=embedded)
 
 ##########################################################################################

--- a/tests/test_time_pyparser.py
+++ b/tests/test_time_pyparser.py
@@ -15,7 +15,7 @@ from tests._helpers import confirm_failure, confirm_success
 def test_hour():
 
     from julian.time_pyparser import hour, hour_strict, hour_float, \
-                                     hour_float_strict, hour_am, hour_pm \
+                                     hour_float_strict, hour_am, hour_pm
 
     ################################
     # hour_strict

--- a/tests/test_time_pyparser.py
+++ b/tests/test_time_pyparser.py
@@ -563,7 +563,7 @@ def test_second():
 
     # Success
     assert p.parse_string('0.5')[0][0] == 'SECOND'
-    for s in range(1440):
+    for s in range(86400):
         assert p.parse_string(str(s) + '.5')[0][1] == s + 0.5
 
     # Failure
@@ -577,7 +577,7 @@ def test_second():
     with pytest.raises(ParseException):
         p.parse_string('10')
     with pytest.raises(ParseException):
-        p.parse_string('1440')
+        p.parse_string('86400')
     with pytest.raises(ParseException):
         p.parse_string('1500')
     with pytest.raises(ParseException):

--- a/tests/test_time_pyparser.py
+++ b/tests/test_time_pyparser.py
@@ -2,6 +2,7 @@
 # julian/test_time_pyparser.py
 ##########################################################################################
 
+import warnings
 import pytest
 
 from pyparsing import ParseException, StringEnd
@@ -486,6 +487,12 @@ def test_second():
         p.parse_string('a')
     with pytest.raises(ParseException):
         p.parse_string('000.5')
+    with pytest.raises(ParseException):
+        p.parse_string('0.5')
+    with pytest.raises(ParseException):
+        p.parse_string(' 0.5')
+    with pytest.raises(ParseException):
+        p.parse_string('.5')
 
     ################################
     # second_float
@@ -834,24 +841,26 @@ def test_timesys():
 
     p = timesys + StringEnd()
 
-    # Success
-    for space in ('', ' '):
-        assert p.parse_string(space + 'UTC')[0][1] == 'UTC'
-        assert p.parse_string(space + 'utc')[0][1] == 'UTC'
-        assert p.parse_string(space + 'UT') [0][1] == 'UTC'
-        assert p.parse_string(space + 'UT1')[0][1] == 'UTC'
-        assert p.parse_string(space + 'TAI')[0][1] == 'TAI'
-        assert p.parse_string(space + 'tai')[0][1] == 'TAI'
-        assert p.parse_string(space + 'TDB')[0][1] == 'TDB'
-        assert p.parse_string(space + 'ET') [0][1] == 'TDB'
-        assert p.parse_string(space + 'TDT')[0][1] == 'TT'
-        assert p.parse_string(space + 'TT') [0][1] == 'TT'
-        assert p.parse_string(space + 'tt') [0][1] == 'TT'
-        assert p.parse_string(space + 'Z')  [0][1] == 'UTC'
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', DeprecationWarning)
+        # Success
+        for space in ('', ' '):
+            assert p.parse_string(space + 'UTC')[0][1] == 'UTC'
+            assert p.parse_string(space + 'utc')[0][1] == 'UTC'
+            assert p.parse_string(space + 'UT') [0][1] == 'UTC'
+            assert p.parse_string(space + 'UT1')[0][1] == 'UTC'
+            assert p.parse_string(space + 'TAI')[0][1] == 'TAI'
+            assert p.parse_string(space + 'tai')[0][1] == 'TAI'
+            assert p.parse_string(space + 'TDB')[0][1] == 'TDB'
+            assert p.parse_string(space + 'ET') [0][1] == 'TDB'
+            assert p.parse_string(space + 'TDT')[0][1] == 'TT'
+            assert p.parse_string(space + 'TT') [0][1] == 'TT'
+            assert p.parse_string(space + 'tt') [0][1] == 'TT'
+            assert p.parse_string(space + 'Z')  [0][1] == 'UTC'
 
-    # Failure
-    with pytest.raises(ParseException):
-        p.parse_string('PST')
+        # Failure
+        with pytest.raises(ParseException):
+            p.parse_string('PST')
 
 ####################################################################
 # time_pyparser

--- a/tests/test_utc_tai_tdb_tt.py
+++ b/tests/test_utc_tai_tdb_tt.py
@@ -423,10 +423,10 @@ def test_utc_tai_tdb_tt():
 
         # TDB tests...
 
-        assert abs(day_sec_as_type_from_utc(0, 0, time_type='TDB')[1]
-                        - 64.183927284731055) < 1.e15
-        assert abs(utc_from_day_sec_as_type(0, 0, time_type='TDB')[1]
-                        + 64.183927284731055) < 1.e15
+        assert day_sec_as_type_from_utc(0, 0, time_type='TDB')[1] == \
+                        pytest.approx(64.18391281194636, abs=1e-14)
+        (day, sec) = utc_from_day_sec_as_type(0, 0, time_type='TDB')
+        assert day * 86400 + sec == pytest.approx(-64.18391281194636, abs=1e-7)
 
         tdb = time_from_day_sec(0, 0., 'TDB')
         (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)

--- a/tests/test_utc_tai_tdb_tt.py
+++ b/tests/test_utc_tai_tdb_tt.py
@@ -39,426 +39,433 @@ from julian.formatters   import iso_from_tai
 from julian.leap_seconds import set_ut_model
 
 
+@pytest.mark.filterwarnings('ignore::julian._warnings.JulianDeprecationWarning')
 def test_utc_tai_tdb_tt():
 
-    import warnings
-    from julian._warnings import JulianDeprecationWarning
-    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
-
-    ################################################################
-    # Rigorously compare TDB to cspyce ET around all leap seconds
-    ################################################################
-
-    import cspyce
-
-    julian_root_dir = os.path.split(sys.modules['julian'].__file__)[0]
-    lsk_path = os.path.join(julian_root_dir, 'assets',
-                            leap_seconds._LATEST_LSK_NAME)
-    cspyce.furnsh(lsk_path)
-
-    set_ut_model('SPICE')
-    for origin in ('MIDNIGHT', 'NOON'):
-        set_tai_origin(origin)
-        for y in range(1970, 2030):
-            for m in (1, 7):
-                date = f'{y}-{m:02d}-00T00:00:00'
-                et0 = cspyce.utc2et(date)
-                et_array = np.arange(et0-100, et0+100)
-                iso_array = iso_from_tai(tai_from_tdb(et_array), digits=6, ymd=True)
-                for k, et in enumerate(et_array):
-                    assert iso_array[k] == cspyce.et2utc(et, 'ISOC', 6)
-
-    set_ut_model('LEAPS')
-
-    ########################################
-    # UTC-day conversions
-    ########################################
-
-    set_tai_origin('MIDNIGHT')
-
-    # Check utc_from_day
-    assert utc_from_day(0) == 0
-    assert utc_from_day([0,1])[0] == 0
-    assert utc_from_day([0,1])[1] == 86400
-
-    assert isinstance(utc_from_day(0), numbers.Integral)
-    assert not isinstance(utc_from_day(0.), numbers.Integral)
-
-    # Check day_sec_from_utc
-    assert day_sec_from_utc(0) == (0, 0)
-    assert day_sec_from_utc([100, 86600])[0][0] == 0
-    assert day_sec_from_utc([100, 86600])[0][1] == 1
-    assert day_sec_from_utc([100, 86600])[1][0] == 100
-    assert day_sec_from_utc([100, 86600])[1][1] == 200
-
-    assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
-    assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
-    assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
-
-    # A large number of dates, spanning > 200 years
-    daylist = np.arange(-40000,40000,83)
-
-    # Test as a loop
-    for day in daylist:
-        (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
-        assert test_day == day
-        assert test_sec == 0
-
-    # Test as an array operation
-    (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
-    assert np.all(test_day == daylist)
-    assert np.all(test_sec == 0)
-
-    # Switch UTC origin to NOON
-
-    set_tai_origin('NOON')
-
-    # Check utc_from_day
-    assert utc_from_day(0) == -43200
-    assert utc_from_day([0,1])[0] == -43200
-    assert utc_from_day([0,1])[1] ==  43200
-
-    assert isinstance(utc_from_day(0), numbers.Integral)
-    assert not isinstance(utc_from_day(0.), numbers.Integral)
-
-    # Check day_sec_from_utc
-    assert day_sec_from_utc(0) == (0, 43200)
-    assert day_sec_from_utc([100, 86600])[0][0] == 0
-    assert day_sec_from_utc([100, 86600])[0][1] == 1
-    assert day_sec_from_utc([100, 86600])[1][0] == 43300
-    assert day_sec_from_utc([100, 86600])[1][1] == 43400
-
-    assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
-    assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
-    assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
-
-    # A large number of dates, spanning > 200 years
-    daylist = np.arange(-40000,40000,83)
-
-    # Test as a loop
-    for day in daylist:
-        (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
-        assert test_day == day
-        assert test_sec == 0
-
-    # Test as an array operation
-    (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
-    assert np.all(test_day == daylist)
-    assert np.all(test_sec == 0)
-
-    ########################################
-    # UTC-TAI conversions
-    ########################################
-
-    set_ut_model('LEAPS')
-    set_tai_origin('NOON')
-
-    # Check tai_from_day
-    assert tai_from_day(0) == 32 - 43200
-    assert tai_from_day([0,1])[0] == 32 - 43200
-    assert tai_from_day([0,1])[1] == 32 + 43200
-
-    assert isinstance(tai_from_day(0), numbers.Integral)
-    assert not isinstance(tai_from_day(0.), numbers.Integral)
-
-    # Check day_sec_from_tai
-    assert day_sec_from_tai(32.) == (0, 43200.)
-    assert day_sec_from_tai([35.,86435.])[0][0] == 0
-    assert day_sec_from_tai([35.,86435.])[0][1] == 1
-    assert day_sec_from_tai([35.,86435.])[1][0] == 43203.
-    assert day_sec_from_tai([35.,86435.])[1][1] == 43203.
-
-    assert isinstance(day_sec_from_tai([35,86435])[0][1], numbers.Integral)
-    assert isinstance(day_sec_from_tai([35,86435])[1][0], numbers.Integral)
-    assert not isinstance(day_sec_from_tai([35.,86435.])[1][0], numbers.Integral)
-
-    # utc_from_tai
-    assert day_sec_from_utc(utc_from_tai(32)) == (0, 43200.)
-    assert day_sec_from_utc(utc_from_tai([35,86435]))[0][0] == 0
-    assert day_sec_from_utc(utc_from_tai([35,86435]))[0][1] == 1
-    assert day_sec_from_utc(utc_from_tai([35,86435]))[1][0] == 43235-32
-    assert day_sec_from_utc(utc_from_tai([35,86435]))[1][1] == 43235-32
-
-    assert isinstance(utc_from_tai(32), numbers.Integral)
-    assert isinstance(utc_from_tai([35,86435])[0], numbers.Integral)
-    assert not isinstance(utc_from_tai(32.), numbers.Integral)
-    assert not isinstance(utc_from_tai([35.,86435.])[0], numbers.Integral)
-
-    # tai_from_utc
-    assert day_sec_from_tai(tai_from_utc(0)) == (0, 43200)
-    assert day_sec_from_tai(tai_from_utc([100,200]))[0][0] == 0
-    assert day_sec_from_tai(tai_from_utc([100,200]))[0][1] == 0
-    assert day_sec_from_tai(tai_from_utc([100,200]))[1][0] == 43300
-    assert day_sec_from_tai(tai_from_utc([100,200]))[1][1] == 43400
-
-    assert isinstance(tai_from_utc(43200), numbers.Integral)
-    assert isinstance(tai_from_utc([100,200])[0], numbers.Integral)
-    assert not isinstance(tai_from_utc(43200.), numbers.Integral)
-    assert not isinstance(tai_from_utc([100.,200.])[0], numbers.Integral)
-
-    # A large number of dates, spanning > 200 years
-    daylist = np.arange(-40000,40000,83)
-
-    # Test as a loop
-    for day in daylist:
-        (test_day, test_sec) = day_sec_from_tai(tai_from_day(day))
-        assert test_day == day, 'Day mismatch at ' + str(day)
-        assert test_sec == 0,   'Sec mismatch at ' + str(day)
-
-    # Test as an array operation
-    (test_day, test_sec) = day_sec_from_tai(tai_from_day(daylist))
-    assert np.all(test_day == daylist)
-    assert np.all(test_sec == 0)
-
-    ########################################
-    # TAI-TDB conversions
-    ########################################
-
-    # Check tdb_from_tai
-    assert tdb_from_tai(tai_from_day(0) + 43200) == pytest.approx(64.183927284731055, abs=1e-15)
-
-    # Check tai_from_tdb
-    assert tai_from_tdb(64.183927284731055) == pytest.approx(32., abs=1e-15)
-
-    # Test inversions around tdb = 0.
-    # A list of two million small numbers spanning 2 sec
-    secs = 2.
-    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-    assert np.all(errors <  1.e-11 * secs)
-    assert np.all(errors > -1.e-11 * secs)
-
-    # Now make sure we get the exact same results when we replace arrays by
-    # scalars
-    for i in range(0, tdbs.size, 1000):
-        assert errors[i] == tdb_from_tai(tai_from_tdb(tdbs[i])) - tdbs[i]
-
-    # A list of two million bigger numbers spanning ~ 20 days
-    secs = 20. * 86400.
-    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-    assert np.all(errors <  1.e-15 * secs)
-    assert np.all(errors > -1.e-15 * secs)
-
-    # A list of two million still bigger numbers spanning ~ 2000 years
-    secs = 2000. * 365. * 86400.
-    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-    assert np.all(errors <  1.e-15 * secs)
-    assert np.all(errors > -1.e-15 * secs)
-
-    ########################################
-    # TAI-TT conversions
-    ########################################
-
-    assert tt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
-    assert tdt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
-
-    assert tai_from_tt(10.) == pytest.approx(-22.184, abs=1e-14)
-    assert tai_from_tdt(10.) == pytest.approx(-22.184, abs=1e-14)
-
-    set_tai_origin('MIDNIGHT')
-
-    assert tt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
-    assert tdt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
-
-    assert tai_from_tt(32.184) == pytest.approx(43200, abs=1e-14)
-    assert tai_from_tdt(32.184) == pytest.approx(43200, abs=1e-14)
-
-    set_tai_origin('NOON')
-
-    ########################################
-    # Time System conversions
-    ########################################
-
-    offsets_1971_12_31 = {'LEAPS': 10, 'SPICE':9, 'CANON': 9.889649987220764,
-                          'PRE-1972': 9.889649987220764}
-
-    # For the batch test of every day 1971-2012. Conversions should be exact.
-    daylist = np.arange(day_from_ymd(1971,1,1), day_from_ymd(2012,1,1))
-
-    for model in ('SPICE', 'PRE-1972', 'CANON', 'LEAPS'):
-      set_ut_model(model)
-
-      for origin in ('MIDNIGHT', 'NOON'):
-        set_tai_origin(origin)
-
-        for value in [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]:
-            assert time_from_time(value, 'UTC', 'TAI') == tai_from_utc(value)
-            assert time_from_time(value, 'TDB', 'TAI') == tai_from_tdb(value)
-            assert time_from_time(value, 'TT' , 'TAI') == tai_from_tt( value)
-            assert time_from_time(value, 'TAI', 'UTC') == utc_from_tai(value)
-            assert time_from_time(value, 'TAI', 'TDB') == tdb_from_tai(value)
-            assert time_from_time(value, 'TAI', 'TT' ) == tt_from_tai( value)
-
-        t1 = [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]
-        for tsys1 in ('UTC', 'TAI', 'TT', 'TDB'):
-          for tsys2 in ('UTC', 'TAI', 'TT', 'TDB'):
-            t2 = time_from_time(t1, tsys1, tsys2)
-            t3 = time_from_time(t2, tsys2, tsys1)
-            assert np.abs(t3-t1).max() < 1.e-11
-
-        assert time_from_day_sec(10, 43200, 'TAI') == \
-                         tai_from_day_sec(10, 43200)
-        assert time_from_day_sec(10, 43200, 'TDB') == \
-                         tdb_from_tai(tai_from_day_sec(10, 43200))
-        assert time_from_day_sec(10, 43200, 'TT') == \
-                         tt_from_tai(tai_from_day_sec(10, 43200))
-
-        assert day_sec_from_time(10000., 'TAI') == \
-                         day_sec_from_tai(10000.)
-        assert day_sec_from_time(10000., 'TDB') == \
-                         day_sec_from_tai(tai_from_tdb(10000.))
-        assert day_sec_from_time(10000., 'TT') == \
-                         day_sec_from_tai(tai_from_tt(10000.))
-
-        # "Dates" in other time systems
-        tai = time_from_day_sec(365, 32, timesys='TAI', leapsecs=False)
-        assert day_sec_from_time(tai, timesys='TAI') == (365, 0)
-
-        tt = time_from_day_sec(365, 64.184, timesys='TT', leapsecs=False)
-        assert day_sec_from_time(tt, timesys='TT')[0] == 365
-        assert day_sec_from_time(tt, timesys='TT')[1] == pytest.approx(0., abs=1e-14)
-
-        days = np.arange(365, 731)
-        tdb = time_from_day_sec(days, 43200., timesys='TDB', leapsecs=False)
-        tt  = time_from_day_sec(days, 43200., timesys='TT',  leapsecs=False)
-
-        sec1 = day_sec_from_time(tdb, timesys='TDB')[1]
-        sec2 = day_sec_from_time(tt,  timesys='TT')[1]
-        diffs = sec1 - sec2
-        assert np.abs(diffs).max() < 0.0017
-        assert np.abs(diffs.mean()) < 2.e-7
-
-        # TAI tests...
-
-        # TAI offset was 31-32 seconds ahead of UTC in 1999,2000,2001
-        (day, sec) = day_sec_as_type_from_utc((-366,0,366), 0., time_type='TAI')
-        assert np.all(day == (-366,0,366))
-        assert np.all(sec == (31.,32.,32.))
-
-        tai = time_from_day_sec((-366, 0, 366), 0., 'TAI')
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        assert np.all(day == (-366,0,366))
-        assert np.all(sec == (31.,32.,32.))
-
-        # Inverse of the above
-        (day, sec) = utc_from_day_sec_as_type((-366,0,366), 32., time_type='TAI')
-        assert np.all(day == (-366,0,366))
-        assert np.all(sec == (1.,0.,0.))
-
-        tai = time_from_day_sec((-366, 0, 366), 32., 'TAI', leapsecs=False)
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-        assert np.all(day == (-366,0,366))
-        assert np.all(sec == (1.,0.,0.))
-
-        # TAI offset depended on model before 1972
-        (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1972,1,1), 0, time_type='TAI')
-        assert sec == 10
-
-        tai = time_from_day_sec(day_from_ymd(1972,1,1), 0., 'TAI')
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        assert sec == 10
-
-        (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1971,12,31), 0, time_type='TAI')
-        assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
-
-        tai = time_from_day_sec(day_from_ymd(1971,12,31), 0., 'TAI')
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
-
-        # Inverses of the above
-        (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1972,1,1), 10, time_type='TAI')
-        assert sec == 0
-
-        tai = time_from_day_sec(day_from_ymd(1972,1,1), 10, 'TAI', leapsecs=False)
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-        assert sec == 0
-
-        (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1971,12,31),
-                                              offsets_1971_12_31[model]+1, time_type='TAI')
-        assert sec == pytest.approx(1, abs=1e-14)
-
-        tai = time_from_day_sec(day_from_ymd(1971,12,31), offsets_1971_12_31[model],
-                                'TAI', leapsecs=False)
-        (day, sec) = day_sec_from_time(tai+1, 'TAI', leapsecs=True)
-        assert sec == pytest.approx(1, abs=1e-14)
-
-        # Batch test 1971-2012. Conversions should be exact.
-        (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TAI')
-        (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 43200.)
-
-        tai = time_from_day_sec(daylist, 43200., 'TAI')
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
-        (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 43200.)
-
-        (day, sec) = day_sec_as_type_from_utc(daylist, 0., time_type='TAI')
-        (dtest,stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 0.)
-
-        tai = time_from_day_sec(daylist, 0., 'TAI')
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
-        (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 0.)
-
-        (day, sec) = utc_from_day_sec_as_type(daylist, 0., time_type='TAI')
-        (dtest,stest) = day_sec_as_type_from_utc(day, sec, time_type='TAI')
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 0.)
-
-        tai = time_from_day_sec(daylist, 0., 'TAI', leapsecs=False)
-        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-        tai = time_from_day_sec(day, sec, 'TAI', leapsecs=True)
-        (dtest, stest) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-        assert np.all(dtest == daylist)
-        assert np.all(stest == 0.)
-
-        # TDB tests...
-
-        assert day_sec_as_type_from_utc(0, 0, time_type='TDB')[1] == \
-                        pytest.approx(64.18391281194636, abs=1e-14)
-        (day, sec) = utc_from_day_sec_as_type(0, 0, time_type='TDB')
-        assert day * 86400 + sec == pytest.approx(-64.18391281194636, abs=1e-7)
-
-        tdb = time_from_day_sec(0, 0., 'TDB')
-        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
-        assert sec == pytest.approx(64.18391281194636, abs=1e-14)
-
-        (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TDB')
-        (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TDB')
-        assert np.all(dtest == daylist)
-        assert np.abs(stest - 43200.).max() < 1.e-7
-
-        (day, sec) = utc_from_day_sec_as_type(daylist, 43200., time_type='TDB')
-        (dtest, stest) = day_sec_as_type_from_utc(day, sec, time_type='TDB')
-        assert np.all(dtest == daylist)
-        assert np.abs(stest - 43200.).max() < 2.e-7
-
-        tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=True)
-        tdb2 = tdb_from_tai(tai_from_day_sec(daylist, 43200.))
-        assert np.all(tdb == tdb2)
-
-        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
-        tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=False)
-        assert np.abs(tdb - tdb2).max() < 1.e-7
-
-        (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=True)
-        assert np.all(dtest == daylist)
-        assert np.abs(stest - 43200.).max() < 1.e-7
-
-        tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=False)
-        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=True)
-        tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=True)
-        (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=False)
-        assert np.all(dtest == daylist)
-        assert np.abs(stest - 43200.).max() < 2.e-7
+    try:
+        ################################################################
+        # Rigorously compare TDB to cspyce ET around all leap seconds
+        ################################################################
+
+        import cspyce
+
+        julian_root_dir = os.path.split(sys.modules['julian'].__file__)[0]
+        lsk_path = os.path.join(julian_root_dir, 'assets',
+                                leap_seconds._LATEST_LSK_NAME)
+        cspyce.furnsh(lsk_path)
+
+        set_ut_model('SPICE')
+        for origin in ('MIDNIGHT', 'NOON'):
+            set_tai_origin(origin)
+            for y in range(1970, 2030):
+                for m in (1, 7):
+                    date = f'{y}-{m:02d}-00T00:00:00'
+                    et0 = cspyce.utc2et(date)
+                    et_array = np.arange(et0-100, et0+100)
+                    iso_array = iso_from_tai(tai_from_tdb(et_array), digits=6, ymd=True)
+                    for k, et in enumerate(et_array):
+                        assert iso_array[k] == cspyce.et2utc(et, 'ISOC', 6)
+
+        set_ut_model('LEAPS')
+
+        ########################################
+        # UTC-day conversions
+        ########################################
+
+        set_tai_origin('MIDNIGHT')
+
+        # Check utc_from_day
+        assert utc_from_day(0) == 0
+        assert utc_from_day([0,1])[0] == 0
+        assert utc_from_day([0,1])[1] == 86400
+
+        assert isinstance(utc_from_day(0), numbers.Integral)
+        assert not isinstance(utc_from_day(0.), numbers.Integral)
+
+        # Check day_sec_from_utc
+        assert day_sec_from_utc(0) == (0, 0)
+        assert day_sec_from_utc([100, 86600])[0][0] == 0
+        assert day_sec_from_utc([100, 86600])[0][1] == 1
+        assert day_sec_from_utc([100, 86600])[1][0] == 100
+        assert day_sec_from_utc([100, 86600])[1][1] == 200
+
+        assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
+        assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
+        assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
+
+        # A large number of dates, spanning > 200 years
+        daylist = np.arange(-40000,40000,83)
+
+        # Test as a loop
+        for day in daylist:
+            (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
+            assert test_day == day
+            assert test_sec == 0
+
+        # Test as an array operation
+        (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
+        assert np.all(test_day == daylist)
+        assert np.all(test_sec == 0)
+
+        # Switch UTC origin to NOON
+
+        set_tai_origin('NOON')
+
+        # Check utc_from_day
+        assert utc_from_day(0) == -43200
+        assert utc_from_day([0,1])[0] == -43200
+        assert utc_from_day([0,1])[1] ==  43200
+
+        assert isinstance(utc_from_day(0), numbers.Integral)
+        assert not isinstance(utc_from_day(0.), numbers.Integral)
+
+        # Check day_sec_from_utc
+        assert day_sec_from_utc(0) == (0, 43200)
+        assert day_sec_from_utc([100, 86600])[0][0] == 0
+        assert day_sec_from_utc([100, 86600])[0][1] == 1
+        assert day_sec_from_utc([100, 86600])[1][0] == 43300
+        assert day_sec_from_utc([100, 86600])[1][1] == 43400
+
+        assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
+        assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
+        assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
+
+        # A large number of dates, spanning > 200 years
+        daylist = np.arange(-40000,40000,83)
+
+        # Test as a loop
+        for day in daylist:
+            (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
+            assert test_day == day
+            assert test_sec == 0
+
+        # Test as an array operation
+        (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
+        assert np.all(test_day == daylist)
+        assert np.all(test_sec == 0)
+
+        ########################################
+        # UTC-TAI conversions
+        ########################################
+
+        set_ut_model('LEAPS')
+        set_tai_origin('NOON')
+
+        # Check tai_from_day
+        assert tai_from_day(0) == 32 - 43200
+        assert tai_from_day([0,1])[0] == 32 - 43200
+        assert tai_from_day([0,1])[1] == 32 + 43200
+
+        assert isinstance(tai_from_day(0), numbers.Integral)
+        assert not isinstance(tai_from_day(0.), numbers.Integral)
+
+        # Check day_sec_from_tai
+        assert day_sec_from_tai(32.) == (0, 43200.)
+        assert day_sec_from_tai([35.,86435.])[0][0] == 0
+        assert day_sec_from_tai([35.,86435.])[0][1] == 1
+        assert day_sec_from_tai([35.,86435.])[1][0] == 43203.
+        assert day_sec_from_tai([35.,86435.])[1][1] == 43203.
+
+        assert isinstance(day_sec_from_tai([35,86435])[0][1], numbers.Integral)
+        assert isinstance(day_sec_from_tai([35,86435])[1][0], numbers.Integral)
+        assert not isinstance(day_sec_from_tai([35.,86435.])[1][0], numbers.Integral)
+
+        # utc_from_tai
+        assert day_sec_from_utc(utc_from_tai(32)) == (0, 43200.)
+        assert day_sec_from_utc(utc_from_tai([35,86435]))[0][0] == 0
+        assert day_sec_from_utc(utc_from_tai([35,86435]))[0][1] == 1
+        assert day_sec_from_utc(utc_from_tai([35,86435]))[1][0] == 43235-32
+        assert day_sec_from_utc(utc_from_tai([35,86435]))[1][1] == 43235-32
+
+        assert isinstance(utc_from_tai(32), numbers.Integral)
+        assert isinstance(utc_from_tai([35,86435])[0], numbers.Integral)
+        assert not isinstance(utc_from_tai(32.), numbers.Integral)
+        assert not isinstance(utc_from_tai([35.,86435.])[0], numbers.Integral)
+
+        # tai_from_utc
+        assert day_sec_from_tai(tai_from_utc(0)) == (0, 43200)
+        assert day_sec_from_tai(tai_from_utc([100,200]))[0][0] == 0
+        assert day_sec_from_tai(tai_from_utc([100,200]))[0][1] == 0
+        assert day_sec_from_tai(tai_from_utc([100,200]))[1][0] == 43300
+        assert day_sec_from_tai(tai_from_utc([100,200]))[1][1] == 43400
+
+        assert isinstance(tai_from_utc(43200), numbers.Integral)
+        assert isinstance(tai_from_utc([100,200])[0], numbers.Integral)
+        assert not isinstance(tai_from_utc(43200.), numbers.Integral)
+        assert not isinstance(tai_from_utc([100.,200.])[0], numbers.Integral)
+
+        # A large number of dates, spanning > 200 years
+        daylist = np.arange(-40000,40000,83)
+
+        # Test as a loop
+        for day in daylist:
+            (test_day, test_sec) = day_sec_from_tai(tai_from_day(day))
+            assert test_day == day, 'Day mismatch at ' + str(day)
+            assert test_sec == 0,   'Sec mismatch at ' + str(day)
+
+        # Test as an array operation
+        (test_day, test_sec) = day_sec_from_tai(tai_from_day(daylist))
+        assert np.all(test_day == daylist)
+        assert np.all(test_sec == 0)
+
+        ########################################
+        # TAI-TDB conversions
+        ########################################
+
+        # Check tdb_from_tai
+        assert tdb_from_tai(tai_from_day(0) + 43200) == pytest.approx(64.183927284731055, abs=1e-15)
+
+        # Check tai_from_tdb
+        assert tai_from_tdb(64.183927284731055) == pytest.approx(32., abs=1e-15)
+
+        # Test inversions around tdb = 0.
+        # A list of two million small numbers spanning 2 sec
+        secs = 2.
+        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+        assert np.all(errors <  1.e-11 * secs)
+        assert np.all(errors > -1.e-11 * secs)
+
+        # Now make sure we get the exact same results when we replace arrays by
+        # scalars
+        for i in range(0, tdbs.size, 1000):
+            assert errors[i] == tdb_from_tai(tai_from_tdb(tdbs[i])) - tdbs[i]
+
+        # A list of two million bigger numbers spanning ~ 20 days
+        secs = 20. * 86400.
+        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+        assert np.all(errors <  1.e-15 * secs)
+        assert np.all(errors > -1.e-15 * secs)
+
+        # A list of two million still bigger numbers spanning ~ 2000 years
+        secs = 2000. * 365. * 86400.
+        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+        assert np.all(errors <  1.e-15 * secs)
+        assert np.all(errors > -1.e-15 * secs)
+
+        ########################################
+        # TAI-TT conversions
+        ########################################
+
+        assert tt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
+        assert tdt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
+
+        assert tai_from_tt(10.) == pytest.approx(-22.184, abs=1e-14)
+        assert tai_from_tdt(10.) == pytest.approx(-22.184, abs=1e-14)
+
+        set_tai_origin('MIDNIGHT')
+
+        assert tt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
+        assert tdt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
+
+        assert tai_from_tt(32.184) == pytest.approx(43200, abs=1e-14)
+        assert tai_from_tdt(32.184) == pytest.approx(43200, abs=1e-14)
+
+        set_tai_origin('NOON')
+
+        ########################################
+        # Time System conversions
+        ########################################
+
+        offsets_1971_12_31 = {'LEAPS': 10, 'SPICE':9, 'CANON': 9.889649987220764,
+                              'PRE-1972': 9.889649987220764}
+
+        # For the batch test of every day 1971-2012. Conversions should be exact.
+        daylist = np.arange(day_from_ymd(1971,1,1), day_from_ymd(2012,1,1))
+
+        for model in ('SPICE', 'PRE-1972', 'CANON', 'LEAPS'):
+            set_ut_model(model)
+
+            for origin in ('MIDNIGHT', 'NOON'):
+                set_tai_origin(origin)
+
+                for value in [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]:
+                    assert time_from_time(value, 'UTC', 'TAI') == tai_from_utc(value)
+                    assert time_from_time(value, 'TDB', 'TAI') == tai_from_tdb(value)
+                    assert time_from_time(value, 'TT' , 'TAI') == tai_from_tt( value)
+                    assert time_from_time(value, 'TAI', 'UTC') == utc_from_tai(value)
+                    assert time_from_time(value, 'TAI', 'TDB') == tdb_from_tai(value)
+                    assert time_from_time(value, 'TAI', 'TT' ) == tt_from_tai( value)
+
+                t1 = [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]
+                for tsys1 in ('UTC', 'TAI', 'TT', 'TDB'):
+                    for tsys2 in ('UTC', 'TAI', 'TT', 'TDB'):
+                        t2 = time_from_time(t1, tsys1, tsys2)
+                        t3 = time_from_time(t2, tsys2, tsys1)
+                        assert np.abs(t3-t1).max() < 1.e-11
+
+                assert time_from_day_sec(10, 43200, 'TAI') == \
+                                 tai_from_day_sec(10, 43200)
+                assert time_from_day_sec(10, 43200, 'TDB') == \
+                                 tdb_from_tai(tai_from_day_sec(10, 43200))
+                assert time_from_day_sec(10, 43200, 'TT') == \
+                                 tt_from_tai(tai_from_day_sec(10, 43200))
+
+                assert day_sec_from_time(10000., 'TAI') == \
+                                 day_sec_from_tai(10000.)
+                assert day_sec_from_time(10000., 'TDB') == \
+                                 day_sec_from_tai(tai_from_tdb(10000.))
+                assert day_sec_from_time(10000., 'TT') == \
+                                 day_sec_from_tai(tai_from_tt(10000.))
+
+                # "Dates" in other time systems
+                tai = time_from_day_sec(365, 32, timesys='TAI', leapsecs=False)
+                assert day_sec_from_time(tai, timesys='TAI') == (365, 0)
+
+                tt = time_from_day_sec(365, 64.184, timesys='TT', leapsecs=False)
+                assert day_sec_from_time(tt, timesys='TT')[0] == 365
+                assert day_sec_from_time(tt, timesys='TT')[1] == pytest.approx(0., abs=1e-14)
+
+                days = np.arange(365, 731)
+                tdb = time_from_day_sec(days, 43200., timesys='TDB', leapsecs=False)
+                tt  = time_from_day_sec(days, 43200., timesys='TT',  leapsecs=False)
+
+                sec1 = day_sec_from_time(tdb, timesys='TDB')[1]
+                sec2 = day_sec_from_time(tt,  timesys='TT')[1]
+                diffs = sec1 - sec2
+                assert np.abs(diffs).max() < 0.0017
+                assert np.abs(diffs.mean()) < 2.e-7
+
+                # TAI tests...
+
+                # TAI offset was 31-32 seconds ahead of UTC in 1999,2000,2001
+                (day, sec) = day_sec_as_type_from_utc((-366,0,366), 0., time_type='TAI')
+                assert np.all(day == (-366,0,366))
+                assert np.all(sec == (31.,32.,32.))
+
+                tai = time_from_day_sec((-366, 0, 366), 0., 'TAI')
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                assert np.all(day == (-366,0,366))
+                assert np.all(sec == (31.,32.,32.))
+
+                # Inverse of the above
+                (day, sec) = utc_from_day_sec_as_type((-366,0,366), 32., time_type='TAI')
+                assert np.all(day == (-366,0,366))
+                assert np.all(sec == (1.,0.,0.))
+
+                tai = time_from_day_sec((-366, 0, 366), 32., 'TAI', leapsecs=False)
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+                assert np.all(day == (-366,0,366))
+                assert np.all(sec == (1.,0.,0.))
+
+                # TAI offset depended on model before 1972
+                (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1972,1,1), 0, time_type='TAI')
+                assert sec == 10
+
+                tai = time_from_day_sec(day_from_ymd(1972,1,1), 0., 'TAI')
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                assert sec == 10
+
+                (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1971,12,31), 0, time_type='TAI')
+                assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
+
+                tai = time_from_day_sec(day_from_ymd(1971,12,31), 0., 'TAI')
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
+
+                # Inverses of the above
+                (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1972,1,1), 10, time_type='TAI')
+                assert sec == 0
+
+                tai = time_from_day_sec(day_from_ymd(1972,1,1), 10, 'TAI', leapsecs=False)
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+                assert sec == 0
+
+                (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1971,12,31),
+                                                      offsets_1971_12_31[model]+1, time_type='TAI')
+                assert sec == pytest.approx(1, abs=1e-14)
+
+                tai = time_from_day_sec(day_from_ymd(1971,12,31), offsets_1971_12_31[model],
+                                        'TAI', leapsecs=False)
+                (day, sec) = day_sec_from_time(tai+1, 'TAI', leapsecs=True)
+                assert sec == pytest.approx(1, abs=1e-14)
+
+                # Batch test 1971-2012. Conversions should be exact.
+                (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TAI')
+                (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 43200.)
+
+                tai = time_from_day_sec(daylist, 43200., 'TAI')
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
+                (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 43200.)
+
+                (day, sec) = day_sec_as_type_from_utc(daylist, 0., time_type='TAI')
+                (dtest,stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 0.)
+
+                tai = time_from_day_sec(daylist, 0., 'TAI')
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
+                (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 0.)
+
+                (day, sec) = utc_from_day_sec_as_type(daylist, 0., time_type='TAI')
+                (dtest,stest) = day_sec_as_type_from_utc(day, sec, time_type='TAI')
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 0.)
+
+                tai = time_from_day_sec(daylist, 0., 'TAI', leapsecs=False)
+                (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+                tai = time_from_day_sec(day, sec, 'TAI', leapsecs=True)
+                (dtest, stest) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+                assert np.all(dtest == daylist)
+                assert np.all(stest == 0.)
+
+                # TDB tests...
+
+                assert day_sec_as_type_from_utc(0, 0, time_type='TDB')[1] == \
+                                pytest.approx(64.18391281194636, abs=1e-14)
+                (day, sec) = utc_from_day_sec_as_type(0, 0, time_type='TDB')
+                assert day * 86400 + sec == pytest.approx(-64.18391281194636, abs=1e-7)
+
+                tdb = time_from_day_sec(0, 0., 'TDB')
+                (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
+                assert sec == pytest.approx(64.18391281194636, abs=1e-14)
+
+                (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TDB')
+                (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TDB')
+                assert np.all(dtest == daylist)
+                assert np.abs(stest - 43200.).max() < 1.e-7
+
+                (day, sec) = utc_from_day_sec_as_type(daylist, 43200., time_type='TDB')
+                (dtest, stest) = day_sec_as_type_from_utc(day, sec, time_type='TDB')
+                assert np.all(dtest == daylist)
+                assert np.abs(stest - 43200.).max() < 2.e-7
+
+                tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=True)
+                tdb2 = tdb_from_tai(tai_from_day_sec(daylist, 43200.))
+                assert np.all(tdb == tdb2)
+
+                (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
+                tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=False)
+                assert np.abs(tdb - tdb2).max() < 1.e-7
+
+                (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=True)
+                assert np.all(dtest == daylist)
+                assert np.abs(stest - 43200.).max() < 1.e-7
+
+                tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=False)
+                (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=True)
+                tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=True)
+                (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=False)
+                assert np.all(dtest == daylist)
+                assert np.abs(stest - 43200.).max() < 2.e-7
+
+    finally:
+        try:
+            cspyce.kclear()
+        except NameError:
+            pass
+        set_ut_model('LEAPS')
+        set_tai_origin('MIDNIGHT')
+
 
 ##########################################################################################

--- a/tests/test_utc_tai_tdb_tt.py
+++ b/tests/test_utc_tai_tdb_tt.py
@@ -7,6 +7,7 @@ import numpy as np
 import os
 import pytest
 import sys
+from contextlib import suppress
 
 from julian.utc_tai_tdb_tt import (
     day_sec_from_tai,
@@ -460,10 +461,8 @@ def test_utc_tai_tdb_tt():
                 assert np.abs(stest - 43200.).max() < 2.e-7
 
     finally:
-        try:
+        with suppress(NameError):
             cspyce.kclear()
-        except NameError:
-            pass
         set_ut_model('LEAPS')
         set_tai_origin('MIDNIGHT')
 

--- a/tests/test_utc_tai_tdb_tt.py
+++ b/tests/test_utc_tai_tdb_tt.py
@@ -5,8 +5,8 @@
 import numbers
 import numpy as np
 import os
+import pytest
 import sys
-import unittest
 
 from julian.utc_tai_tdb_tt import (
     day_sec_from_tai,
@@ -39,430 +39,426 @@ from julian.formatters   import iso_from_tai
 from julian.leap_seconds import set_ut_model
 
 
-class Test_utc_tai_tdb_tt(unittest.TestCase):
-
-    def runTest(self):
-
-        import warnings
-        from julian._warnings import JulianDeprecationWarning
-        warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
-
-        ################################################################
-        # Rigorously compare TDB to cspyce ET around all leap seconds
-        ################################################################
-
-        import cspyce
-
-        julian_root_dir = os.path.split(sys.modules['julian'].__file__)[0]
-        lsk_path = os.path.join(julian_root_dir, 'assets',
-                                leap_seconds._LATEST_LSK_NAME)
-        cspyce.furnsh(lsk_path)
-
-        set_ut_model('SPICE')
-        for origin in ('MIDNIGHT', 'NOON'):
-            set_tai_origin(origin)
-            for y in range(1970, 2030):
-                for m in (1, 7):
-                    date = f'{y}-{m:02d}-00T00:00:00'
-                    et0 = cspyce.utc2et(date)
-                    et_array = np.arange(et0-100, et0+100)
-                    iso_array = iso_from_tai(tai_from_tdb(et_array), digits=6, ymd=True)
-                    for k, et in enumerate(et_array):
-                        self.assertEqual(iso_array[k], cspyce.et2utc(et, 'ISOC', 6))
-
-        set_ut_model('LEAPS')
-
-        ########################################
-        # UTC-day conversions
-        ########################################
-
-        set_tai_origin('MIDNIGHT')
-
-        # Check utc_from_day
-        self.assertEqual(utc_from_day(0), 0)
-        self.assertEqual(utc_from_day([0,1])[0], 0)
-        self.assertEqual(utc_from_day([0,1])[1], 86400)
-
-        self.assertIsInstance(utc_from_day(0), numbers.Integral)
-        self.assertNotIsInstance(utc_from_day(0.), numbers.Integral)
-
-        # Check day_sec_from_utc
-        self.assertEqual(day_sec_from_utc(0), (0, 0))
-        self.assertEqual(day_sec_from_utc([100, 86600])[0][0], 0)
-        self.assertEqual(day_sec_from_utc([100, 86600])[0][1], 1)
-        self.assertEqual(day_sec_from_utc([100, 86600])[1][0], 100)
-        self.assertEqual(day_sec_from_utc([100, 86600])[1][1], 200)
-
-        self.assertIsInstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
-        self.assertIsInstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
-        self.assertNotIsInstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
-
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
-
-        # Test as a loop
-        for day in daylist:
-            (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
-            self.assertEqual(test_day, day)
-            self.assertEqual(test_sec, 0)
-
-        # Test as an array operation
-        (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
-        self.assertTrue(np.all(test_day == daylist))
-        self.assertTrue(np.all(test_sec == 0))
-
-        # Switch UTC origin to NOON
-
-        set_tai_origin('NOON')
-
-        # Check utc_from_day
-        self.assertEqual(utc_from_day(0), -43200)
-        self.assertEqual(utc_from_day([0,1])[0], -43200)
-        self.assertEqual(utc_from_day([0,1])[1],  43200)
-
-        self.assertIsInstance(utc_from_day(0), numbers.Integral)
-        self.assertNotIsInstance(utc_from_day(0.), numbers.Integral)
-
-        # Check day_sec_from_utc
-        self.assertEqual(day_sec_from_utc(0), (0, 43200))
-        self.assertEqual(day_sec_from_utc([100, 86600])[0][0], 0)
-        self.assertEqual(day_sec_from_utc([100, 86600])[0][1], 1)
-        self.assertEqual(day_sec_from_utc([100, 86600])[1][0], 43300)
-        self.assertEqual(day_sec_from_utc([100, 86600])[1][1], 43400)
-
-        self.assertIsInstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
-        self.assertIsInstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
-        self.assertNotIsInstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
-
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
-
-        # Test as a loop
-        for day in daylist:
-            (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
-            self.assertEqual(test_day, day)
-            self.assertEqual(test_sec, 0)
-
-        # Test as an array operation
-        (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
-        self.assertTrue(np.all(test_day == daylist))
-        self.assertTrue(np.all(test_sec == 0))
-
-        ########################################
-        # UTC-TAI conversions
-        ########################################
-
-        set_ut_model('LEAPS')
-        set_tai_origin('NOON')
-
-        # Check tai_from_day
-        self.assertEqual(tai_from_day(0), 32 - 43200)
-        self.assertEqual(tai_from_day([0,1])[0], 32 - 43200)
-        self.assertEqual(tai_from_day([0,1])[1], 32 + 43200)
-
-        self.assertIsInstance(tai_from_day(0), numbers.Integral)
-        self.assertNotIsInstance(tai_from_day(0.), numbers.Integral)
-
-        # Check day_sec_from_tai
-        self.assertEqual(day_sec_from_tai(32.), (0, 43200.))
-        self.assertEqual(day_sec_from_tai([35.,86435.])[0][0], 0)
-        self.assertEqual(day_sec_from_tai([35.,86435.])[0][1], 1)
-        self.assertEqual(day_sec_from_tai([35.,86435.])[1][0], 43203.)
-        self.assertEqual(day_sec_from_tai([35.,86435.])[1][1], 43203.)
-
-        self.assertIsInstance(day_sec_from_tai([35,86435])[0][1], numbers.Integral)
-        self.assertIsInstance(day_sec_from_tai([35,86435])[1][0], numbers.Integral)
-        self.assertNotIsInstance(day_sec_from_tai([35.,86435.])[1][0], numbers.Integral)
-
-        # utc_from_tai
-        self.assertEqual(day_sec_from_utc(utc_from_tai(32)), (0, 43200.))
-        self.assertEqual(day_sec_from_utc(utc_from_tai([35,86435]))[0][0], 0)
-        self.assertEqual(day_sec_from_utc(utc_from_tai([35,86435]))[0][1], 1)
-        self.assertEqual(day_sec_from_utc(utc_from_tai([35,86435]))[1][0], 43235-32)
-        self.assertEqual(day_sec_from_utc(utc_from_tai([35,86435]))[1][1], 43235-32)
-
-        self.assertIsInstance(utc_from_tai(32), numbers.Integral)
-        self.assertIsInstance(utc_from_tai([35,86435])[0], numbers.Integral)
-        self.assertNotIsInstance(utc_from_tai(32.), numbers.Integral)
-        self.assertNotIsInstance(utc_from_tai([35.,86435.])[0], numbers.Integral)
-
-        # tai_from_utc
-        self.assertEqual(day_sec_from_tai(tai_from_utc(0)), (0, 43200))
-        self.assertEqual(day_sec_from_tai(tai_from_utc([100,200]))[0][0], 0)
-        self.assertEqual(day_sec_from_tai(tai_from_utc([100,200]))[0][1], 0)
-        self.assertEqual(day_sec_from_tai(tai_from_utc([100,200]))[1][0], 43300)
-        self.assertEqual(day_sec_from_tai(tai_from_utc([100,200]))[1][1], 43400)
-
-        self.assertIsInstance(tai_from_utc(43200), numbers.Integral)
-        self.assertIsInstance(tai_from_utc([100,200])[0], numbers.Integral)
-        self.assertNotIsInstance(tai_from_utc(43200.), numbers.Integral)
-        self.assertNotIsInstance(tai_from_utc([100.,200.])[0], numbers.Integral)
-
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
-
-        # Test as a loop
-        for day in daylist:
-            (test_day, test_sec) = day_sec_from_tai(tai_from_day(day))
-            self.assertEqual(test_day, day, 'Day mismatch at ' + str(day))
-            self.assertEqual(test_sec, 0,   'Sec mismatch at ' + str(day))
-
-        # Test as an array operation
-        (test_day, test_sec) = day_sec_from_tai(tai_from_day(daylist))
-        self.assertTrue(np.all(test_day == daylist))
-        self.assertTrue(np.all(test_sec == 0))
-
-        ########################################
-        # TAI-TDB conversions
-        ########################################
-
-        # Check tdb_from_tai
-        self.assertAlmostEqual(tdb_from_tai(tai_from_day(0) + 43200),
-                               64.183927284731055, places=15)
-
-        # Check tai_from_tdb
-        self.assertAlmostEqual(tai_from_tdb(64.183927284731055), 32., places=15)
-
-        # Test inversions around tdb = 0.
-        # A list of two million small numbers spanning 2 sec
-        secs = 2.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-11 * secs))
-        self.assertTrue(np.all(errors > -1.e-11 * secs))
-
-        # Now make sure we get the exact same results when we replace arrays by
-        # scalars
-        for i in range(0, tdbs.size, 1000):
-            self.assertEqual(errors[i],
-                             tdb_from_tai(tai_from_tdb(tdbs[i])) - tdbs[i])
-
-        # A list of two million bigger numbers spanning ~ 20 days
-        secs = 20. * 86400.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-15 * secs))
-        self.assertTrue(np.all(errors > -1.e-15 * secs))
-
-        # A list of two million still bigger numbers spanning ~ 2000 years
-        secs = 2000. * 365. * 86400.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-15 * secs))
-        self.assertTrue(np.all(errors > -1.e-15 * secs))
-
-        ########################################
-        # TAI-TT conversions
-        ########################################
-
-        self.assertAlmostEqual(tt_from_tai(10.),  42.184, places=15)
-        self.assertAlmostEqual(tdt_from_tai(10.), 42.184, places=15)
-
-        self.assertAlmostEqual(tai_from_tt(10.), -22.184, places=14)
-        self.assertAlmostEqual(tai_from_tdt(10.), -22.184, places=14)
-
-        set_tai_origin('MIDNIGHT')
-
-        self.assertAlmostEqual(tt_from_tai(10. + 43200),  42.184, places=11)
-        self.assertAlmostEqual(tdt_from_tai(10. + 43200), 42.184, places=11)
-
-        self.assertAlmostEqual(tai_from_tt(32.184), 43200, places=14)
-        self.assertAlmostEqual(tai_from_tdt(32.184), 43200, places=14)
-
-        set_tai_origin('NOON')
-
-        ########################################
-        # Time System conversions
-        ########################################
-
-        offsets_1971_12_31 = {'LEAPS': 10, 'SPICE':9, 'CANON': 9.889649987220764,
-                              'PRE-1972': 9.889649987220764}
-
-        # For the batch test of every day 1971-2012. Conversions should be exact.
-        daylist = np.arange(day_from_ymd(1971,1,1), day_from_ymd(2012,1,1))
-
-        for model in ('SPICE', 'PRE-1972', 'CANON', 'LEAPS'):
-          set_ut_model(model)
-
-          for origin in ('MIDNIGHT', 'NOON'):
-            set_tai_origin(origin)
-
-            for value in [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]:
-                self.assertEqual(time_from_time(value, 'UTC', 'TAI'), tai_from_utc(value))
-                self.assertEqual(time_from_time(value, 'TDB', 'TAI'), tai_from_tdb(value))
-                self.assertEqual(time_from_time(value, 'TT' , 'TAI'), tai_from_tt( value))
-                self.assertEqual(time_from_time(value, 'TAI', 'UTC'), utc_from_tai(value))
-                self.assertEqual(time_from_time(value, 'TAI', 'TDB'), tdb_from_tai(value))
-                self.assertEqual(time_from_time(value, 'TAI', 'TT' ), tt_from_tai( value))
-
-            t1 = [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]
-            for tsys1 in ('UTC', 'TAI', 'TT', 'TDB'):
-              for tsys2 in ('UTC', 'TAI', 'TT', 'TDB'):
-                t2 = time_from_time(t1, tsys1, tsys2)
-                t3 = time_from_time(t2, tsys2, tsys1)
-                self.assertLess(np.abs(t3-t1).max(), 1.e-11)
-
-            self.assertEqual(time_from_day_sec(10, 43200, 'TAI'),
-                             tai_from_day_sec(10, 43200))
-            self.assertEqual(time_from_day_sec(10, 43200, 'TDB'),
-                             tdb_from_tai(tai_from_day_sec(10, 43200)))
-            self.assertEqual(time_from_day_sec(10, 43200, 'TT'),
-                             tt_from_tai(tai_from_day_sec(10, 43200)))
-
-            self.assertEqual(day_sec_from_time(10000., 'TAI'),
-                             day_sec_from_tai(10000.))
-            self.assertEqual(day_sec_from_time(10000., 'TDB'),
-                             day_sec_from_tai(tai_from_tdb(10000.)))
-            self.assertEqual(day_sec_from_time(10000., 'TT'),
-                             day_sec_from_tai(tai_from_tt(10000.)))
-
-            # "Dates" in other time systems
-            tai = time_from_day_sec(365, 32, timesys='TAI', leapsecs=False)
-            self.assertEqual(day_sec_from_time(tai, timesys='TAI'), (365, 0))
-
-            tt = time_from_day_sec(365, 64.184, timesys='TT', leapsecs=False)
-            self.assertEqual(day_sec_from_time(tt, timesys='TT')[0], 365)
-            self.assertAlmostEqual(day_sec_from_time(tt, timesys='TT')[1], 0., places=14)
-
-            days = np.arange(365, 731)
-            tdb = time_from_day_sec(days, 43200., timesys='TDB', leapsecs=False)
-            tt  = time_from_day_sec(days, 43200., timesys='TT',  leapsecs=False)
-
-            sec1 = day_sec_from_time(tdb, timesys='TDB')[1]
-            sec2 = day_sec_from_time(tt,  timesys='TT')[1]
-            diffs = sec1 - sec2
-            self.assertLess(np.abs(diffs).max(), 0.0017)
-            self.assertLess(np.abs(diffs.mean()), 2.e-7)
-
-            # TAI tests...
-
-            # TAI offset was 31-32 seconds ahead of UTC in 1999,2000,2001
-            (day, sec) = day_sec_as_type_from_utc((-366,0,366), 0., time_type='TAI')
-            self.assertTrue(np.all(day == (-366,0,366)))
-            self.assertTrue(np.all(sec == (31.,32.,32.)))
-
-            tai = time_from_day_sec((-366, 0, 366), 0., 'TAI')
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            self.assertTrue(np.all(day == (-366,0,366)))
-            self.assertTrue(np.all(sec == (31.,32.,32.)))
-
-            # Inverse of the above
-            (day, sec) = utc_from_day_sec_as_type((-366,0,366), 32., time_type='TAI')
-            self.assertTrue(np.all(day == (-366,0,366)))
-            self.assertTrue(np.all(sec == (1.,0.,0.)))
-
-            tai = time_from_day_sec((-366, 0, 366), 32., 'TAI', leapsecs=False)
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-            self.assertTrue(np.all(day == (-366,0,366)))
-            self.assertTrue(np.all(sec == (1.,0.,0.)))
-
-            # TAI offset depended on model before 1972
-            (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1972,1,1), 0, time_type='TAI')
-            self.assertEqual(sec, 10)
-
-            tai = time_from_day_sec(day_from_ymd(1972,1,1), 0., 'TAI')
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            self.assertEqual(sec, 10)
-
-            (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1971,12,31), 0, time_type='TAI')
-            self.assertAlmostEqual(sec, offsets_1971_12_31[model], places=14)
-
-            tai = time_from_day_sec(day_from_ymd(1971,12,31), 0., 'TAI')
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            self.assertAlmostEqual(sec, offsets_1971_12_31[model], places=14)
-
-            # Inverses of the above
-            (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1972,1,1), 10, time_type='TAI')
-            self.assertEqual(sec, 0)
-
-            tai = time_from_day_sec(day_from_ymd(1972,1,1), 10, 'TAI', leapsecs=False)
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-            self.assertEqual(sec, 0)
-
-            (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1971,12,31),
-                                                  offsets_1971_12_31[model]+1, time_type='TAI')
-            self.assertAlmostEqual(sec, 1, places=14)
-
-            tai = time_from_day_sec(day_from_ymd(1971,12,31), offsets_1971_12_31[model],
-                                    'TAI', leapsecs=False)
-            (day, sec) = day_sec_from_time(tai+1, 'TAI', leapsecs=True)
-            self.assertAlmostEqual(sec, 1, places=14)
-
-            # Batch test 1971-2012. Conversions should be exact.
-            (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TAI')
-            (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 43200.))
-
-            tai = time_from_day_sec(daylist, 43200., 'TAI')
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
-            (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 43200.))
-
-            (day, sec) = day_sec_as_type_from_utc(daylist, 0., time_type='TAI')
-            (dtest,stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 0.))
-
-            tai = time_from_day_sec(daylist, 0., 'TAI')
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
-            (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 0.))
-
-            (day, sec) = utc_from_day_sec_as_type(daylist, 0., time_type='TAI')
-            (dtest,stest) = day_sec_as_type_from_utc(day, sec, time_type='TAI')
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 0.))
-
-            tai = time_from_day_sec(daylist, 0., 'TAI', leapsecs=False)
-            (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
-            tai = time_from_day_sec(day, sec, 'TAI', leapsecs=True)
-            (dtest, stest) = day_sec_from_time(tai, 'TAI', leapsecs=False)
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertTrue(np.all(stest == 0.))
-
-            # TDB tests...
-
-            self.assertTrue(abs(day_sec_as_type_from_utc(0, 0, time_type='TDB')[1]
-                            - 64.183927284731055) < 1.e15)
-            self.assertTrue(abs(utc_from_day_sec_as_type(0, 0, time_type='TDB')[1]
-                            + 64.183927284731055) < 1.e15)
-
-            tdb = time_from_day_sec(0, 0., 'TDB')
-            (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
-            self.assertAlmostEqual(sec, 64.18391281194636, places=14)
-
-            (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TDB')
-            (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TDB')
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertLess(np.abs(stest - 43200.).max(), 1.e-7)
-
-            (day, sec) = utc_from_day_sec_as_type(daylist, 43200., time_type='TDB')
-            (dtest, stest) = day_sec_as_type_from_utc(day, sec, time_type='TDB')
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertLess(np.abs(stest - 43200.).max(), 2.e-7)
-
-            tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=True)
-            tdb2 = tdb_from_tai(tai_from_day_sec(daylist, 43200.))
-            self.assertTrue(np.all(tdb == tdb2))
-
-            (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
-            tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=False)
-            self.assertLess(np.abs(tdb - tdb2).max(), 1.e-7)
-
-            (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=True)
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertLess(np.abs(stest - 43200.).max(), 1.e-7)
-
-            tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=False)
-            (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=True)
-            tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=True)
-            (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=False)
-            self.assertTrue(np.all(dtest == daylist))
-            self.assertLess(np.abs(stest - 43200.).max(), 2.e-7)
+def test_utc_tai_tdb_tt():
+
+    import warnings
+    from julian._warnings import JulianDeprecationWarning
+    warnings.filterwarnings('ignore', category=JulianDeprecationWarning)
+
+    ################################################################
+    # Rigorously compare TDB to cspyce ET around all leap seconds
+    ################################################################
+
+    import cspyce
+
+    julian_root_dir = os.path.split(sys.modules['julian'].__file__)[0]
+    lsk_path = os.path.join(julian_root_dir, 'assets',
+                            leap_seconds._LATEST_LSK_NAME)
+    cspyce.furnsh(lsk_path)
+
+    set_ut_model('SPICE')
+    for origin in ('MIDNIGHT', 'NOON'):
+        set_tai_origin(origin)
+        for y in range(1970, 2030):
+            for m in (1, 7):
+                date = f'{y}-{m:02d}-00T00:00:00'
+                et0 = cspyce.utc2et(date)
+                et_array = np.arange(et0-100, et0+100)
+                iso_array = iso_from_tai(tai_from_tdb(et_array), digits=6, ymd=True)
+                for k, et in enumerate(et_array):
+                    assert iso_array[k] == cspyce.et2utc(et, 'ISOC', 6)
+
+    set_ut_model('LEAPS')
+
+    ########################################
+    # UTC-day conversions
+    ########################################
+
+    set_tai_origin('MIDNIGHT')
+
+    # Check utc_from_day
+    assert utc_from_day(0) == 0
+    assert utc_from_day([0,1])[0] == 0
+    assert utc_from_day([0,1])[1] == 86400
+
+    assert isinstance(utc_from_day(0), numbers.Integral)
+    assert not isinstance(utc_from_day(0.), numbers.Integral)
+
+    # Check day_sec_from_utc
+    assert day_sec_from_utc(0) == (0, 0)
+    assert day_sec_from_utc([100, 86600])[0][0] == 0
+    assert day_sec_from_utc([100, 86600])[0][1] == 1
+    assert day_sec_from_utc([100, 86600])[1][0] == 100
+    assert day_sec_from_utc([100, 86600])[1][1] == 200
+
+    assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
+    assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
+    assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
+
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
+
+    # Test as a loop
+    for day in daylist:
+        (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
+        assert test_day == day
+        assert test_sec == 0
+
+    # Test as an array operation
+    (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
+    assert np.all(test_day == daylist)
+    assert np.all(test_sec == 0)
+
+    # Switch UTC origin to NOON
+
+    set_tai_origin('NOON')
+
+    # Check utc_from_day
+    assert utc_from_day(0) == -43200
+    assert utc_from_day([0,1])[0] == -43200
+    assert utc_from_day([0,1])[1] ==  43200
+
+    assert isinstance(utc_from_day(0), numbers.Integral)
+    assert not isinstance(utc_from_day(0.), numbers.Integral)
+
+    # Check day_sec_from_utc
+    assert day_sec_from_utc(0) == (0, 43200)
+    assert day_sec_from_utc([100, 86600])[0][0] == 0
+    assert day_sec_from_utc([100, 86600])[0][1] == 1
+    assert day_sec_from_utc([100, 86600])[1][0] == 43300
+    assert day_sec_from_utc([100, 86600])[1][1] == 43400
+
+    assert isinstance(day_sec_from_utc([100, 86600])[0][1], numbers.Integral)
+    assert isinstance(day_sec_from_utc([100, 86600])[1][1], numbers.Integral)
+    assert not isinstance(day_sec_from_utc([100., 86600.])[1][0], numbers.Integral)
+
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
+
+    # Test as a loop
+    for day in daylist:
+        (test_day, test_sec) = day_sec_from_utc(utc_from_day(day))
+        assert test_day == day
+        assert test_sec == 0
+
+    # Test as an array operation
+    (test_day, test_sec) = day_sec_from_utc(utc_from_day(daylist))
+    assert np.all(test_day == daylist)
+    assert np.all(test_sec == 0)
+
+    ########################################
+    # UTC-TAI conversions
+    ########################################
+
+    set_ut_model('LEAPS')
+    set_tai_origin('NOON')
+
+    # Check tai_from_day
+    assert tai_from_day(0) == 32 - 43200
+    assert tai_from_day([0,1])[0] == 32 - 43200
+    assert tai_from_day([0,1])[1] == 32 + 43200
+
+    assert isinstance(tai_from_day(0), numbers.Integral)
+    assert not isinstance(tai_from_day(0.), numbers.Integral)
+
+    # Check day_sec_from_tai
+    assert day_sec_from_tai(32.) == (0, 43200.)
+    assert day_sec_from_tai([35.,86435.])[0][0] == 0
+    assert day_sec_from_tai([35.,86435.])[0][1] == 1
+    assert day_sec_from_tai([35.,86435.])[1][0] == 43203.
+    assert day_sec_from_tai([35.,86435.])[1][1] == 43203.
+
+    assert isinstance(day_sec_from_tai([35,86435])[0][1], numbers.Integral)
+    assert isinstance(day_sec_from_tai([35,86435])[1][0], numbers.Integral)
+    assert not isinstance(day_sec_from_tai([35.,86435.])[1][0], numbers.Integral)
+
+    # utc_from_tai
+    assert day_sec_from_utc(utc_from_tai(32)) == (0, 43200.)
+    assert day_sec_from_utc(utc_from_tai([35,86435]))[0][0] == 0
+    assert day_sec_from_utc(utc_from_tai([35,86435]))[0][1] == 1
+    assert day_sec_from_utc(utc_from_tai([35,86435]))[1][0] == 43235-32
+    assert day_sec_from_utc(utc_from_tai([35,86435]))[1][1] == 43235-32
+
+    assert isinstance(utc_from_tai(32), numbers.Integral)
+    assert isinstance(utc_from_tai([35,86435])[0], numbers.Integral)
+    assert not isinstance(utc_from_tai(32.), numbers.Integral)
+    assert not isinstance(utc_from_tai([35.,86435.])[0], numbers.Integral)
+
+    # tai_from_utc
+    assert day_sec_from_tai(tai_from_utc(0)) == (0, 43200)
+    assert day_sec_from_tai(tai_from_utc([100,200]))[0][0] == 0
+    assert day_sec_from_tai(tai_from_utc([100,200]))[0][1] == 0
+    assert day_sec_from_tai(tai_from_utc([100,200]))[1][0] == 43300
+    assert day_sec_from_tai(tai_from_utc([100,200]))[1][1] == 43400
+
+    assert isinstance(tai_from_utc(43200), numbers.Integral)
+    assert isinstance(tai_from_utc([100,200])[0], numbers.Integral)
+    assert not isinstance(tai_from_utc(43200.), numbers.Integral)
+    assert not isinstance(tai_from_utc([100.,200.])[0], numbers.Integral)
+
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
+
+    # Test as a loop
+    for day in daylist:
+        (test_day, test_sec) = day_sec_from_tai(tai_from_day(day))
+        assert test_day == day, 'Day mismatch at ' + str(day)
+        assert test_sec == 0,   'Sec mismatch at ' + str(day)
+
+    # Test as an array operation
+    (test_day, test_sec) = day_sec_from_tai(tai_from_day(daylist))
+    assert np.all(test_day == daylist)
+    assert np.all(test_sec == 0)
+
+    ########################################
+    # TAI-TDB conversions
+    ########################################
+
+    # Check tdb_from_tai
+    assert tdb_from_tai(tai_from_day(0) + 43200) == pytest.approx(64.183927284731055, abs=1e-15)
+
+    # Check tai_from_tdb
+    assert tai_from_tdb(64.183927284731055) == pytest.approx(32., abs=1e-15)
+
+    # Test inversions around tdb = 0.
+    # A list of two million small numbers spanning 2 sec
+    secs = 2.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-11 * secs)
+    assert np.all(errors > -1.e-11 * secs)
+
+    # Now make sure we get the exact same results when we replace arrays by
+    # scalars
+    for i in range(0, tdbs.size, 1000):
+        assert errors[i] == tdb_from_tai(tai_from_tdb(tdbs[i])) - tdbs[i]
+
+    # A list of two million bigger numbers spanning ~ 20 days
+    secs = 20. * 86400.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-15 * secs)
+    assert np.all(errors > -1.e-15 * secs)
+
+    # A list of two million still bigger numbers spanning ~ 2000 years
+    secs = 2000. * 365. * 86400.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = tdb_from_tai(tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-15 * secs)
+    assert np.all(errors > -1.e-15 * secs)
+
+    ########################################
+    # TAI-TT conversions
+    ########################################
+
+    assert tt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
+    assert tdt_from_tai(10.) == pytest.approx(42.184, abs=1e-15)
+
+    assert tai_from_tt(10.) == pytest.approx(-22.184, abs=1e-14)
+    assert tai_from_tdt(10.) == pytest.approx(-22.184, abs=1e-14)
+
+    set_tai_origin('MIDNIGHT')
+
+    assert tt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
+    assert tdt_from_tai(10. + 43200) == pytest.approx(42.184, abs=1e-11)
+
+    assert tai_from_tt(32.184) == pytest.approx(43200, abs=1e-14)
+    assert tai_from_tdt(32.184) == pytest.approx(43200, abs=1e-14)
+
+    set_tai_origin('NOON')
+
+    ########################################
+    # Time System conversions
+    ########################################
+
+    offsets_1971_12_31 = {'LEAPS': 10, 'SPICE':9, 'CANON': 9.889649987220764,
+                          'PRE-1972': 9.889649987220764}
+
+    # For the batch test of every day 1971-2012. Conversions should be exact.
+    daylist = np.arange(day_from_ymd(1971,1,1), day_from_ymd(2012,1,1))
+
+    for model in ('SPICE', 'PRE-1972', 'CANON', 'LEAPS'):
+      set_ut_model(model)
+
+      for origin in ('MIDNIGHT', 'NOON'):
+        set_tai_origin(origin)
+
+        for value in [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]:
+            assert time_from_time(value, 'UTC', 'TAI') == tai_from_utc(value)
+            assert time_from_time(value, 'TDB', 'TAI') == tai_from_tdb(value)
+            assert time_from_time(value, 'TT' , 'TAI') == tai_from_tt( value)
+            assert time_from_time(value, 'TAI', 'UTC') == utc_from_tai(value)
+            assert time_from_time(value, 'TAI', 'TDB') == tdb_from_tai(value)
+            assert time_from_time(value, 'TAI', 'TT' ) == tt_from_tai( value)
+
+        t1 = [-10.e10, -5.e10, -1.e10, 0, 1.e10, 5.e10, 10.e10]
+        for tsys1 in ('UTC', 'TAI', 'TT', 'TDB'):
+          for tsys2 in ('UTC', 'TAI', 'TT', 'TDB'):
+            t2 = time_from_time(t1, tsys1, tsys2)
+            t3 = time_from_time(t2, tsys2, tsys1)
+            assert np.abs(t3-t1).max() < 1.e-11
+
+        assert time_from_day_sec(10, 43200, 'TAI') == \
+                         tai_from_day_sec(10, 43200)
+        assert time_from_day_sec(10, 43200, 'TDB') == \
+                         tdb_from_tai(tai_from_day_sec(10, 43200))
+        assert time_from_day_sec(10, 43200, 'TT') == \
+                         tt_from_tai(tai_from_day_sec(10, 43200))
+
+        assert day_sec_from_time(10000., 'TAI') == \
+                         day_sec_from_tai(10000.)
+        assert day_sec_from_time(10000., 'TDB') == \
+                         day_sec_from_tai(tai_from_tdb(10000.))
+        assert day_sec_from_time(10000., 'TT') == \
+                         day_sec_from_tai(tai_from_tt(10000.))
+
+        # "Dates" in other time systems
+        tai = time_from_day_sec(365, 32, timesys='TAI', leapsecs=False)
+        assert day_sec_from_time(tai, timesys='TAI') == (365, 0)
+
+        tt = time_from_day_sec(365, 64.184, timesys='TT', leapsecs=False)
+        assert day_sec_from_time(tt, timesys='TT')[0] == 365
+        assert day_sec_from_time(tt, timesys='TT')[1] == pytest.approx(0., abs=1e-14)
+
+        days = np.arange(365, 731)
+        tdb = time_from_day_sec(days, 43200., timesys='TDB', leapsecs=False)
+        tt  = time_from_day_sec(days, 43200., timesys='TT',  leapsecs=False)
+
+        sec1 = day_sec_from_time(tdb, timesys='TDB')[1]
+        sec2 = day_sec_from_time(tt,  timesys='TT')[1]
+        diffs = sec1 - sec2
+        assert np.abs(diffs).max() < 0.0017
+        assert np.abs(diffs.mean()) < 2.e-7
+
+        # TAI tests...
+
+        # TAI offset was 31-32 seconds ahead of UTC in 1999,2000,2001
+        (day, sec) = day_sec_as_type_from_utc((-366,0,366), 0., time_type='TAI')
+        assert np.all(day == (-366,0,366))
+        assert np.all(sec == (31.,32.,32.))
+
+        tai = time_from_day_sec((-366, 0, 366), 0., 'TAI')
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        assert np.all(day == (-366,0,366))
+        assert np.all(sec == (31.,32.,32.))
+
+        # Inverse of the above
+        (day, sec) = utc_from_day_sec_as_type((-366,0,366), 32., time_type='TAI')
+        assert np.all(day == (-366,0,366))
+        assert np.all(sec == (1.,0.,0.))
+
+        tai = time_from_day_sec((-366, 0, 366), 32., 'TAI', leapsecs=False)
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+        assert np.all(day == (-366,0,366))
+        assert np.all(sec == (1.,0.,0.))
+
+        # TAI offset depended on model before 1972
+        (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1972,1,1), 0, time_type='TAI')
+        assert sec == 10
+
+        tai = time_from_day_sec(day_from_ymd(1972,1,1), 0., 'TAI')
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        assert sec == 10
+
+        (day, sec) = day_sec_as_type_from_utc(day_from_ymd(1971,12,31), 0, time_type='TAI')
+        assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
+
+        tai = time_from_day_sec(day_from_ymd(1971,12,31), 0., 'TAI')
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        assert sec == pytest.approx(offsets_1971_12_31[model], abs=1e-14)
+
+        # Inverses of the above
+        (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1972,1,1), 10, time_type='TAI')
+        assert sec == 0
+
+        tai = time_from_day_sec(day_from_ymd(1972,1,1), 10, 'TAI', leapsecs=False)
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+        assert sec == 0
+
+        (day, sec) = utc_from_day_sec_as_type(day_from_ymd(1971,12,31),
+                                              offsets_1971_12_31[model]+1, time_type='TAI')
+        assert sec == pytest.approx(1, abs=1e-14)
+
+        tai = time_from_day_sec(day_from_ymd(1971,12,31), offsets_1971_12_31[model],
+                                'TAI', leapsecs=False)
+        (day, sec) = day_sec_from_time(tai+1, 'TAI', leapsecs=True)
+        assert sec == pytest.approx(1, abs=1e-14)
+
+        # Batch test 1971-2012. Conversions should be exact.
+        (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TAI')
+        (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 43200.)
+
+        tai = time_from_day_sec(daylist, 43200., 'TAI')
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
+        (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 43200.)
+
+        (day, sec) = day_sec_as_type_from_utc(daylist, 0., time_type='TAI')
+        (dtest,stest) = utc_from_day_sec_as_type(day, sec, time_type='TAI')
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 0.)
+
+        tai = time_from_day_sec(daylist, 0., 'TAI')
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        tai2 = time_from_day_sec(day, sec, 'TAI', leapsecs=False)
+        (dtest, stest) = day_sec_from_time(tai2, 'TAI', leapsecs=True)
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 0.)
+
+        (day, sec) = utc_from_day_sec_as_type(daylist, 0., time_type='TAI')
+        (dtest,stest) = day_sec_as_type_from_utc(day, sec, time_type='TAI')
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 0.)
+
+        tai = time_from_day_sec(daylist, 0., 'TAI', leapsecs=False)
+        (day, sec) = day_sec_from_time(tai, 'TAI', leapsecs=True)
+        tai = time_from_day_sec(day, sec, 'TAI', leapsecs=True)
+        (dtest, stest) = day_sec_from_time(tai, 'TAI', leapsecs=False)
+        assert np.all(dtest == daylist)
+        assert np.all(stest == 0.)
+
+        # TDB tests...
+
+        assert abs(day_sec_as_type_from_utc(0, 0, time_type='TDB')[1]
+                        - 64.183927284731055) < 1.e15
+        assert abs(utc_from_day_sec_as_type(0, 0, time_type='TDB')[1]
+                        + 64.183927284731055) < 1.e15
+
+        tdb = time_from_day_sec(0, 0., 'TDB')
+        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
+        assert sec == pytest.approx(64.18391281194636, abs=1e-14)
+
+        (day, sec) = day_sec_as_type_from_utc(daylist, 43200., time_type='TDB')
+        (dtest, stest) = utc_from_day_sec_as_type(day, sec, time_type='TDB')
+        assert np.all(dtest == daylist)
+        assert np.abs(stest - 43200.).max() < 1.e-7
+
+        (day, sec) = utc_from_day_sec_as_type(daylist, 43200., time_type='TDB')
+        (dtest, stest) = day_sec_as_type_from_utc(day, sec, time_type='TDB')
+        assert np.all(dtest == daylist)
+        assert np.abs(stest - 43200.).max() < 2.e-7
+
+        tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=True)
+        tdb2 = tdb_from_tai(tai_from_day_sec(daylist, 43200.))
+        assert np.all(tdb == tdb2)
+
+        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=False)
+        tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=False)
+        assert np.abs(tdb - tdb2).max() < 1.e-7
+
+        (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=True)
+        assert np.all(dtest == daylist)
+        assert np.abs(stest - 43200.).max() < 1.e-7
+
+        tdb = time_from_day_sec(daylist, 43200., 'TDB', leapsecs=False)
+        (day, sec) = day_sec_from_time(tdb, 'TDB', leapsecs=True)
+        tdb2 = time_from_day_sec(day, sec, 'TDB', leapsecs=True)
+        (dtest, stest) = day_sec_from_time(tdb2, 'TDB', leapsecs=False)
+        assert np.all(dtest == daylist)
+        assert np.abs(stest - 43200.).max() < 2.e-7
 
 ##########################################################################################

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_utils_int():
     assert isinstance(_int(3.14), int)
 
     assert _int(-3.14) == -4
-    assert isinstance(_int(3.14), int)
+    assert isinstance(_int(-3.14), int)
 
     test = _int([3.14, -3.14])
     assert isinstance(test, np.ndarray)
@@ -86,7 +86,7 @@ def test_utils_number():
     assert isinstance(_number(3.14), float)
 
     assert _number(-3.14) == -3.14
-    assert isinstance(_number(3.14), float)
+    assert isinstance(_number(-3.14), float)
 
     test = _number([3.14, -3.14])
     assert isinstance(test, np.ndarray)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@
 ##########################################################################################
 
 import numpy as np
-import unittest
 
 from julian._utils import (
     _float,
@@ -14,142 +13,140 @@ from julian._utils import (
 )
 
 
-class Test_utils(unittest.TestCase):
+def test_utils_int():
 
-    def test_utils_int(self):
+    assert _int(3.14) == 3
+    assert isinstance(_int(3.14), int)
 
-        self.assertEqual(_int(3.14), 3)
-        self.assertIsInstance(_int(3.14), int)
+    assert _int(-3.14) == -4
+    assert isinstance(_int(3.14), int)
 
-        self.assertEqual(_int(-3.14), -4)
-        self.assertIsInstance(_int(3.14), int)
+    test = _int([3.14, -3.14])
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('int64')
+    assert list(test) == [3, -4]
 
-        test = _int([3.14, -3.14])
-        self.assertTrue(isinstance(test, np.ndarray))
-        self.assertEqual(test.dtype, np.dtype('int64'))
-        self.assertEqual(list(test), [3, -4])
+    test = _int(np.array([3.14, -3.14]))
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('int64')
+    assert list(test) == [3, -4]
 
-        test = _int(np.array([3.14, -3.14]))
-        self.assertTrue(isinstance(test, np.ndarray))
-        self.assertEqual(test.dtype, np.dtype('int64'))
-        self.assertEqual(list(test), [3, -4])
+    test = _int(np.array(7))
+    assert not isinstance(test, np.ndarray)
+    assert isinstance(test, int)
 
-        test = _int(np.array(7))
-        self.assertNotIsInstance(test, np.ndarray)
-        self.assertIsInstance(test, int)
+    test = _int(np.array(7.))
+    assert not isinstance(test, np.ndarray)
+    assert isinstance(test, int)
 
-        test = _int(np.array(7.))
-        self.assertNotIsInstance(test, np.ndarray)
-        self.assertIsInstance(test, int)
+    for dtype in ('int8', 'uint8', 'int16', 'uint16', 'uint64', 'float32', 'float64'):
+        digits = np.arange(10, dtype=dtype)
+        test = _int(digits)
+        assert isinstance(test, np.ndarray)
+        assert test.dtype == np.dtype('int64')
 
-        for dtype in ('int8', 'uint8', 'int16', 'uint16', 'uint64', 'float32', 'float64'):
-            digits = np.arange(10, dtype=dtype)
-            test = _int(digits)
-            self.assertIsInstance(test, np.ndarray)
-            self.assertEqual(test.dtype, np.dtype('int64'))
+        test = _int(digits[0])
+        assert isinstance(test, int)
 
-            test = _int(digits[0])
-            self.assertIsInstance(test, int)
+def test_utils_float():
 
-    def test_utils_float(self):
+    assert _float(3) == 3.
+    assert isinstance(_float(3), float)
 
-        self.assertEqual(_float(3), 3.)
-        self.assertIsInstance(_float(3), float)
+    test = _float([3, -4])
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('float64')
+    assert list(test) == [3., -4.]
 
-        test = _float([3, -4])
-        self.assertTrue(isinstance(test, np.ndarray))
-        self.assertEqual(test.dtype, np.dtype('float64'))
-        self.assertEqual(list(test), [3., -4.])
+    test = _float(np.array([3, -4]))
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('float64')
+    assert list(test) == [3., -4.]
 
-        test = _float(np.array([3, -4]))
-        self.assertTrue(isinstance(test, np.ndarray))
-        self.assertEqual(test.dtype, np.dtype('float64'))
-        self.assertEqual(list(test), [3., -4.])
+    test = _float(np.array(7))
+    assert not isinstance(test, np.ndarray)
+    assert isinstance(test, float)
 
-        test = _float(np.array(7))
-        self.assertNotIsInstance(test, np.ndarray)
-        self.assertIsInstance(test, float)
+    test = _float(np.array(7.))
+    assert not isinstance(test, np.ndarray)
+    assert isinstance(test, float)
 
-        test = _float(np.array(7.))
-        self.assertNotIsInstance(test, np.ndarray)
-        self.assertIsInstance(test, float)
+    for dtype in ('int8', 'uint8', 'uint16', 'int32', 'uint64', 'float32', 'float64'):
+        digits = np.arange(10, dtype=dtype)
+        test = _float(digits)
+        assert isinstance(test, np.ndarray)
+        assert test.dtype == np.dtype('float64')
 
-        for dtype in ('int8', 'uint8', 'uint16', 'int32', 'uint64', 'float32', 'float64'):
-            digits = np.arange(10, dtype=dtype)
-            test = _float(digits)
-            self.assertIsInstance(test, np.ndarray)
-            self.assertEqual(test.dtype, np.dtype('float64'))
+        test = _float(digits[0])
+        assert isinstance(test, float)
 
-            test = _float(digits[0])
-            self.assertIsInstance(test, float)
+def test_utils_number():
 
-    def test_utils_number(self):
+    assert _number(3.14) == 3.14
+    assert isinstance(_number(3.14), float)
 
-        self.assertEqual(_number(3.14), 3.14)
-        self.assertIsInstance(_number(3.14), float)
+    assert _number(-3.14) == -3.14
+    assert isinstance(_number(3.14), float)
 
-        self.assertEqual(_number(-3.14), -3.14)
-        self.assertIsInstance(_number(3.14), float)
+    test = _number([3.14, -3.14])
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('float64')
+    assert list(test) == [3.14, -3.14]
 
-        test = _number([3.14, -3.14])
-        self.assertIsInstance(test, np.ndarray)
-        self.assertEqual(test.dtype, np.dtype('float64'))
-        self.assertEqual(list(test), [3.14, -3.14])
+    test = _number(np.array([3.14, -3.14]))
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('float64')
+    assert list(test) == [3.14, -3.14]
 
-        test = _number(np.array([3.14, -3.14]))
-        self.assertIsInstance(test, np.ndarray)
-        self.assertEqual(test.dtype, np.dtype('float64'))
-        self.assertEqual(list(test), [3.14, -3.14])
+    assert _number(3) == 3
+    assert isinstance(_number(3), int)
 
-        self.assertEqual(_number(3), 3)
-        self.assertIsInstance(_number(3), int)
+    test = _number([3, -4])
+    assert isinstance(test, np.ndarray)
+    assert test.dtype == np.dtype('int64')
+    assert list(test) == [3, -4]
 
-        test = _number([3, -4])
-        self.assertIsInstance(test, np.ndarray)
-        self.assertEqual(test.dtype, np.dtype('int64'))
-        self.assertEqual(list(test), [3, -4])
+    test = _number(np.array(7))
+    assert isinstance(test, int)
 
-        test = _number(np.array(7))
-        self.assertIsInstance(test, int)
+    test = _number(np.array(7.))
+    assert isinstance(test, float)
 
-        test = _number(np.array(7.))
-        self.assertIsInstance(test, float)
+    for dtype in ('int8', 'uint8', 'uint16', 'int32', 'uint64', 'float32', 'float64'):
+        digits = np.arange(10, dtype=dtype)
+        test = _number(digits)
+        assert isinstance(test, np.ndarray)
+        if dtype[0] == 'f':
+            assert test.dtype == np.dtype(dtype)
+        else:
+            assert test.dtype == np.dtype('int64')
 
-        for dtype in ('int8', 'uint8', 'uint16', 'int32', 'uint64', 'float32', 'float64'):
-            digits = np.arange(10, dtype=dtype)
-            test = _number(digits)
-            self.assertIsInstance(test, np.ndarray)
-            if dtype[0] == 'f':
-                self.assertEqual(test.dtype, np.dtype(dtype))
-            else:
-                self.assertEqual(test.dtype, np.dtype('int64'))
+        test = _number(digits[0])
+        if dtype[0] == 'f':
+            assert isinstance(test, float)
+        else:
+            assert isinstance(test, int)
 
-            test = _number(digits[0])
-            if dtype[0] == 'f':
-                self.assertIsInstance(test, float)
-            else:
-                self.assertIsInstance(test, int)
+def test_utils_is_int():
 
-    def test_utils_is_int(self):
+    assert _is_int(3)
+    assert not _is_int(3.)
 
-        self.assertTrue(_is_int(3))
-        self.assertFalse(_is_int(3.))
+    assert _is_int([3,4])
+    assert not _is_int([3,4.])
 
-        self.assertTrue(_is_int([3,4]))
-        self.assertFalse(_is_int([3,4.]))
+    assert _is_int(np.array([3,4]))
+    assert not _is_int(np.array([3,4.]))
 
-        self.assertTrue(_is_int(np.array([3,4])))
-        self.assertFalse(_is_int(np.array([3,4.])))
+def test_utils_is_float():
 
-    def test_utils_is_float(self):
+    assert _is_float(3.)
+    assert not _is_float(3)
 
-        self.assertTrue(_is_float(3.))
-        self.assertFalse(_is_float(3))
+    assert _is_float([3.,4])
+    assert not _is_float([3,4])
 
-        self.assertTrue(_is_float([3.,4]))
-        self.assertFalse(_is_float([3,4]))
-
-        self.assertTrue(_is_float(np.array([3.,4])))
-        self.assertFalse(_is_float(np.array([3,4])))
+    assert _is_float(np.array([3.,4]))
+    assert not _is_float(np.array([3,4]))
 
 ##########################################################################################

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -4,7 +4,7 @@
 
 import julian as j
 import numpy as np
-import unittest
+import pytest
 import warnings
 
 from julian._exceptions import JulianValidateFailure as JVF
@@ -15,810 +15,815 @@ import julian._warnings as _warnings
 # Calendar conversions
 ########################################
 
-class Test_Calendar_v1(unittest.TestCase):
+def test_calendar_v1():
 
-    def runTest(self):
+    warnings.filterwarnings('ignore', category=JDW)
 
-        warnings.filterwarnings('ignore', category=JDW)
+    # day_from_ymd()
+    assert j.day_from_ymd(2000,1,1) == 0
+    assert j.day_from_ymd(2000,2,[27,28,29]).tolist() == [57,58,59]
+    assert j.day_from_ymd(2000,[1,2,3],1).tolist() == [ 0,31,60]
+    assert j.day_from_ymd([2000,2001,2002],1,1).tolist() == [0,366,731]
 
-        # day_from_ymd()
-        self.assertEqual(j.day_from_ymd(2000,1,1), 0)
-        self.assertEqual(j.day_from_ymd(2000,2,[27,28,29]).tolist(),    [57,58,59])
-        self.assertEqual(j.day_from_ymd(2000,[1,2,3],1).tolist(),       [ 0,31,60])
-        self.assertEqual(j.day_from_ymd([2000,2001,2002],1,1).tolist(), [0,366,731])
+    # ymd_from_day()
+    assert j.ymd_from_day(0) == (2000,1,1)
+    assert j.ymd_from_day(60) == (2000,3,1)
+    assert j.ymd_from_day(365) == (2000,12,31)
+    assert j.ymd_from_day(366) == (2001,1,1)
 
-        # ymd_from_day()
-        self.assertEqual(j.ymd_from_day(0),   (2000,1,1))
-        self.assertEqual(j.ymd_from_day(60),  (2000,3,1))
-        self.assertEqual(j.ymd_from_day(365), (2000,12,31))
-        self.assertEqual(j.ymd_from_day(366), (2001,1,1))
+    # yd_from_day()
+    assert j.yd_from_day(0) == (2000,1)
+    assert j.yd_from_day(365) == (2000,366)
 
-        # yd_from_day()
-        self.assertEqual(j.yd_from_day(0), (2000,1))
-        self.assertEqual(j.yd_from_day(365), (2000,366))
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
 
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
+    # Convert to ymd and back
+    (ylist, mlist, dlist) = j.ymd_from_day(daylist)
+    test_daylist = j.day_from_ymd(ylist, mlist, dlist)
 
-        # Convert to ymd and back
-        (ylist, mlist, dlist) = j.ymd_from_day(daylist)
-        test_daylist = j.day_from_ymd(ylist, mlist, dlist)
+    assert np.all(test_daylist == daylist), \
+        "Large-scale conversion from day to YMD and back failed"
 
-        self.assertTrue(np.all(test_daylist == daylist),
-            "Large-scale conversion from day to YMD and back failed")
+    # Make sure every month is in range
+    assert np.all(mlist >= 1), "Month-of-year < 1 found"
+    assert np.all(mlist <= 12), "Month-of-year > 12 found"
 
-        # Make sure every month is in range
-        self.assertTrue(np.all(mlist >= 1), "Month-of-year < 1 found")
-        self.assertTrue(np.all(mlist <= 12), "Month-of-year > 12 found")
+    # Make sure every day is in range
+    assert np.all(dlist >= 1), "Day < 1 found"
+    assert np.all(dlist <= 31), "Day > 31 found"
 
-        # Make sure every day is in range
-        self.assertTrue(np.all(dlist >= 1), "Day < 1 found")
-        self.assertTrue(np.all(dlist <= 31), "Day > 31 found")
+    # Another large number of dates, spanning > 200 years
+    daylist = np.arange(-40001,40000,79)
 
-        # Another large number of dates, spanning > 200 years
-        daylist = np.arange(-40001,40000,79)
+    # Convert to yd and back
+    (ylist, dlist) = j.yd_from_day(daylist)
+    test_daylist = j.day_from_yd(ylist, dlist)
 
-        # Convert to yd and back
-        (ylist, dlist) = j.yd_from_day(daylist)
-        test_daylist = j.day_from_yd(ylist, dlist)
+    assert np.all(test_daylist == daylist)
 
-        self.assertTrue(np.all(test_daylist == daylist))
+    # Make sure every day is in range
+    assert np.all(dlist >= 1), "Day < 1 found"
+    assert np.all(dlist <= 366), "Day > 366 found"
 
-        # Make sure every day is in range
-        self.assertTrue(np.all(dlist >= 1), "Day < 1 found")
-        self.assertTrue(np.all(dlist <= 366), "Day > 366 found")
+    # A large number of months, spanning > 200 years
+    monthlist = np.arange(-15002,15000,19)
 
-        # A large number of months, spanning > 200 years
-        monthlist = np.arange(-15002,15000,19)
+    # Convert to ym and back
+    (ylist, mlist) = j.ym_from_month(monthlist)
+    test_monthlist = j.month_from_ym(ylist, mlist)
 
-        # Convert to ym and back
-        (ylist, mlist) = j.ym_from_month(monthlist)
-        test_monthlist = j.month_from_ym(ylist, mlist)
+    assert np.all(test_monthlist == monthlist)
 
-        self.assertTrue(np.all(test_monthlist == monthlist))
+    # Make sure every month is in range
+    assert np.all(mlist >= 1), "Month-of-year < 1 found"
+    assert np.all(mlist <= 12), "Month-of-year > 12 found"
 
-        # Make sure every month is in range
-        self.assertTrue(np.all(mlist >= 1), "Month-of-year < 1 found")
-        self.assertTrue(np.all(mlist <= 12), "Month-of-year > 12 found")
+    # Check the days in each January
+    mlist = np.arange(j.month_from_ym(1980,1), j.month_from_ym(2220,1),12)
+    assert np.all(j.days_in_month(mlist) == 31), \
+        "Not every January has 31 days"
 
-        # Check the days in each January
-        mlist = np.arange(j.month_from_ym(1980,1), j.month_from_ym(2220,1),12)
-        self.assertTrue(np.all(j.days_in_month(mlist) == 31),
-            "Not every January has 31 days")
+    # Check the days in each April
+    mlist = np.arange(j.month_from_ym(1980,4), j.month_from_ym(2220,4),12)
+    assert np.all(j.days_in_month(mlist) == 30), \
+        "Not every April has 30 days"
 
-        # Check the days in each April
-        mlist = np.arange(j.month_from_ym(1980,4), j.month_from_ym(2220,4),12)
-        self.assertTrue(np.all(j.days_in_month(mlist) == 30),
-            "Not every April has 30 days")
+    # Check the days in each year
+    ylist = np.arange(1890, 2210)
+    dlist = j.days_in_year(ylist)
+    assert np.all((dlist == 365) | (dlist == 366)), \
+        "Not every year has 365 or 366 days"
 
-        # Check the days in each year
-        ylist = np.arange(1890, 2210)
-        dlist = j.days_in_year(ylist)
-        self.assertTrue(np.all((dlist == 365) | (dlist == 366)),
-            "Not every year has 365 or 366 days")
+    # Every leap year is a multiple of four
+    select = np.where(dlist == 366)
+    assert np.all(ylist[select]%4 == 0), \
+        "Not every leapyear is a multiple of four"
 
-        # Every leap year is a multiple of four
-        select = np.where(dlist == 366)
-        self.assertTrue(np.all(ylist[select]%4 == 0),
-            "Not every leapyear is a multiple of four")
+    # February always has 29 days in a leapyear
+    assert np.all(j.days_in_month(j.month_from_ym(ylist[select],2))
+        == 29), "Not every leap year February has 29 days"
 
-        # February always has 29 days in a leapyear
-        self.assertTrue(np.all(j.days_in_month(j.month_from_ym(ylist[select],2))
-            == 29), "Not every leap year February has 29 days")
+    # February always has 28 days otherwise
+    select = np.where(dlist == 365)
+    assert np.all(j.days_in_month(j.month_from_ym(ylist[select],2))
+        == 28), "Not every non-leap year February has 28 days"
 
-        # February always has 28 days otherwise
-        select = np.where(dlist == 365)
-        self.assertTrue(np.all(j.days_in_month(j.month_from_ym(ylist[select],2))
-            == 28), "Not every non-leap year February has 28 days")
+    # Julian vs. Gregorian calendars around 1 CE
+    for use_julian in (False, True):
+      start_day = j.day_from_ymd(-10, 1, 1, proleptic=(not use_julian))
+      stop_day  = j.day_from_ymd( 11, 1, 1, proleptic=(not use_julian))
+      for day in range(start_day, stop_day+1):
+        (y, m, d) = j.ymd_from_day(day, proleptic=(not use_julian))
+        day2 = j.day_from_ymd(y, m, d, proleptic=(not use_julian))
+        assert day == day2
 
-        # Julian vs. Gregorian calendars around 1 CE
-        for use_julian in (False, True):
-          start_day = j.day_from_ymd(-10, 1, 1, proleptic=(not use_julian))
-          stop_day  = j.day_from_ymd( 11, 1, 1, proleptic=(not use_julian))
-          for day in range(start_day, stop_day+1):
-            (y, m, d) = j.ymd_from_day(day, proleptic=(not use_julian))
-            day2 = j.day_from_ymd(y, m, d, proleptic=(not use_julian))
-            self.assertEqual(day, day2)
+    # Julian vs. Gregorian calendars around 1582
+    for use_julian in (False, True):
+      start_day = j.day_from_ymd(1572, 1, 1, proleptic=(not use_julian))
+      stop_day  = j.day_from_ymd(1593, 1, 1, proleptic=(not use_julian))
+      for day in range(start_day, stop_day+1):
+        (y, m, d) = j.ymd_from_day(day, proleptic=(not use_julian))
+        day2 = j.day_from_ymd(y, m, d, proleptic=(not use_julian))
+        assert day == day2
 
-        # Julian vs. Gregorian calendars around 1582
-        for use_julian in (False, True):
-          start_day = j.day_from_ymd(1572, 1, 1, proleptic=(not use_julian))
-          stop_day  = j.day_from_ymd(1593, 1, 1, proleptic=(not use_julian))
-          for day in range(start_day, stop_day+1):
-            (y, m, d) = j.ymd_from_day(day, proleptic=(not use_julian))
-            day2 = j.day_from_ymd(y, m, d, proleptic=(not use_julian))
-            self.assertEqual(day, day2)
+    # Reality checks, set_gregorian_start
+    assert j.day_from_ymd(-4712, 1, 1, proleptic=False) == -2451545
+    assert j.day_from_ymd(-4713,11,24, proleptic=True) == -2451545
+    assert j.days_in_year(1582, proleptic=False) == 355
+    assert j.days_in_year(1582, proleptic=True) == 365
 
-        # Reality checks, set_gregorian_start
-        self.assertEqual(j.day_from_ymd(-4712, 1, 1, proleptic=False), -2451545)
-        self.assertEqual(j.day_from_ymd(-4713,11,24, proleptic=True),  -2451545)
-        self.assertEqual(j.days_in_year(1582, proleptic=False), 355)
-        self.assertEqual(j.days_in_year(1582, proleptic=True),  365)
+    j.set_gregorian_start(None)
+    assert j.day_from_ymd(-4713,11,24, proleptic=True) == -2451545
+    assert j.day_from_ymd(-4713,11,24, proleptic=False) == -2451545
 
-        j.set_gregorian_start(None)
-        self.assertEqual(j.day_from_ymd(-4713,11,24, proleptic=True),  -2451545)
-        self.assertEqual(j.day_from_ymd(-4713,11,24, proleptic=False), -2451545)
+    j.set_gregorian_start(1752, 9, 14)
+    assert j.days_in_year(1582, proleptic=False) == 365
+    assert j.days_in_year(1582, proleptic=True) == 365
+    assert j.days_in_year(1752, proleptic=False) == 355
+    assert j.days_in_year(1752, proleptic=True) == 366
 
-        j.set_gregorian_start(1752, 9, 14)
-        self.assertEqual(j.days_in_year(1582, proleptic=False), 365)
-        self.assertEqual(j.days_in_year(1582, proleptic=True),  365)
-        self.assertEqual(j.days_in_year(1752, proleptic=False), 355)
-        self.assertEqual(j.days_in_year(1752, proleptic=True),  366)
+    j.set_gregorian_start()
 
-        j.set_gregorian_start()
-
-        warnings.resetwarnings()
-        _warnings._reset_warnings()
+    warnings.resetwarnings()
+    _warnings._reset_warnings()
 
 ########################################
 # Leapsecond routines
 ########################################
 
-class Test_Leapseconds_v1(unittest.TestCase):
+def test_leapseconds_v1():
 
-    def runTest(self):
+    # A large number of dates, spanning > 200 years
+    daylist = range(-40001,40000,83)
 
-        # A large number of dates, spanning > 200 years
-        daylist = range(-40001,40000,83)
+    # Check all seconds are within the range
+    assert np.all(j.seconds_on_day(daylist) >= 86400)
+    assert np.all(j.seconds_on_day(daylist) <= 86401)
 
-        # Check all seconds are within the range
-        self.assertTrue(np.all(j.seconds_on_day(daylist) >= 86400))
-        self.assertTrue(np.all(j.seconds_on_day(daylist) <= 86401))
+    assert j.seconds_on_day(j.day_from_ymd(1998,12,31)) == 86401
 
-        self.assertEqual(j.seconds_on_day(j.day_from_ymd(1998,12,31)), 86401)
+    # Check case where leap seconds are ignored
+    assert np.all(j.seconds_on_day(daylist,False) == 86400)
 
-        # Check case where leap seconds are ignored
-        self.assertTrue(np.all(j.seconds_on_day(daylist,False) == 86400))
-
-        self.assertEqual(j.seconds_on_day(j.day_from_ymd(1998,12,31), False), 86400)
+    assert j.seconds_on_day(j.day_from_ymd(1998,12,31), False) == 86400
 
 ########################################
 # TAI - UTC conversions
 ########################################
 
-class Test_TAI_UTC_v1(unittest.TestCase):
+def test_tai_utc_v1():
 
-    def runTest(self):
+    j.set_tai_origin('MIDNIGHT')
 
-        j.set_tai_origin('MIDNIGHT')
+    # Check tai_from_day
+    assert j.tai_from_day(0) == 32
+    assert j.tai_from_day([0,1])[0] == 32
+    assert j.tai_from_day([0,1])[1] == 86432
 
-        # Check tai_from_day
-        self.assertEqual(j.tai_from_day(0), 32)
-        self.assertEqual(j.tai_from_day([0,1])[0],    32)
-        self.assertEqual(j.tai_from_day([0,1])[1], 86432)
+    # Check day_sec_from_tai
+    assert j.day_sec_from_tai(32.) == (0, 0.)
+    assert j.day_sec_from_tai([35.,86435.])[0][0] == 0
+    assert j.day_sec_from_tai([35.,86435.])[0][1] == 1
+    assert j.day_sec_from_tai([35.,86435.])[1][0] == 3.
+    assert j.day_sec_from_tai([35.,86435.])[1][1] == 3.
 
-        # Check day_sec_from_tai
-        self.assertEqual(j.day_sec_from_tai(32.), (0, 0.))
-        self.assertEqual(j.day_sec_from_tai([35.,86435.])[0][0], 0)
-        self.assertEqual(j.day_sec_from_tai([35.,86435.])[0][1], 1)
-        self.assertEqual(j.day_sec_from_tai([35.,86435.])[1][0], 3.)
-        self.assertEqual(j.day_sec_from_tai([35.,86435.])[1][1], 3.)
+    # A large number of dates, spanning > 200 years
+    daylist = np.arange(-40000,40000,83)
 
-        # A large number of dates, spanning > 200 years
-        daylist = np.arange(-40000,40000,83)
+    # Test as a loop
+    for day in daylist:
+        (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(day))
+        assert test_day == day, "Day mismatch at " + str(day)
+        assert test_sec == 0,   "Sec mismatch at " + str(day)
 
-        # Test as a loop
-        for day in daylist:
-            (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(day))
-            self.assertEqual(test_day, day, "Day mismatch at " + str(day))
-            self.assertEqual(test_sec, 0,   "Sec mismatch at " + str(day))
+    # Test as an array operation
+    (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(daylist))
+    assert np.all(test_day == daylist)
+    assert np.all(test_sec == 0)
 
-        # Test as an array operation
-        (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(daylist))
-        self.assertTrue(np.all(test_day == daylist))
-        self.assertTrue(np.all(test_sec == 0))
-
-        j.set_tai_origin('NOON')
+    j.set_tai_origin('NOON')
 
 ########################################
 # Time-of-day conversions
 ########################################
 
-class Test_Time_of_Day_v1(unittest.TestCase):
+def test_time_of_day_v1():
 
-    def runTest(self):
+    # Check hms_from_sec
+    assert j.hms_from_sec(0) == (0, 0, 0), \
+                     "0 is not (0, 0, 0)."
+    assert j.hms_from_sec(86400) == (23, 59, 60), \
+                     "86400 is not (23, 59, 60)."
+    assert j.hms_from_sec(86409) == (23, 59, 69), \
+                     "86469 is not (23, 59, 69)."
+    with pytest.raises(ValueError):
+        j.hms_from_sec(86410, validate=True)
+    with pytest.raises(ValueError):
+        j.hms_from_sec(-1.e-300, validate=True)
 
-        # Check hms_from_sec
-        self.assertEqual(j.hms_from_sec(0), (0, 0, 0),
-                         "0 is not (0, 0, 0).")
-        self.assertEqual(j.hms_from_sec(86400), (23, 59, 60),
-                         "86400 is not (23, 59, 60).")
-        self.assertEqual(j.hms_from_sec(86409), (23, 59, 69),
-                         "86469 is not (23, 59, 69).")
-        self.assertRaises(ValueError, j.hms_from_sec, 86410, validate=True)
-        self.assertRaises(ValueError, j.hms_from_sec, -1.e-300, validate=True)
+    # Check sec_from_hms
+    assert j.sec_from_hms(0, 0, 0) == 0, \
+                     "(0, 0, 0) is not 0 seconds."
+    assert j.sec_from_hms(23, 59, 60) == 86400, \
+                     "(23, 59, 60) is not 86400 seconds."
 
-        # Check sec_from_hms
-        self.assertEqual(j.sec_from_hms(0, 0, 0), 0,
-                         "(0, 0, 0) is not 0 seconds.")
-        self.assertEqual(j.sec_from_hms(23, 59, 60), 86400,
-                         "(23, 59, 60) is not 86400 seconds.")
+    # Array tests
+    # This makes about 333,000 non-uniformly spaced transcendental numbers
+    secs = 86410. * np.sqrt(np.arange(0., 1., 3.e-6))
 
-        # Array tests
-        # This makes about 333,000 non-uniformly spaced transcendental numbers
-        secs = 86410. * np.sqrt(np.arange(0., 1., 3.e-6))
+    # Because HMS times carry extra precision, inversions should be exact
+    (h,m,s) = j.hms_from_sec(secs)
+    errors = (j.sec_from_hms(h,m,s) - secs)
+    assert np.all(errors == 0.)
 
-        # Because HMS times carry extra precision, inversions should be exact
-        (h,m,s) = j.hms_from_sec(secs)
-        errors = (j.sec_from_hms(h,m,s) - secs)
-        self.assertTrue(np.all(errors == 0.))
+    # Test all seconds
+    seclist = np.arange(0,86410)
 
-        # Test all seconds
-        seclist = np.arange(0,86410)
+    # Convert to hms and back
+    (h, m, t) = j.hms_from_sec(seclist)
+    test_seclist = j.sec_from_hms(h, m, t)
 
-        # Convert to hms and back
-        (h, m, t) = j.hms_from_sec(seclist)
-        test_seclist = j.sec_from_hms(h, m, t)
-
-        self.assertTrue(np.all(test_seclist == seclist),
-            'Large-scale conversion from sec to hms and back failed')
+    assert np.all(test_seclist == seclist), \
+        'Large-scale conversion from sec to hms and back failed'
 
 ########################################
 # TDB - TAI conversions
 ########################################
 
-class Test_TDB_TAI_v1(unittest.TestCase):
+def test_tdb_tai_v1():
 
-    def runTest(self):
+    j.set_tai_origin('MIDNIGHT')
 
-        j.set_tai_origin('MIDNIGHT')
+    # Check tdb_from_tai
+    assert j.tdb_from_tai(j.tai_from_day(0)) == pytest.approx(64.18391281194636-43200, abs=1e-15)
 
-        # Check tdb_from_tai
-        self.assertAlmostEqual(j.tdb_from_tai(j.tai_from_day(0)),
-                               64.18391281194636-43200, places=15)
+    # Check tai_from_tdb
+    assert abs(j.tai_from_tdb(64.18391281194636)
+                                     - j.tai_from_day(0)) < 1.e15
 
-        # Check tai_from_tdb
-        self.assertTrue(abs(j.tai_from_tdb(64.18391281194636)
-                                         - j.tai_from_day(0)) < 1.e15)
+    j.set_tai_origin('NOON')
 
-        j.set_tai_origin('NOON')
+    # Test inversions around tdb = 0.
+    # A list of two million small numbers spanning 2 sec
+    secs = 2.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-11 * secs)
+    assert np.all(errors > -1.e-11 * secs)
 
-        # Test inversions around tdb = 0.
-        # A list of two million small numbers spanning 2 sec
-        secs = 2.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-11 * secs))
-        self.assertTrue(np.all(errors > -1.e-11 * secs))
+    # Now make sure we get the exact same results when we replace arrays by
+    # scalars
+    for i in range(0, tdbs.size, 1000):
+        assert errors[i] == j.tdb_from_tai(j.tai_from_tdb(tdbs[i])) - tdbs[i]
 
-        # Now make sure we get the exact same results when we replace arrays by
-        # scalars
-        for i in range(0, tdbs.size, 1000):
-            self.assertEqual(errors[i],
-                             j.tdb_from_tai(j.tai_from_tdb(tdbs[i])) - tdbs[i])
+    # A list of two million bigger numbers spanning ~ 20 days
+    secs = 20. * 86400.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-15 * secs)
+    assert np.all(errors > -1.e-15 * secs)
 
-        # A list of two million bigger numbers spanning ~ 20 days
-        secs = 20. * 86400.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-15 * secs))
-        self.assertTrue(np.all(errors > -1.e-15 * secs))
-
-        # A list of two million still bigger numbers spanning ~ 2000 years
-        secs = 2000. * 365. * 86400.
-        tdbs = np.arange(-secs, secs, 1.e-6 * secs)
-        errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
-        self.assertTrue(np.all(errors <  1.e-15 * secs))
-        self.assertTrue(np.all(errors > -1.e-15 * secs))
+    # A list of two million still bigger numbers spanning ~ 2000 years
+    secs = 2000. * 365. * 86400.
+    tdbs = np.arange(-secs, secs, 1.e-6 * secs)
+    errors = j.tdb_from_tai(j.tai_from_tdb(tdbs)) - tdbs
+    assert np.all(errors <  1.e-15 * secs)
+    assert np.all(errors > -1.e-15 * secs)
 
 ########################################
 # Julian Date and Modified Julian Date
 ########################################
 
-class Test_JD_MJD_v1(unittest.TestCase):
+def test_jd_mjd_v1():
 
-    def runTest(self):
+    # Test integer conversions...
+    assert j.mjd_from_day(0) == 51544
+    assert j.day_from_mjd(51545) == 1
 
-        # Test integer conversions...
-        self.assertEqual(j.mjd_from_day(0), 51544)
-        self.assertEqual(j.day_from_mjd(51545), 1)
+    assert np.all(j.mjd_from_day(np.arange(10)) ==
+                           np.arange(10) + 51544)
 
-        self.assertTrue(np.all(j.mjd_from_day(np.arange(10)) ==
-                               np.arange(10) + 51544))
+    assert np.all(j.day_from_mjd(np.arange(10)) ==
+                           np.arange(10) - 51544)
 
-        self.assertTrue(np.all(j.day_from_mjd(np.arange(10)) ==
-                               np.arange(10) - 51544))
+    # Test MJD floating-point conversions spanning 1000 years
+    span = 1000. * 365.25
+    mjdlist = np.arange(-span, span, np.pi) + j.mjd_jd._MJD_OF_JAN_1_2000
 
-        # Test MJD floating-point conversions spanning 1000 years
-        span = 1000. * 365.25
-        mjdlist = np.arange(-span, span, np.pi) + j.mjd_jd._MJD_OF_JAN_1_2000
+    test = j.mjd_from_time(j.time_from_mjd(mjdlist))
+    error = np.max(np.abs(test - mjdlist))
+    assert np.max(np.abs(test - mjdlist)) < span * 1.e-15
 
-        test = j.mjd_from_time(j.time_from_mjd(mjdlist))
-        error = np.max(np.abs(test - mjdlist))
-        self.assertTrue(np.max(np.abs(test - mjdlist)) < span * 1.e-15)
+    for mjd in mjdlist[:100]:
+        error = abs(j.mjd_from_time(j.time_from_mjd(mjd)) - mjd)
+        assert error < span * 1.e-15
 
-        for mjd in mjdlist[:100]:
-            error = abs(j.mjd_from_time(j.time_from_mjd(mjd)) - mjd)
-            self.assertTrue(error < span * 1.e-15)
+    (day,sec) = j.day_sec_from_mjd(mjdlist)
+    test = j.mjd_from_day_sec(day,sec)
+    error = np.abs(test - mjdlist)
+    assert np.max(np.abs(test - mjdlist)) < span * 1.e-15
 
-        (day,sec) = j.day_sec_from_mjd(mjdlist)
-        test = j.mjd_from_day_sec(day,sec)
-        error = np.abs(test - mjdlist)
-        self.assertTrue(np.max(np.abs(test - mjdlist)) < span * 1.e-15)
+    for mjd in mjdlist[:100]:
+        (day,sec) = j.day_sec_from_mjd(mjd)
+        error = abs(j.mjd_from_day_sec(day,sec) - mjd)
+        assert error < span * 1.e-15
 
-        for mjd in mjdlist[:100]:
-            (day,sec) = j.day_sec_from_mjd(mjd)
-            error = abs(j.mjd_from_day_sec(day,sec) - mjd)
-            self.assertTrue(error < span * 1.e-15)
+    # Test JD floating-point conversions spanning 100 years
+    span = 100. * 365.25
+    jdlist = np.arange(-span, span, np.pi/10.) + j.mjd_jd._JD_OF_JAN_1_2000
 
-        # Test JD floating-point conversions spanning 100 years
-        span = 100. * 365.25
-        jdlist = np.arange(-span, span, np.pi/10.) + j.mjd_jd._JD_OF_JAN_1_2000
+    test = j.jd_from_time(j.time_from_jd(jdlist))
+    error = np.max(np.abs(test - jdlist))
+    assert np.max(np.abs(test - jdlist)) < j.mjd_jd._JD_OF_JAN_1_2000*1.e-15
 
-        test = j.jd_from_time(j.time_from_jd(jdlist))
-        error = np.max(np.abs(test - jdlist))
-        self.assertTrue(np.max(np.abs(test - jdlist)) < j.mjd_jd._JD_OF_JAN_1_2000*1.e-15)
+    for jd in jdlist[:100]:
+        error = abs(j.jd_from_time(j.time_from_jd(jd)) - jd)
+        assert error < span * 1.e-15
 
-        for jd in jdlist[:100]:
-            error = abs(j.jd_from_time(j.time_from_jd(jd)) - jd)
-            self.assertTrue(error < span * 1.e-15)
+    (day,sec) = j.day_sec_from_jd(jdlist)
+    test = j.jd_from_day_sec(day,sec)
+    error = np.abs(test - jdlist)
+    assert np.max(np.abs(test - jdlist)) < j.mjd_jd._JD_OF_JAN_1_2000*1.e-15
 
-        (day,sec) = j.day_sec_from_jd(jdlist)
-        test = j.jd_from_day_sec(day,sec)
-        error = np.abs(test - jdlist)
-        self.assertTrue(np.max(np.abs(test - jdlist)) < j.mjd_jd._JD_OF_JAN_1_2000*1.e-15)
-
-        for jd in jdlist[:100]:
-            (day,sec) = j.day_sec_from_jd(jd)
-            error = abs(j.jd_from_day_sec(day,sec) - jd)
-            self.assertTrue(error < span * 1.e-15)
+    for jd in jdlist[:100]:
+        (day,sec) = j.day_sec_from_jd(jd)
+        error = abs(j.jd_from_day_sec(day,sec) - jd)
+        assert error < span * 1.e-15
 
 ########################################
 # Time System conversions
 ########################################
 
-class Test_Conversions_v1(unittest.TestCase):
+def test_conversions_v1():
 
-    def runTest(self):
+    warnings.filterwarnings('ignore', category=JDW)
 
-        warnings.filterwarnings('ignore', category=JDW)
+    j.set_ut_model('LEAPS')
 
-        j.set_ut_model('LEAPS')
+    # TAI was 31-32 seconds ahead of UTC in 1999,2000,2001
+    (day,sec) = j.day_sec_as_type_from_utc((-366,0,366),0.,"TAI")
+    assert np.all(day == (-366,0,366))
+    assert np.all(sec == (31.,32.,32.))
 
-        # TAI was 31-32 seconds ahead of UTC in 1999,2000,2001
-        (day,sec) = j.day_sec_as_type_from_utc((-366,0,366),0.,"TAI")
-        self.assertTrue(np.all(day == (-366,0,366)))
-        self.assertTrue(np.all(sec == (31.,32.,32.)))
+    # Inverse of the above
+    (day,sec) = j.utc_from_day_sec_as_type((-366,0,366),32.,"TAI")
+    assert np.all(day == (-366,0,366))
+    assert np.all(sec == (1.,0.,0.))
 
-        # Inverse of the above
-        (day,sec) = j.utc_from_day_sec_as_type((-366,0,366),32.,"TAI")
-        self.assertTrue(np.all(day == (-366,0,366)))
-        self.assertTrue(np.all(sec == (1.,0.,0.)))
+    # TAI did not jump ahead of UTC at the beginning of 1972
+    (day,sec) = j.day_sec_as_type_from_utc(j.day_from_ymd(1972,1,1),0,"TAI")
+    assert sec == 10
+    (day,sec) = j.day_sec_as_type_from_utc(j.day_from_ymd(1971,12,31),0,"TAI")
+    assert sec == 10
 
-        # TAI did not jump ahead of UTC at the beginning of 1972
-        (day,sec) = j.day_sec_as_type_from_utc(j.day_from_ymd(1972,1,1),0,"TAI")
-        self.assertEqual(sec,10)
-        (day,sec) = j.day_sec_as_type_from_utc(j.day_from_ymd(1971,12,31),0,"TAI")
-        self.assertEqual(sec,10)
+    # Inverses of the above
+    (day,sec) = j.utc_from_day_sec_as_type(j.day_from_ymd(1972,1,1),10,"TAI")
+    assert sec == 0
+    (day,sec) = j.utc_from_day_sec_as_type(j.day_from_ymd(1971,12,31),10,"TAI")
+    assert sec == 0
 
-        # Inverses of the above
-        (day,sec) = j.utc_from_day_sec_as_type(j.day_from_ymd(1972,1,1),10,"TAI")
-        self.assertEqual(sec,0)
-        (day,sec) = j.utc_from_day_sec_as_type(j.day_from_ymd(1971,12,31),10,"TAI")
-        self.assertEqual(sec,0)
+    # Now do a batch test 1971-2012. Conversions should be exact.
+    daylist = np.arange(j.day_from_ymd(1971,1,1), j.day_from_ymd(2012,1,1))
 
-        # Now do a batch test 1971-2012. Conversions should be exact.
-        daylist = np.arange(j.day_from_ymd(1971,1,1), j.day_from_ymd(2012,1,1))
+    (day,sec) = j.day_sec_as_type_from_utc(daylist,43200.,"TAI")
+    (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TAI")
+    assert np.all(dtest == daylist)
+    assert np.all(stest == 43200.)
 
-        (day,sec) = j.day_sec_as_type_from_utc(daylist,43200.,"TAI")
-        (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TAI")
-        self.assertTrue(np.all(dtest == daylist))
-        self.assertTrue(np.all(stest == 43200.))
+    (day,sec) = j.day_sec_as_type_from_utc(daylist,0.,"TAI")
+    (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TAI")
+    assert np.all(dtest == daylist)
+    assert np.all(stest == 0.)
 
-        (day,sec) = j.day_sec_as_type_from_utc(daylist,0.,"TAI")
-        (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TAI")
-        self.assertTrue(np.all(dtest == daylist))
-        self.assertTrue(np.all(stest == 0.))
+    (day,sec) = j.utc_from_day_sec_as_type(daylist,0.,"TAI")
+    (dtest,stest) = j.day_sec_as_type_from_utc(day,sec,"TAI")
+    assert np.all(dtest == daylist)
+    assert np.all(stest == 0.)
 
-        (day,sec) = j.utc_from_day_sec_as_type(daylist,0.,"TAI")
-        (dtest,stest) = j.day_sec_as_type_from_utc(day,sec,"TAI")
-        self.assertTrue(np.all(dtest == daylist))
-        self.assertTrue(np.all(stest == 0.))
+    # TDB tests...
 
-        # TDB tests...
+    assert abs(j.day_sec_as_type_from_utc(0,0,"TDB")[1]
+                        - 64.183927284731055) < 1.e15
+    assert abs(j.utc_from_day_sec_as_type(0,0,"TDB")[1]
+                        + 64.183927284731055) < 1.e15
 
-        self.assertTrue(abs(j.day_sec_as_type_from_utc(0,0,"TDB")[1]
-                            - 64.183927284731055) < 1.e15)
-        self.assertTrue(abs(j.utc_from_day_sec_as_type(0,0,"TDB")[1]
-                            + 64.183927284731055) < 1.e15)
+    (day,sec) = j.day_sec_as_type_from_utc(daylist,43200.,"TDB")
+    (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TDB")
+    assert np.all(dtest == daylist)
+    assert np.all(np.abs(stest - 43200.) < 1.e-6)
 
-        (day,sec) = j.day_sec_as_type_from_utc(daylist,43200.,"TDB")
-        (dtest,stest) = j.utc_from_day_sec_as_type(day,sec,"TDB")
-        self.assertTrue(np.all(dtest == daylist))
-        self.assertTrue(np.all(np.abs(stest - 43200.) < 1.e-6))
+    (day,sec) = j.utc_from_day_sec_as_type(daylist,43200.,"TDB")
+    (dtest,stest) = j.day_sec_as_type_from_utc(day,sec,"TDB")
+    assert np.all(dtest == daylist)
+    assert np.all(np.abs(stest - 43200.) < 1.e-6)
 
-        (day,sec) = j.utc_from_day_sec_as_type(daylist,43200.,"TDB")
-        (dtest,stest) = j.day_sec_as_type_from_utc(day,sec,"TDB")
-        self.assertTrue(np.all(dtest == daylist))
-        self.assertTrue(np.all(np.abs(stest - 43200.) < 1.e-6))
+    j.set_ut_model('LEAPS')
 
-        j.set_ut_model('LEAPS')
-
-        warnings.resetwarnings()
-        _warnings._reset_warnings()
+    warnings.resetwarnings()
+    _warnings._reset_warnings()
 
 ########################################
 # Formatting Routines
 ########################################
 
-class Test_Formatting_v1(unittest.TestCase):
+def test_formatting_v1():
 
-    def runTest(self):
+    # ymd_format_from_day()
+    assert j.ymd_format_from_day(0) == "2000-01-01"
 
-        # ymd_format_from_day()
-        self.assertEqual(j.ymd_format_from_day(0), "2000-01-01")
+    assert np.all(j.ymd_format_from_day([-365,0,366]) ==
+                    ["1999-01-01", "2000-01-01", "2001-01-01"])
 
-        self.assertTrue(np.all(j.ymd_format_from_day([-365,0,366]) ==
-                        ["1999-01-01", "2000-01-01", "2001-01-01"]))
+    # yd_format_from_day()
+    assert j.yd_format_from_day(0) == "2000-001"
 
-        # yd_format_from_day()
-        self.assertEqual(j.yd_format_from_day(0), "2000-001")
+    assert np.all(j.yd_format_from_day([-365,0,366]) ==
+                    ["1999-001", "2000-001", "2001-001"])
 
-        self.assertTrue(np.all(j.yd_format_from_day([-365,0,366]) ==
-                        ["1999-001", "2000-001", "2001-001"]))
+    # Check if yd_format_from_day start from 2000-001
+    assert j.yd_format_from_day(0) == "2000-001"
 
-        # Check if yd_format_from_day start from 2000-001
-        self.assertEqual(j.yd_format_from_day(0), "2000-001")
+    # Check if one day is 86400 seconds
+    assert j.hms_format_from_sec(86400) == "23:59:60"
 
-        # Check if one day is 86400 seconds
-        self.assertEqual(j.hms_format_from_sec(86400), "23:59:60")
+    # Check if hms_format_from_sec end with 86410
+    assert j.hms_format_from_sec(86409) == "23:59:69"
 
-        # Check if hms_format_from_sec end with 86410
-        self.assertEqual(j.hms_format_from_sec(86409), "23:59:69")
+    # Check if hms_format_from_sec returns the correct format.
+    assert j.hms_format_from_sec(0) == "00:00:00"
+    assert j.hms_format_from_sec(0,3) == "00:00:00.000"
+    assert j.hms_format_from_sec(0,3,'Z') == "00:00:00.000Z"
 
-        # Check if hms_format_from_sec returns the correct format.
-        self.assertEqual(j.hms_format_from_sec(0), "00:00:00")
-        self.assertEqual(j.hms_format_from_sec(0,3), "00:00:00.000")
-        self.assertEqual(j.hms_format_from_sec(0,3,'Z'), "00:00:00.000Z")
+    # Check if hms_format_from_sec accepts seconds over 86410
+    with pytest.raises(JVF):
+        j.hms_format_from_sec(86411)
 
-        # Check if hms_format_from_sec accepts seconds over 86410
-        self.assertRaises(JVF, j.hms_format_from_sec, 86411)
+    # Check if ymdhms_format_from_day_sec returns the correct format.
+    assert j.ymdhms_format_from_day_sec(0,0) == \
+                     "2000-01-01T00:00:00"
+    assert j.ymdhms_format_from_day_sec(0,0,'T',3) == \
+                     "2000-01-01T00:00:00.000"
+    assert j.ymdhms_format_from_day_sec(0,0,'T',3,'Z') == \
+                     "2000-01-01T00:00:00.000Z"
+    assert j.ymdhms_format_from_day_sec(0,0,'T',None) == \
+                     "2000-01-01T00:00:00"
+    assert j.ymdhms_format_from_day_sec(0,0,'T',None,'Z') == \
+                     "2000-01-01T00:00:00Z"
 
-        # Check if ymdhms_format_from_day_sec returns the correct format.
-        self.assertEqual(j.ymdhms_format_from_day_sec(0,0),
-                         "2000-01-01T00:00:00")
-        self.assertEqual(j.ymdhms_format_from_day_sec(0,0,'T',3),
-                         "2000-01-01T00:00:00.000")
-        self.assertEqual(j.ymdhms_format_from_day_sec(0,0,'T',3,'Z'),
-                         "2000-01-01T00:00:00.000Z")
-        self.assertEqual(j.ymdhms_format_from_day_sec(0,0,'T',None),
-                         "2000-01-01T00:00:00")
-        self.assertEqual(j.ymdhms_format_from_day_sec(0,0,'T',None,'Z'),
-                         "2000-01-01T00:00:00Z")
+    ymdhms = j.ymdhms_format_from_day_sec([0,366],[0,43200])
+    assert np.all(ymdhms == ("2000-01-01T00:00:00",
+                                      "2001-01-01T12:00:00"))
 
-        ymdhms = j.ymdhms_format_from_day_sec([0,366],[0,43200])
-        self.assertTrue(np.all(ymdhms == ("2000-01-01T00:00:00",
-                                          "2001-01-01T12:00:00")))
+    # Check TAI formatting
 
-        # Check TAI formatting
+    j.set_tai_origin('MIDNIGHT')
 
-        j.set_tai_origin('MIDNIGHT')
-
-        # The 32's below are for the offset between TAI and UTC
-        self.assertTrue(np.all(j.ydhms_format_from_tai([32.,366.*86400.+32.]) ==
-                        ("2000-001T00:00:00", "2001-001T00:00:00")))
-        j.set_tai_origin('NOON')
+    # The 32's below are for the offset between TAI and UTC
+    assert np.all(j.ydhms_format_from_tai([32.,366.*86400.+32.]) ==
+                    ("2000-001T00:00:00", "2001-001T00:00:00"))
+    j.set_tai_origin('NOON')
 
 ########################################
 # ISO format parsers
 ########################################
 
-class Test_ISO_Parsing_v1(unittest.TestCase):
+def test_iso_parsing_v1():
 
-    def runTest(self):
+    # day_from_iso()
+    assert j.day_from_iso( "2001-01-01") == 366
 
-        # day_from_iso()
-        self.assertEqual(j.day_from_iso( "2001-01-01"), 366)
+    strings = ["1999-01-01", "2000-01-01", "2001-01-01"]
+    days    = [       -365 ,           0 ,         366 ]
+    assert np.all(j.day_from_iso(strings) == days)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01-01"]
-        days    = [       -365 ,           0 ,         366 ]
-        self.assertTrue(np.all(j.day_from_iso(strings) == days))
+    strings = [["2000-001", "2000-002"], ["2000-003", "2000-004"]]
+    days    = [[        0 ,         1 ], [        2 ,         3 ]]
+    assert np.all(j.day_from_iso(strings) == days)
 
-        strings = [["2000-001", "2000-002"], ["2000-003", "2000-004"]]
-        days    = [[        0 ,         1 ], [        2 ,         3 ]]
-        self.assertTrue(np.all(j.day_from_iso(strings) == days))
+    strings = ["1999-01-01", "2000-01-01", "2001-01+01"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings, syntax=True)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01+01"]
-        self.assertRaises(ValueError, j.day_from_iso, strings, syntax=True)
+    strings = ["1999-01-01", "2000-01-01", "2001-01-aa"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01-aa"]
-        self.assertRaises(ValueError, j.day_from_iso, strings)
+    strings = ["1999-01-01", "2000-01-01", "2001-01- 1"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings, syntax=True)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01- 1"]
-        self.assertRaises(ValueError, j.day_from_iso, strings, syntax=True)
+    strings = ["1999-01-01", "2000-01-01", "2001-01-00"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01-00"]
-        self.assertRaises(ValueError, j.day_from_iso, strings)
+    strings = ["1999-01-01", "2000-01-01", "2001-00-01"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-00-01"]
-        self.assertRaises(ValueError, j.day_from_iso, strings)
+    strings = ["1999-01-01", "2000-01-01", "2001-13-01"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-13-01"]
-        self.assertRaises(ValueError, j.day_from_iso, strings)
+    strings = ["1999-01-01", "2000-01-01", "2001-02-29"]
+    with pytest.raises(ValueError):
+        j.day_from_iso(strings)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-02-29"]
-        self.assertRaises(ValueError, j.day_from_iso, strings)
+    # sec_from_iso()
+    assert j.sec_from_iso("01:00:00") == 3600
+    assert j.sec_from_iso("23:59:60") == 86400
+    assert j.sec_from_iso("23:59:69") == 86409
+    assert j.sec_from_iso("23:59:69Z") == 86409
+    assert j.sec_from_iso("23:59:69.10") == 86409.10
+    assert j.sec_from_iso("23:59:69.5Z") == 86409.5
 
-        # sec_from_iso()
-        self.assertEqual(j.sec_from_iso("01:00:00"),     3600)
-        self.assertEqual(j.sec_from_iso("23:59:60"),    86400)
-        self.assertEqual(j.sec_from_iso("23:59:69"),    86409)
-        self.assertEqual(j.sec_from_iso("23:59:69Z"),   86409)
-        self.assertEqual(j.sec_from_iso("23:59:69.10"), 86409.10)
-        self.assertEqual(j.sec_from_iso("23:59:69.5Z"), 86409.5)
+    strings = ["00:00:00", "00:01:00", "00:02:00"]
+    secs    = [        0 ,        60 ,       120 ]
+    assert np.all(j.sec_from_iso(strings) == secs)
 
-        strings = ["00:00:00", "00:01:00", "00:02:00"]
-        secs    = [        0 ,        60 ,       120 ]
-        self.assertTrue(np.all(j.sec_from_iso(strings) == secs))
+    strings = [["00:02:00Z", "00:04:00Z"], ["00:06:00Z", "00:08:01Z"]]
+    secs    = [[      120  ,       240  ], [       360 ,        481 ]]
+    assert np.all(j.sec_from_iso(strings) == secs)
 
-        strings = [["00:02:00Z", "00:04:00Z"], ["00:06:00Z", "00:08:01Z"]]
-        secs    = [[      120  ,       240  ], [       360 ,        481 ]]
-        self.assertTrue(np.all(j.sec_from_iso(strings) == secs))
+    strings = ["00:00:00.01", "00:01:00.02", "23:59:69.03"]
+    secs    = [        0.01 ,        60.02 ,     86409.03 ]
+    assert np.all(j.sec_from_iso(strings) == secs)
 
-        strings = ["00:00:00.01", "00:01:00.02", "23:59:69.03"]
-        secs    = [        0.01 ,        60.02 ,     86409.03 ]
-        self.assertTrue(np.all(j.sec_from_iso(strings) == secs))
+    strings = ["00:00:00.01", "00:01:00.02", "00:02+00.03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings, syntax=True)
 
-        strings = ["00:00:00.01", "00:01:00.02", "00:02+00.03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings, syntax=True)
+    strings = ["00:00:00.01", "00:01:00.02", "00:02: 0.03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings, syntax=True)
 
-        strings = ["00:00:00.01", "00:01:00.02", "00:02: 0.03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings, syntax=True)
+    strings = ["00:02:00.1Z", "00:04:00.2Z", "00:06:00.3z"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings, syntax=True)
 
-        strings = ["00:02:00.1Z", "00:04:00.2Z", "00:06:00.3z"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings, syntax=True)
+    strings = ["00:00:00.01", "00:01:00.02", "00:02:00+03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings, syntax=True)
 
-        strings = ["00:00:00.01", "00:01:00.02", "00:02:00+03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings, syntax=True)
+    strings = ["00:00:00.01", "00:01:00.02", "-0:02:00.03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings, syntax=True)
 
-        strings = ["00:00:00.01", "00:01:00.02", "-0:02:00.03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings, syntax=True)
+    strings = ["00:00:00.01", "00:01:00.02", "24:02:00.03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings)
 
-        strings = ["00:00:00.01", "00:01:00.02", "24:02:00.03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings)
+    strings = ["00:00:00.01", "00:01:00.02", "00:60:00.03"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings)
 
-        strings = ["00:00:00.01", "00:01:00.02", "00:60:00.03"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings)
+    strings = ["00:00:00", "00:01:00", "00:00:70"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings)
 
-        strings = ["00:00:00", "00:01:00", "00:00:70"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings)
+    strings = ["00:00:00.01", "00:01:00.02", "00:00:69.00"]
+    with pytest.raises(ValueError):
+        j.sec_from_iso(strings)
 
-        strings = ["00:00:00.01", "00:01:00.02", "00:00:69.00"]
-        self.assertRaises(ValueError, j.sec_from_iso, strings)
+    # day_sec_from_iso()
+    assert j.day_sec_from_iso( "2001-01-01 01:00:00") == (366,3600)
+    assert j.day_sec_from_iso( "2001-01-01T01:00:00") == (366,3600)
 
-        # day_sec_from_iso()
-        self.assertEqual(j.day_sec_from_iso( "2001-01-01 01:00:00"), (366,3600))
-        self.assertEqual(j.day_sec_from_iso( "2001-01-01T01:00:00"), (366,3600))
+    assert j.day_sec_from_iso("1998-12-31 23:59:60") == (-366, 86400)
 
-        self.assertEqual(j.day_sec_from_iso("1998-12-31 23:59:60"), (-366, 86400))
+    with pytest.raises(ValueError):
+        j.day_sec_from_iso("2000-01-01 23:59:60")
+    with pytest.raises(ValueError):
+        j.day_sec_from_iso("1999-12-31 23:59:61")
 
-        self.assertRaises(ValueError, j.day_sec_from_iso, "2000-01-01 23:59:60")
-        self.assertRaises(ValueError, j.day_sec_from_iso, "1999-12-31 23:59:61")
+    strings = ["1999-01-01", "2000-01-01", "2001-01-01"]
+    days    = [       -365 ,           0 ,         366 ]
+    assert np.all(j.day_sec_from_iso(strings)[0] == days)
+    assert np.all(j.day_sec_from_iso(strings)[1] == 0)
 
-        strings = ["1999-01-01", "2000-01-01", "2001-01-01"]
-        days    = [       -365 ,           0 ,         366 ]
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[0] == days))
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[1] == 0))
+    strings = [["2000-001", "2000-002"], ["2000-003", "2000-004"]]
+    days    = [[        0 ,         1 ], [        2 ,         3 ]]
+    assert np.all(j.day_sec_from_iso(strings)[0] == days)
+    assert np.all(j.day_sec_from_iso(strings)[1] == 0)
 
-        strings = [["2000-001", "2000-002"], ["2000-003", "2000-004"]]
-        days    = [[        0 ,         1 ], [        2 ,         3 ]]
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[0] == days))
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[1] == 0))
+    strings = ["1998-12-31 23:59:60", "2001-01-01 01:00:01"]
+    days    = [       -366          ,         366          ]
+    secs    = [               86400 ,                 3601 ]
+    assert np.all(j.day_sec_from_iso(strings)[0] == days)
+    assert np.all(j.day_sec_from_iso(strings)[1] == secs)
 
-        strings = ["1998-12-31 23:59:60", "2001-01-01 01:00:01"]
-        days    = [       -366          ,         366          ]
-        secs    = [               86400 ,                 3601 ]
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[0] == days))
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[1] == secs))
+    strings = ["1998-12-31T23:59:60", "2001-01-01T01:00:01"]
+    days    = [       -366          ,         366          ]
+    secs    = [               86400 ,                 3601 ]
+    assert np.all(j.day_sec_from_iso(strings)[0] == days)
+    assert np.all(j.day_sec_from_iso(strings)[1] == secs)
 
-        strings = ["1998-12-31T23:59:60", "2001-01-01T01:00:01"]
-        days    = [       -366          ,         366          ]
-        secs    = [               86400 ,                 3601 ]
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[0] == days))
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[1] == secs))
+    strings = ["1998-12-31 23:59:60Z", "2001-01-01 01:00:01Z"]
+    days    = [       -366           ,         366           ]
+    secs    = [               86400  ,                 3601  ]
+    assert np.all(j.day_sec_from_iso(strings)[0] == days)
+    assert np.all(j.day_sec_from_iso(strings)[1] == secs)
 
-        strings = ["1998-12-31 23:59:60Z", "2001-01-01 01:00:01Z"]
-        days    = [       -366           ,         366           ]
-        secs    = [               86400  ,                 3601  ]
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[0] == days))
-        self.assertTrue(np.all(j.day_sec_from_iso(strings)[1] == secs))
+    strings = ["1998-12-31 23:59:60Z", "2001-01-01x01:00:01Z"]
+    with pytest.raises(ValueError):
+        j.day_sec_from_iso(strings, syntax=True)
 
-        strings = ["1998-12-31 23:59:60Z", "2001-01-01x01:00:01Z"]
-        self.assertRaises(ValueError, j.day_sec_from_iso, strings, syntax=True)
-
-        strings = ["1998-12-31 23:59:60Z", "1998-12-31 23:59:61Z"]
-        self.assertRaises(ValueError, j.day_sec_from_iso, strings)
+    strings = ["1998-12-31 23:59:60Z", "1998-12-31 23:59:61Z"]
+    with pytest.raises(ValueError):
+        j.day_sec_from_iso(strings)
 
 ########################################
 # General Parsing Routines
 ########################################
 
-class Test_General_Parsing_v1(unittest.TestCase):
+def test_general_parsing_v1():
 
-    def runTest(self):
+    warnings.filterwarnings('ignore', category=JDW)
 
-        warnings.filterwarnings('ignore', category=JDW)
+    # Note: julian_dateparser.py has more extensive unit tests
 
-        # Note: julian_dateparser.py has more extensive unit tests
+    # Check if day_from_string works like day_from_ymd
+    assert j.day_from_string("2000-01-01") == \
+                     j.day_from_ymd(2000,1,1)
 
-        # Check if day_from_string works like day_from_ymd
-        self.assertEqual(j.day_from_string("2000-01-01"),
-                         j.day_from_ymd(2000,1,1))
+    # Check day_from_string
+    assert j.day_from_string("01-02-2000", "MDY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_from_string("01-02-00", "MDY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_from_string("02-01-2000", "DMY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_from_string("02-01-00", "DMY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_from_string("2000-02-29","DMY") == \
+                     j.day_from_ymd(2000,2,29)
 
-        # Check day_from_string
-        self.assertEqual(j.day_from_string("01-02-2000", "MDY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_from_string("01-02-00", "MDY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_from_string("02-01-2000", "DMY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_from_string("02-01-00", "DMY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_from_string("2000-02-29","DMY"),
-                         j.day_from_ymd(2000,2,29))
+    # Check date validator
+    with pytest.raises(ValueError):
+        j.day_from_string("2001-11-31")
+    with pytest.raises(ValueError):
+        j.day_from_string("2001-02-29")
 
-        # Check date validator
-        self.assertRaises(ValueError, j.day_from_string, "2001-11-31")
-        self.assertRaises(ValueError, j.day_from_string, "2001-02-29")
+    # Check day_in_string
+    assert j.day_in_string("Today is 01-02-2000!", "MDY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_in_string("Today is:[01-02-00]", "MDY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_in_string("Is this today?02-01-2000-0", "DMY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_in_string("Test--02-01-00-00", "DMY") == \
+                     j.day_from_ymd(2000,1,2)
+    assert j.day_in_string("Test 2000-02-29=today","DMY") == \
+                     j.day_from_ymd(2000,2,29)
 
-        # Check day_in_string
-        self.assertEqual(j.day_in_string("Today is 01-02-2000!", "MDY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_in_string("Today is:[01-02-00]", "MDY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_in_string("Is this today?02-01-2000-0", "DMY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_in_string("Test--02-01-00-00", "DMY"),
-                         j.day_from_ymd(2000,1,2))
-        self.assertEqual(j.day_in_string("Test 2000-02-29=today","DMY"),
-                         j.day_from_ymd(2000,2,29))
+    # Check days_in_string
+    assert j.days_in_string("Today is 01-02-2000!", "MDY") == \
+                     [j.day_from_ymd(2000,1,2)]
+    assert j.days_in_string("Today is:[01-02-00]", "MDY") == \
+                     [j.day_from_ymd(2000,1,2)]
+    assert j.days_in_string("Is this today?02-01-2000-0", "DMY") == \
+                     [j.day_from_ymd(2000,1,2)]
+    assert j.days_in_string("Test--02-01-00-00", "DMY") == \
+                     [j.day_from_ymd(2000,1,2)]
+    assert j.days_in_string("Test 2000-02-29=today","DMY") == \
+                     [j.day_from_ymd(2000,2,29)]
+    assert j.days_in_string("Test 2000=today","DMY") == \
+                     []
+    assert j.days_in_string("2020-01-01|30-10-20, etc.",) == \
+                     [j.day_from_ymd(2020,1,1), j.day_from_ymd(2030,10,20)]
 
-        # Check days_in_string
-        self.assertEqual(j.days_in_string("Today is 01-02-2000!", "MDY"),
-                         [j.day_from_ymd(2000,1,2)])
-        self.assertEqual(j.days_in_string("Today is:[01-02-00]", "MDY"),
-                         [j.day_from_ymd(2000,1,2)])
-        self.assertEqual(j.days_in_string("Is this today?02-01-2000-0", "DMY"),
-                         [j.day_from_ymd(2000,1,2)])
-        self.assertEqual(j.days_in_string("Test--02-01-00-00", "DMY"),
-                         [j.day_from_ymd(2000,1,2)])
-        self.assertEqual(j.days_in_string("Test 2000-02-29=today","DMY"),
-                         [j.day_from_ymd(2000,2,29)])
-        self.assertEqual(j.days_in_string("Test 2000=today","DMY"),
-                         [])
-        self.assertEqual(j.days_in_string("2020-01-01|30-10-20, etc.",),
-                         [j.day_from_ymd(2020,1,1), j.day_from_ymd(2030,10,20)])
+    # Check date validator
+    with pytest.raises(JVF):
+        j.day_in_string("Today=(2001-11-31)")
+    with pytest.raises(JVF):
+        j.day_in_string("Today 2001-02-29T12:34:56")
 
-        # Check date validator
-        self.assertRaises(JVF, j.day_in_string, "Today=(2001-11-31)")
-        self.assertRaises(JVF, j.day_in_string, "Today 2001-02-29T12:34:56")
+    assert j.day_in_string("Today 2001-01-01, not tomorrow",
+                                     remainder=True) == (366, ', not tomorrow')
 
-        self.assertEqual(j.day_in_string("Today 2001-01-01, not tomorrow",
-                                         remainder=True), (366, ', not tomorrow'))
+    # Check sec_from_string
+    assert j.sec_from_string("00:00:00.000") == 0.0
+    assert j.sec_from_string("00:00:00") == 0
+    assert j.sec_from_string("00:00:59.000") == 59.0
+    assert j.sec_from_string("00:00:59") == 59
 
-        # Check sec_from_string
-        self.assertEqual(j.sec_from_string("00:00:00.000"), 0.0)
-        self.assertEqual(j.sec_from_string("00:00:00"), 0)
-        self.assertEqual(j.sec_from_string("00:00:59.000"), 59.0)
-        self.assertEqual(j.sec_from_string("00:00:59"), 59)
+    # Check leap seconds
+    assert j.sec_from_string("23:59:60.000") == 86400.0
+    assert j.sec_from_string("23:59:69.000") == 86409.0
+    with pytest.raises(ValueError):
+        j.sec_from_string("23:59:70.000")
 
-        # Check leap seconds
-        self.assertEqual(j.sec_from_string("23:59:60.000"), 86400.0)
-        self.assertEqual(j.sec_from_string("23:59:69.000"), 86409.0)
-        self.assertRaises(ValueError, j.sec_from_string, "23:59:70.000")
+    # Check time_in_string
+    assert j.time_in_string("This is the time--00:00:00.000") == 0.0
+    assert j.time_in_string("Is this the time? 00:00:00=now") == 0
+    assert j.time_in_string("Time:00:00:59.000 is now") == 59.0
+    assert j.time_in_string("Time (00:00:59)") == 59
 
-        # Check time_in_string
-        self.assertEqual(j.time_in_string("This is the time--00:00:00.000"), 0.0)
-        self.assertEqual(j.time_in_string("Is this the time? 00:00:00=now"), 0)
-        self.assertEqual(j.time_in_string("Time:00:00:59.000 is now"), 59.0)
-        self.assertEqual(j.time_in_string("Time (00:00:59)"), 59)
+    # Check time_in_string with leap seconds
+    assert j.time_in_string("End time[23:59:60.000]") == 86400.0
+    assert j.time_in_string("End time is 23:59:69.000 and later") == 86409.0
+    assert j.time_in_string("Error 23:5z:00.000:0") is None
 
-        # Check time_in_string with leap seconds
-        self.assertEqual(j.time_in_string("End time[23:59:60.000]"), 86400.0)
-        self.assertEqual(j.time_in_string("End time is 23:59:69.000 and later"), 86409.0)
-        self.assertEqual(j.time_in_string("Error 23:5z:00.000:0"), None)
+    # Check times_in_string with leap seconds
+    assert j.times_in_string("End time[23:59:60.000]") == [86400.0]
+    assert j.times_in_string("End time is 23:59:69.000 and later") == [86409.0]
+    assert j.times_in_string("Error 23:5z:00.000:0") == []
 
-        # Check times_in_string with leap seconds
-        self.assertEqual(j.times_in_string("End time[23:59:60.000]"), [86400.0])
-        self.assertEqual(j.times_in_string("End time is 23:59:69.000 and later"), [86409.0])
-        self.assertEqual(j.times_in_string("Error 23:5z:00.000:0"), [])
+    # Check day_sec_type_from_string
+    assert j.day_sec_type_from_string("2000-01-01 00:00:00.00") == \
+                     (0, 0.0, "UTC")
+    assert j.day_sec_type_from_string("2000-01-01 00:00:00.00 tai") == \
+                     (0, 0.0, "TAI")
+    assert j.day_sec_type_from_string("2000-01-01 00:00:00.00Z") == \
+                     (0, 0.0, "UTC")
+    assert j.day_sec_type_from_string("2000-01-01 00:00:00.00 TDB") == \
+                     (0, 0.0, "TDB")
 
-        # Check day_sec_type_from_string
-        self.assertEqual(j.day_sec_type_from_string("2000-01-01 00:00:00.00"),
-                         (0, 0.0, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("2000-01-01 00:00:00.00 tai"),
-                         (0, 0.0, "TAI"))
-        self.assertEqual(j.day_sec_type_from_string("2000-01-01 00:00:00.00Z"),
-                         (0, 0.0, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("2000-01-01 00:00:00.00 TDB"),
-                         (0, 0.0, "TDB"))
+    # Check if DMY is same as MDY
+    assert j.day_sec_type_from_string("31-12-2000 12:34:56", "DMY") == \
+                     j.day_sec_type_from_string("12-31-2000 12:34:56", "MDY")
 
-        # Check if DMY is same as MDY
-        self.assertEqual(j.day_sec_type_from_string("31-12-2000 12:34:56", "DMY"),
-                         j.day_sec_type_from_string("12-31-2000 12:34:56", "MDY"))
+    # Check leap second validator
+    assert j.day_sec_type_from_string("1998-12-31 23:59:60") == \
+                     (-366, 86400, "UTC")
+    assert j.day_sec_type_from_string("1998-12-31 23:59:60.99") == \
+                     (-366, 86400.99, "UTC")
 
-        # Check leap second validator
-        self.assertEqual(j.day_sec_type_from_string("1998-12-31 23:59:60"),
-                         (-366, 86400, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("1998-12-31 23:59:60.99"),
-                         (-366, 86400.99, "UTC"))
+    with pytest.raises(ValueError):
+        j.day_sec_type_from_string("2000-01-01 23:59:60")
+    with pytest.raises(ValueError):
+        j.day_sec_type_from_string("1999-12-31 23:59:61")
 
-        self.assertRaises(ValueError, j.day_sec_type_from_string,
-                                      "2000-01-01 23:59:60")
-        self.assertRaises(ValueError, j.day_sec_type_from_string,
-                                      "1999-12-31 23:59:61")
+    # Numeric times
+    assert j.day_sec_type_from_string("2000-01-01") == \
+                     (0, 0, "UTC")
+    assert j.day_sec_type_from_string("MJD 51544") == \
+                     (0, 0, "UTC")
+    assert j.day_sec_type_from_string("51544 (MJD)") == \
+                     (0, 0, "UTC")
+    assert j.day_sec_type_from_string("JD 2451545") == \
+                     (0, 43200, "UTC")
+    assert j.day_sec_type_from_string("2451545.  jd") == \
+                     (0, 43200, "UTC")
+    assert j.day_sec_type_from_string("2451545.  jed") == \
+                     j.day_sec_type_from_string("JAN-1.5-2000  TDB")
+    assert j.day_sec_type_from_string("51544.5  mjed") == \
+                     j.day_sec_type_from_string("JAN-1.5-2000  TDB")
 
-        # Numeric times
-        self.assertEqual(j.day_sec_type_from_string("2000-01-01"),
-                         (0, 0, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("MJD 51544"),
-                         (0, 0, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("51544 (MJD)"),
-                         (0, 0, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("JD 2451545"),
-                         (0, 43200, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("2451545.  jd"),
-                         (0, 43200, "UTC"))
-        self.assertEqual(j.day_sec_type_from_string("2451545.  jed"),
-                         j.day_sec_type_from_string("JAN-1.5-2000  TDB"))
-        self.assertEqual(j.day_sec_type_from_string("51544.5  mjed"),
-                         j.day_sec_type_from_string("JAN-1.5-2000  TDB"))
+    # Check day_sec_type_in_string
+    assert j.day_sec_type_in_string("Time:2000-01-01 00:00:00.00") == \
+                     (0, 0.0, "UTC")
+    assert j.day_sec_type_in_string("Time[2000-01-01 00:00:00.00 tai]") == \
+                     (0, 0.0, "TAI")
+    assert j.day_sec_type_in_string("2000-01-01 00:00:00.00 Z=now") == \
+                     (0, 0.0, "UTC")
+    assert j.day_sec_type_in_string("Today is [[2000-01-01 00:00:00.00 TDB]]") == \
+                     (0, 0.0, "TDB")
 
-        # Check day_sec_type_in_string
-        self.assertEqual(j.day_sec_type_in_string("Time:2000-01-01 00:00:00.00"),
-                         (0, 0.0, "UTC"))
-        self.assertEqual(j.day_sec_type_in_string("Time[2000-01-01 00:00:00.00 tai]"),
-                         (0, 0.0, "TAI"))
-        self.assertEqual(j.day_sec_type_in_string("2000-01-01 00:00:00.00 Z=now"),
-                         (0, 0.0, "UTC"))
-        self.assertEqual(j.day_sec_type_in_string("Today is [[2000-01-01 00:00:00.00 TDB]]"),
-                         (0, 0.0, "TDB"))
+    # Check if DMY is same as MDY
+    assert j.day_sec_type_in_string("Today-31-12-2000 12:34:56!", "DMY") == \
+                     j.day_sec_type_in_string("Today:12-31-2000 12:34:56?", "MDY")
 
-        # Check if DMY is same as MDY
-        self.assertEqual(j.day_sec_type_in_string("Today-31-12-2000 12:34:56!", "DMY"),
-                         j.day_sec_type_in_string("Today:12-31-2000 12:34:56?", "MDY"))
+    # Check leap second validator
+    assert j.day_sec_type_in_string("Date-1998-12-31 23:59:60 xyz") == \
+                     (-366, 86400, "UTC")
+    assert j.day_sec_type_in_string("Date? 1998-12-31 23:59:60.99 XYZ") == \
+                     (-366, 86400.99, "UTC")
 
-        # Check leap second validator
-        self.assertEqual(j.day_sec_type_in_string("Date-1998-12-31 23:59:60 xyz"),
-                         (-366, 86400, "UTC"))
-        self.assertEqual(j.day_sec_type_in_string("Date? 1998-12-31 23:59:60.99 XYZ"),
-                         (-366, 86400.99, "UTC"))
+    with pytest.raises(JVF):
+        j.day_sec_type_in_string("Today 2000-01-01 23:59:60=leapsecond")
+    with pytest.raises(JVF):
+        j.day_sec_type_in_string("today 1999-12-31 23:59:61 leapsecond")
 
-        self.assertRaises(JVF, j.day_sec_type_in_string,
-                          "Today 2000-01-01 23:59:60=leapsecond")
-        self.assertRaises(JVF, j.day_sec_type_in_string,
-                          "today 1999-12-31 23:59:61 leapsecond")
+    # dates_in_string
+    assert j.dates_in_string("Time:2000-01-01 00:00:00.00") == \
+                     [(0, 0.0, "UTC")]
+    assert j.dates_in_string("Time[2000-01-01 00:00:00.00 tai]") == \
+                     [(0, 0.0, "TAI")]
+    assert j.dates_in_string("2000-01-01 00:00:00.00 Z=now") == \
+                     [(0, 0.0, "UTC")]
+    assert j.dates_in_string("Today is [[2000-01-01 00:00:00.00 TDB]]") == \
+                     [(0, 0.0, "TDB")]
+    assert j.dates_in_string("Today is [[200z-01-01 0z:00:0z.00 TDB]]") == \
+                     []
 
-        # dates_in_string
-        self.assertEqual(j.dates_in_string("Time:2000-01-01 00:00:00.00"),
-                         [(0, 0.0, "UTC")])
-        self.assertEqual(j.dates_in_string("Time[2000-01-01 00:00:00.00 tai]"),
-                         [(0, 0.0, "TAI")])
-        self.assertEqual(j.dates_in_string("2000-01-01 00:00:00.00 Z=now"),
-                         [(0, 0.0, "UTC")])
-        self.assertEqual(j.dates_in_string("Today is [[2000-01-01 00:00:00.00 TDB]]"),
-                         [(0, 0.0, "TDB")])
-        self.assertEqual(j.dates_in_string("Today is [[200z-01-01 0z:00:0z.00 TDB]]"),
-                         [])
-
-        warnings.resetwarnings()
-        _warnings._reset_warnings()
+    warnings.resetwarnings()
+    _warnings._reset_warnings()
 
 
-class Test_v1_warnings(unittest.TestCase):
+def test_v1_warnings():
 
-    def runTest(self):
-
-        with self.assertWarns(JDW):
-            (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
-
-        # This should yield an error
-        warnings.filterwarnings('error')
-        self.assertRaises(JDW, j.times_in_string, "End time[23:59:60.000]")
-
-        # This warning was already raised so it should not be repeated
+    with pytest.warns(JDW):
         (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
 
-        warnings.resetwarnings()
+    # This should yield an error
+    warnings.filterwarnings('error')
+    with pytest.raises(JDW):
+        j.times_in_string("End time[23:59:60.000]")
+
+    # This warning was already raised so it should not be repeated
+    (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
+
+    warnings.resetwarnings()
 
 ##########################################################################################

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -11,13 +11,20 @@ from julian._exceptions import JulianValidateFailure as JVF
 from julian._warnings import JulianDeprecationWarning as JDW
 import julian._warnings as _warnings
 
+
+@pytest.fixture
+def suppress_julian_deprecation():
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=JDW)
+        yield
+    _warnings._reset_warnings()
+
+
 ########################################
 # Calendar conversions
 ########################################
 
-def test_calendar_v1():
-
-    warnings.filterwarnings('ignore', category=JDW)
+def test_calendar_v1(suppress_julian_deprecation):
 
     # day_from_ymd()
     assert j.day_from_ymd(2000,1,1) == 0
@@ -144,9 +151,6 @@ def test_calendar_v1():
     assert j.days_in_year(1752, proleptic=True) == 366
 
     j.set_gregorian_start()
-
-    warnings.resetwarnings()
-    _warnings._reset_warnings()
 
 ########################################
 # Leapsecond routines
@@ -355,9 +359,7 @@ def test_jd_mjd_v1():
 # Time System conversions
 ########################################
 
-def test_conversions_v1():
-
-    warnings.filterwarnings('ignore', category=JDW)
+def test_conversions_v1(suppress_julian_deprecation):
 
     j.set_ut_model('LEAPS')
 
@@ -419,9 +421,6 @@ def test_conversions_v1():
     assert np.all(np.abs(stest - 43200.) < 1.e-6)
 
     j.set_ut_model('LEAPS')
-
-    warnings.resetwarnings()
-    _warnings._reset_warnings()
 
 ########################################
 # Formatting Routines
@@ -636,9 +635,7 @@ def test_iso_parsing_v1():
 # General Parsing Routines
 ########################################
 
-def test_general_parsing_v1():
-
-    warnings.filterwarnings('ignore', category=JDW)
+def test_general_parsing_v1(suppress_julian_deprecation):
 
     # Note: julian_dateparser.py has more extensive unit tests
 
@@ -807,8 +804,6 @@ def test_general_parsing_v1():
     assert j.dates_in_string("Today is [[200z-01-01 0z:00:0z.00 TDB]]") == \
                      []
 
-    warnings.resetwarnings()
-    _warnings._reset_warnings()
 
 
 def test_v1_warnings():
@@ -816,14 +811,13 @@ def test_v1_warnings():
     with pytest.warns(JDW):
         (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
 
-    # This should yield an error
-    warnings.filterwarnings('error')
-    with pytest.raises(JDW):
-        j.times_in_string("End time[23:59:60.000]")
+    with warnings.catch_warnings():
+        warnings.filterwarnings('error', category=JDW)
+        # This should yield an error
+        with pytest.raises(JDW):
+            j.times_in_string("End time[23:59:60.000]")
 
-    # This warning was already raised so it should not be repeated
-    (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
-
-    warnings.resetwarnings()
+        # This warning was already raised so it should not be repeated
+        (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
 
 ##########################################################################################

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -805,7 +805,6 @@ def test_general_parsing_v1(suppress_julian_deprecation):
                      []
 
 
-
 def test_v1_warnings():
 
     with pytest.warns(JDW):

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -140,17 +140,18 @@ def test_calendar_v1(suppress_julian_deprecation):
     assert j.days_in_year(1582, proleptic=False) == 355
     assert j.days_in_year(1582, proleptic=True) == 365
 
-    j.set_gregorian_start(None)
-    assert j.day_from_ymd(-4713,11,24, proleptic=True) == -2451545
-    assert j.day_from_ymd(-4713,11,24, proleptic=False) == -2451545
+    try:
+        j.set_gregorian_start(None)
+        assert j.day_from_ymd(-4713,11,24, proleptic=True) == -2451545
+        assert j.day_from_ymd(-4713,11,24, proleptic=False) == -2451545
 
-    j.set_gregorian_start(1752, 9, 14)
-    assert j.days_in_year(1582, proleptic=False) == 365
-    assert j.days_in_year(1582, proleptic=True) == 365
-    assert j.days_in_year(1752, proleptic=False) == 355
-    assert j.days_in_year(1752, proleptic=True) == 366
-
-    j.set_gregorian_start()
+        j.set_gregorian_start(1752, 9, 14)
+        assert j.days_in_year(1582, proleptic=False) == 365
+        assert j.days_in_year(1582, proleptic=True) == 365
+        assert j.days_in_year(1752, proleptic=False) == 355
+        assert j.days_in_year(1752, proleptic=True) == 366
+    finally:
+        j.set_gregorian_start()
 
 ########################################
 # Leapsecond routines
@@ -178,35 +179,36 @@ def test_leapseconds_v1():
 
 def test_tai_utc_v1():
 
-    j.set_tai_origin('MIDNIGHT')
+    try:
+        j.set_tai_origin('MIDNIGHT')
 
-    # Check tai_from_day
-    assert j.tai_from_day(0) == 32
-    assert j.tai_from_day([0,1])[0] == 32
-    assert j.tai_from_day([0,1])[1] == 86432
+        # Check tai_from_day
+        assert j.tai_from_day(0) == 32
+        assert j.tai_from_day([0,1])[0] == 32
+        assert j.tai_from_day([0,1])[1] == 86432
 
-    # Check day_sec_from_tai
-    assert j.day_sec_from_tai(32.) == (0, 0.)
-    assert j.day_sec_from_tai([35.,86435.])[0][0] == 0
-    assert j.day_sec_from_tai([35.,86435.])[0][1] == 1
-    assert j.day_sec_from_tai([35.,86435.])[1][0] == 3.
-    assert j.day_sec_from_tai([35.,86435.])[1][1] == 3.
+        # Check day_sec_from_tai
+        assert j.day_sec_from_tai(32.) == (0, 0.)
+        assert j.day_sec_from_tai([35.,86435.])[0][0] == 0
+        assert j.day_sec_from_tai([35.,86435.])[0][1] == 1
+        assert j.day_sec_from_tai([35.,86435.])[1][0] == 3.
+        assert j.day_sec_from_tai([35.,86435.])[1][1] == 3.
 
-    # A large number of dates, spanning > 200 years
-    daylist = np.arange(-40000,40000,83)
+        # A large number of dates, spanning > 200 years
+        daylist = np.arange(-40000,40000,83)
 
-    # Test as a loop
-    for day in daylist:
-        (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(day))
-        assert test_day == day, "Day mismatch at " + str(day)
-        assert test_sec == 0,   "Sec mismatch at " + str(day)
+        # Test as a loop
+        for day in daylist:
+            (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(day))
+            assert test_day == day, "Day mismatch at " + str(day)
+            assert test_sec == 0,   "Sec mismatch at " + str(day)
 
-    # Test as an array operation
-    (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(daylist))
-    assert np.all(test_day == daylist)
-    assert np.all(test_sec == 0)
-
-    j.set_tai_origin('NOON')
+        # Test as an array operation
+        (test_day, test_sec) = j.day_sec_from_tai(j.tai_from_day(daylist))
+        assert np.all(test_day == daylist)
+        assert np.all(test_sec == 0)
+    finally:
+        j.set_tai_origin('NOON')
 
 ########################################
 # Time-of-day conversions
@@ -257,16 +259,17 @@ def test_time_of_day_v1():
 
 def test_tdb_tai_v1():
 
-    j.set_tai_origin('MIDNIGHT')
+    try:
+        j.set_tai_origin('MIDNIGHT')
 
-    # TDB at midnight day 0 (MIDNIGHT): same instant as tai_from_day(0)
-    tdb_at_midnight = 64.18391281194636 - 43200
-    assert j.tdb_from_tai(j.tai_from_day(0)) == pytest.approx(tdb_at_midnight, abs=1e-15)
+        # TDB at midnight day 0 (MIDNIGHT): same instant as tai_from_day(0)
+        tdb_at_midnight = 64.18391281194636 - 43200
+        assert j.tdb_from_tai(j.tai_from_day(0)) == pytest.approx(tdb_at_midnight, abs=1e-15)
 
-    # Check tai_from_tdb
-    assert abs(j.tai_from_tdb(tdb_at_midnight) - j.tai_from_day(0)) < 1.e-15
-
-    j.set_tai_origin('NOON')
+        # Check tai_from_tdb
+        assert abs(j.tai_from_tdb(tdb_at_midnight) - j.tai_from_day(0)) < 1.e-15
+    finally:
+        j.set_tai_origin('NOON')
 
     # Test inversions around tdb = 0.
     # A list of two million small numbers spanning 2 sec
@@ -476,12 +479,14 @@ def test_formatting_v1():
 
     # Check TAI formatting
 
-    j.set_tai_origin('MIDNIGHT')
+    try:
+        j.set_tai_origin('MIDNIGHT')
 
-    # The 32's below are for the offset between TAI and UTC
-    assert np.all(j.ydhms_format_from_tai([32.,366.*86400.+32.]) ==
-                    ("2000-001T00:00:00", "2001-001T00:00:00"))
-    j.set_tai_origin('NOON')
+        # The 32's below are for the offset between TAI and UTC
+        assert np.all(j.ydhms_format_from_tai([32.,366.*86400.+32.]) ==
+                        ("2000-001T00:00:00", "2001-001T00:00:00"))
+    finally:
+        j.set_tai_origin('NOON')
 
 ########################################
 # ISO format parsers
@@ -807,16 +812,21 @@ def test_general_parsing_v1(suppress_julian_deprecation):
 
 def test_v1_warnings():
 
-    with pytest.warns(JDW):
-        (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
+    saved = set(_warnings._WARNING_MESSAGES)
+    _warnings._reset_warnings()
+    try:
+        with pytest.warns(JDW):
+            (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('error', category=JDW)
-        # This should yield an error
-        with pytest.raises(JDW):
-            j.times_in_string("End time[23:59:60.000]")
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=JDW)
+            # This should yield an error
+            with pytest.raises(JDW):
+                j.times_in_string("End time[23:59:60.000]")
 
-        # This warning was already raised so it should not be repeated
-        (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
+            # This warning was already raised so it should not be repeated
+            (day, sec) = j.day_sec_as_type_from_utc((-366,0,366), 0., "TAI")
+    finally:
+        _warnings._WARNING_MESSAGES = saved
 
 ##########################################################################################

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -259,12 +259,12 @@ def test_tdb_tai_v1():
 
     j.set_tai_origin('MIDNIGHT')
 
-    # Check tdb_from_tai
-    assert j.tdb_from_tai(j.tai_from_day(0)) == pytest.approx(64.18391281194636-43200, abs=1e-15)
+    # TDB at midnight day 0 (MIDNIGHT): same instant as tai_from_day(0)
+    tdb_at_midnight = 64.18391281194636 - 43200
+    assert j.tdb_from_tai(j.tai_from_day(0)) == pytest.approx(tdb_at_midnight, abs=1e-15)
 
     # Check tai_from_tdb
-    assert abs(j.tai_from_tdb(64.18391281194636)
-                                     - j.tai_from_day(0)) < 1.e15
+    assert abs(j.tai_from_tdb(tdb_at_midnight) - j.tai_from_day(0)) < 1.e-15
 
     j.set_tai_origin('NOON')
 


### PR DESCRIPTION
# PR Summary: Test suite refactor and Issue 9 fix

## Overview

This branch fixes **Issue 9** (pyparsing deprecation), refactors the test suite from `unittest` to **pytest** with parametrization for parallel execution, and applies follow-up fixes from code review (scalar loop scope, warning isolation, duplicate removal, formatter loop indentation, and TDB assertion correctness).

---

## 1. Fix Issue 9 – Pyparsing deprecation

**File:** `julian/time_pyparser.py`

- Replaced deprecated `setParseAction` with `set_parse_action` (5 call sites) so the code runs without pyparsing deprecation warnings. Fixes #9.

---

## 2. Test suite refactor (Split tests)

### Goals

- Convert all tests from `unittest.TestCase` to **pytest** (standalone functions and `@pytest.mark.parametrize`).
- Reduce the **longest single test** to under **6 seconds** so `pytest-xdist` can balance work across workers.
- Keep **total sequential runtime** and **coverage** unchanged; no test duplication.

### Infrastructure

- **`tests/_helpers.py`** (new): Shared `confirm_failure` and `confirm_success` used by date/time pyparser tests (replacing `TestCase._confirm_*`).
- **`pyproject.toml`**: `addopts = ["-n", "auto", "--cov=julian"]` to run tests in parallel with pytest-xdist.
- **`requirements.txt`**: Added `pytest-xdist` (and any other deps used by tests).
- **`.github/workflows/run-tests.yml`**: Adjusted if needed for the new test layout (e.g. pytest invocation).

### Test conversions (unittest → pytest)

All 17+ test modules were converted:

- **Removed** `unittest.TestCase` subclasses; tests are standalone functions.
- **Replaced** `self.assertEqual` / `self.assertRaises` / `self.assertIn` etc. with `assert` and `pytest.raises` / `pytest.approx` where appropriate.
- **Parametrized** the slowest tests so each *item* is a separate test for xdist.

### Parametrization of slow tests

- **`test_date_pyparser.py`**: Former ~67 s single test split into parametrized tests (`test_date_pyparser_dates`, `test_date_pyparser_dates_weekdays`, `test_date_pyparser_dates_weekdays_extras`, `test_date_pyparser_dates_quick`, plus parametrized `test_ISO_DATE_PYPARSERS`, `test_YD_PYPARSERS`, `test_DATE_PYPARSERS`, `test_date_pyparser_mjd`, `test_date_pyparser_iso_only`). Helper `date_tester` supports `_fmt_range` and `_skip_extras` for finer splits.
- **`test_time_pyparser.py`**: Single long test split into `test_time_pyparser` (main options), `test_time_pyparser_iso_only`, and `test_time_pyparser_quick`, each parametrized.
- **`test_mjd_pyparser.py`**: Exposes a standalone `mjd_tester()` used by `test_date_pyparser` and `test_datetime_pyparser`; converted to pytest.
- **`test_datetime_pyparser.py`**: Uses `mjd_tester` from `test_mjd_pyparser`; converted to pytest.

### Result

- **Before:** One test ~67 s; a handful of very long test methods.
- **After:** Longest test item &lt; 6 s; many small parametrized items; total sequential time similar; **118** tests (items) passing.

---

## 3. Remove Python 3.9 compatibility

- Due to test failures, the minimum Python version is now 3.10. Also fixed an issue with tests under Python 3.13.

---
 
## Summary of files changed

| Area | Files |
|------|--------|
| Production code | `julian/time_pyparser.py` |
| Config / CI | `.github/workflows/run-tests.yml`, `pyproject.toml`, `requirements.txt` |
| Test infra | `tests/_helpers.py` (new) |
| Tests (converted + parametrized/fixed) | All `tests/test_*.py` (17+ modules) |

---

## How to run

- **Sequential:** `pytest tests/ -n0`
- **Parallel (default from pyproject.toml):** `pytest tests/`
- **With durations:** `pytest tests/ -n0 --durations=20`

All tests should pass with no new failures and no increase in sequential runtime or loss of coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated the test suite from unittest to pytest, added shared test helpers, converted many class-based tests to function-based pytest tests, and enabled parallel test execution with coverage collection.

* **Chores**
  * Updated test tooling and dependencies for pytest, pytest-cov and xdist; raised supported Python baseline to 3.10+.

* **Refactor**
  * Updated internal parser usage to align with the current parsing library API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->